### PR TITLE
fix(core): add symbolic marker for vimmode factory chain detection

### DIFF
--- a/src/lifecycle.ts
+++ b/src/lifecycle.ts
@@ -59,6 +59,8 @@ export function registerVimLifecycle(
       new VimEditor(tui, theme, keybindings, options, diagnostics, vimOptions));
   const schedule = dependencies.schedule ?? ((callback) => setTimeout(callback, 0));
 
+  const VIM_FACTORY_MARKER = Symbol("pi-vimmode:factory");
+
   const editorFactory: VimEditorFactory = (tui, theme, keybindings) => {
     const editor = createEditor(tui, theme, keybindings, currentOptions, currentDiagnostics, {
       onShutdown: currentShutdown,
@@ -67,6 +69,7 @@ export function registerVimLifecycle(
     if (agentBusy) editor.setAgentBusy(true);
     return editor as VimEditor;
   };
+  (editorFactory as unknown as Record<symbol, unknown>)[VIM_FACTORY_MARKER] = true;
 
   const applyLoadedOptions = (ctx: ExtensionContext, loaded: VimConfigLoadResult) => {
     currentOptions = loaded.options;
@@ -95,9 +98,39 @@ export function registerVimLifecycle(
     }
   };
 
+  /** Walk Symbol-keyed factory chain up to 10 hops, check if vimmode marker present. */
+  function factoryChainContainsVim(factory: EditorComponentFactory): boolean {
+    const seen = new Set<EditorComponentFactory>();
+    let current: unknown = factory;
+    let hops = 0;
+
+    while (
+      typeof current === "function" &&
+      hops < 10 &&
+      !seen.has(current as EditorComponentFactory)
+    ) {
+      seen.add(current as EditorComponentFactory);
+      if ((current as unknown as Record<symbol, unknown>)[VIM_FACTORY_MARKER] === true) return true;
+
+      // Duck-type foreign wrapper symbols: follow any Symbol-keyed function-valued property
+      const symbols = Object.getOwnPropertySymbols(current);
+      let next: unknown = null;
+      for (const sym of symbols) {
+        const val: unknown = (current as unknown as Record<symbol, unknown>)[sym];
+        if (typeof val === "function" && val !== current) {
+          next = val;
+          break;
+        }
+      }
+      current = next;
+      hops++;
+    }
+    return false;
+  }
+
   const finishInstall = (ctx: ExtensionContext) => {
     currentShutdown = () => ctx.shutdown();
-    if (ctx.ui.getEditorComponent() !== editorFactory) {
+    if (!factoryChainContainsVim(ctx.ui.getEditorComponent())) {
       previousEditorFactory = ctx.ui.getEditorComponent();
       ctx.ui.setEditorComponent(editorFactory);
     }


### PR DESCRIPTION
## Summary

Replace direct equality check against editorFactory with a Symbol-keyed marker and chain walker that detects vimmode's factory even when wrapped in proxy/decorator layers by other extensions.

## Changes

- Tag editorFactory with VIM_FACTORY_MARKER symbol
- Add factoryChainContainsVim() to traverse Symbol-keyed function-valued properties up to 10 hops
- Update finishInstall() to use chain walker instead of === reference equality

Previously, any extension wrapping the editor component in a decorator/proxy would break the factory swap guard, causing duplicate registration or missed swap. The symbol marker survives wrapping; the chain walker follows foreign wrapper symbols to find the original factory.
## Testing

- [x] `bun test` passes
- [x] `bun run check-types` passes
- [x] `bun run lint` passes
- [x] Manually tested in Pi

## Related Issues

Closes #16 

detailed implementation plan:  [2026-07-13-1915-vimmode-factory-chain.md](https://github.com/user-attachments/files/29950119/2026-07-13-1915-vimmode-factory-chain.md)
