### PR TITLE
feat(ui): allow right-aligned editor-border status group

### DIFF
--- a/docs/features.md
+++ b/docs/features.md
@@ -861,8 +861,9 @@ Optional status item:
 
 Rendering behavior:
 
-- Narrow widths use narrow labels: `I`, `N`, `V`, `VL`, `VB`.
-- Active macro recording shows `REC {slot}`.
+- Status items are left-aligned by default; `piVimMode.ui.status.position: "right"` moves the complete ordered status group to the far-right border slot.
+- Mode, pending state, selection, cursor position, and active macro recording (`REC {slot}`) always move together.
+- Narrow widths use narrow labels: `I`, `N`, `V`, `VL`, `VB`, and truncate the aligned status group to fit.
 - Visual selections are highlighted inline.
 - Selected empty lines in visual line mode render a highlighted blank cell when width permits.
 - Insert-mode autocomplete rows remain Pi-owned and visible; Vim status feedback renders on a separate row while completion UI is open.

--- a/docs/settings.md
+++ b/docs/settings.md
@@ -710,19 +710,22 @@ Example:
 
 ### Status
 
-| Path                          | Default                                                      | Accepted values                                                   | Effect                                                                |
-| ----------------------------- | ------------------------------------------------------------ | ----------------------------------------------------------------- | --------------------------------------------------------------------- |
-| `piVimMode.ui.status.enabled` | `true`                                                       | boolean                                                           | Enables/disables all status text in the editor border.                |
-| `piVimMode.ui.status.items`   | `["mode", "pendingOperator", "selection", "cursorPosition"]` | array of `mode`, `pendingOperator`, `selection`, `cursorPosition` | Ordered status items to render. Empty/invalid arrays do not override. |
+| Path                           | Default                                                      | Accepted values                                                   | Effect                                                                |
+| ------------------------------ | ------------------------------------------------------------ | ----------------------------------------------------------------- | --------------------------------------------------------------------- |
+| `piVimMode.ui.status.enabled`  | `true`                                                       | boolean                                                           | Enables/disables all status text in the editor border.                |
+| `piVimMode.ui.status.position` | `"left"`                                                     | `"left"`, `"right"`                                               | Aligns the complete ordered status group at the selected border edge. |
+| `piVimMode.ui.status.items`    | `["mode", "pendingOperator", "selection", "cursorPosition"]` | array of `mode`, `pendingOperator`, `selection`, `cursorPosition` | Ordered status items to render. Empty/invalid arrays do not override. |
 
 Status item meanings:
 
-| Item              | Shows                                                                                                                                             |
-| ----------------- | ------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `mode`            | Mode label when enabled. Active macro recording shows `REC {slot}` whenever status is enabled, next to mode when present and prepended otherwise. |
-| `pendingOperator` | Pending prefixes with an ellipsis, such as `d…`, `g…`, `/query…`, `m…`, or `:command…`.                                                           |
-| `selection`       | Visual selection summary and preview when enabled.                                                                                                |
-| `cursorPosition`  | Cursor position when `ui.cursorPosition.enabled` is true.                                                                                         |
+| Item              | Shows                                                                                                                                      |
+| ----------------- | ------------------------------------------------------------------------------------------------------------------------------------------ |
+| `mode`            | Mode label when enabled. Active macro recording shows `REC {slot}` at the mode item's order position when present and prepended otherwise. |
+| `pendingOperator` | Pending prefixes with an ellipsis, such as `d…`, `g…`, `/query…`, `m…`, or `:command…`.                                                    |
+| `selection`       | Visual selection summary and preview when enabled.                                                                                         |
+| `cursorPosition`  | Cursor position when `ui.cursorPosition.enabled` is true.                                                                                  |
+
+`position` aligns the complete status sequence, so mode, pending state, selection, cursor position, and macro recording always move together. The aligned group is truncated as needed to preserve terminal width.
 
 ### Mode labels
 
@@ -1018,6 +1021,7 @@ This is the resolved default shape. Comments are not valid JSON; this block omit
     "ui": {
       "status": {
         "enabled": true,
+        "position": "left",
         "items": ["mode", "pendingOperator", "selection", "cursorPosition"]
       },
       "mode": {
@@ -1177,12 +1181,15 @@ Now delete only accepts `d{wordForward}` and `d{lineEnd}` among finite operator 
 }
 ```
 
-### Custom mode labels
+### Custom right-aligned mode labels
 
 ```json
 {
   "piVimMode": {
     "ui": {
+      "status": {
+        "position": "right"
+      },
       "mode": {
         "labels": {
           "normal": "COMMAND",

--- a/openspec/specs/vim-mode-editor/spec.md
+++ b/openspec/specs/vim-mode-editor/spec.md
@@ -150,10 +150,15 @@ The Vim editor SHALL render Vim status feedback according to the resolved UI con
 - **WHEN** the editor switches modes and `piVimMode.ui.mode.labels` configures labels for those modes
 - **THEN** the rendered editor shows the configured active-mode label where the mode status item is enabled and width permits
 
+#### Scenario: Status group can be right-aligned
+
+- **WHEN** `piVimMode.ui.status.position` is set to `"right"`
+- **THEN** the complete ordered status group, including mode, pending state, visual selection status, cursor position, and macro recording, renders at the right edge
+
 #### Scenario: Mode status can be hidden by config
 
 - **WHEN** `piVimMode.ui.mode.enabled` is set to `false` or the status item list omits `mode`
-- **THEN** the rendered editor omits mode feedback while preserving prompt editing behavior
+- **THEN** the rendered editor omits mode feedback from both border slots while preserving prompt editing behavior
 
 #### Scenario: Render width respected
 

--- a/openspec/specs/vim-ui-configuration/spec.md
+++ b/openspec/specs/vim-ui-configuration/spec.md
@@ -44,6 +44,21 @@ The Vim editor SHALL support configured labels for insert, normal, characterwise
 - **WHEN** `piVimMode.ui.mode.narrowLabels.visualLine` is set to a non-empty string and available status width is narrow
 - **THEN** the rendered visual-line mode status uses the configured narrow label
 
+#### Scenario: Status position defaults left
+
+- **WHEN** no `piVimMode.ui.status.position` setting is configured
+- **THEN** the complete ordered status group remains left-aligned
+
+#### Scenario: Status position configured right
+
+- **WHEN** `piVimMode.ui.status.position` is set to `"right"`
+- **THEN** the complete ordered status group, including mode, pending state, selection, cursor position, and macro recording, renders in the right border slot
+
+#### Scenario: Invalid status position falls back
+
+- **WHEN** `piVimMode.ui.status.position` is neither `"left"` nor `"right"`
+- **THEN** settings resolution records a warning, retains the inherited status position, and preserves valid sibling UI fields
+
 #### Scenario: Mode status disabled
 
 - **WHEN** `piVimMode.ui.mode.enabled` is set to `false`
@@ -107,8 +122,13 @@ The Vim editor MUST keep rendered output width-safe for every supported UI confi
 
 #### Scenario: Width safety preserved
 
-- **WHEN** Pi renders the editor at any supported terminal width with configured status items, labels, selection preview, and cursor position
+- **WHEN** Pi renders the editor at any supported terminal width with configured status items, labels, selection preview, cursor position, and status position
 - **THEN** every rendered line from the Vim editor fits within the provided width
+
+#### Scenario: Aligned status group fits narrow widths
+
+- **WHEN** the configured status group cannot fit within the provided width
+- **THEN** the aligned group is truncated and the rendered border never exceeds the provided width
 
 #### Scenario: Automated validation runs
 

--- a/openspec/specs/vim-ui-configuration/spec.md
+++ b/openspec/specs/vim-ui-configuration/spec.md
@@ -30,20 +30,6 @@ The Vim editor SHALL read `piVimMode.ui.status` to determine which status items 
 - **WHEN** `piVimMode.ui.status.items` contains an unsupported item name
 - **THEN** the unsupported item is ignored, a warning is recorded, and supported status items remain usable
 
-### Requirement: Mode labels are configurable
-
-The Vim editor SHALL support configured labels for insert, normal, characterwise visual, and visual line modes.
-
-#### Scenario: Mode labels configured
-
-- **WHEN** `piVimMode.ui.mode.labels.normal` is set to a non-empty string and the editor is in normal mode
-- **THEN** the rendered mode status uses the configured normal-mode label when width permits
-
-#### Scenario: Narrow mode labels configured
-
-- **WHEN** `piVimMode.ui.mode.narrowLabels.visualLine` is set to a non-empty string and available status width is narrow
-- **THEN** the rendered visual-line mode status uses the configured narrow label
-
 #### Scenario: Status position defaults left
 
 - **WHEN** no `piVimMode.ui.status.position` setting is configured
@@ -58,6 +44,20 @@ The Vim editor SHALL support configured labels for insert, normal, characterwise
 
 - **WHEN** `piVimMode.ui.status.position` is neither `"left"` nor `"right"`
 - **THEN** settings resolution records a warning, retains the inherited status position, and preserves valid sibling UI fields
+
+### Requirement: Mode labels are configurable
+
+The Vim editor SHALL support configured labels for insert, normal, characterwise visual, and visual line modes.
+
+#### Scenario: Mode labels configured
+
+- **WHEN** `piVimMode.ui.mode.labels.normal` is set to a non-empty string and the editor is in normal mode
+- **THEN** the rendered mode status uses the configured normal-mode label when width permits
+
+#### Scenario: Narrow mode labels configured
+
+- **WHEN** `piVimMode.ui.mode.narrowLabels.visualLine` is set to a non-empty string and available status width is narrow
+- **THEN** the rendered visual-line mode status uses the configured narrow label
 
 #### Scenario: Mode status disabled
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -32,6 +32,7 @@ import type {
   VimStatusItem,
   VimTextObjectKind,
   VimTextObjectTarget,
+  VimUiEditorOptions,
 } from "./types.ts";
 
 import {
@@ -200,6 +201,7 @@ export const DEFAULT_VIM_KEYMAP = Object.freeze({
 export const DEFAULT_VIM_UI = Object.freeze({
   status: Object.freeze({
     enabled: true,
+    position: "left",
     items: Object.freeze(["mode", "pendingOperator", "selection", "cursorPosition"]),
   }),
   mode: Object.freeze({
@@ -361,17 +363,7 @@ type PartialPromptTransformOptions = {
   commands?: Partial<Record<PromptTransformAction, string[]>>;
 };
 
-type PartialUiOptions = {
-  status?: Partial<ResolvedVimUi["status"]>;
-  mode?: {
-    enabled?: boolean;
-    labels?: Partial<Record<VimMode, string>>;
-    narrowLabels?: Partial<Record<VimMode, string>>;
-  };
-  selection?: Partial<ResolvedVimUi["selection"]>;
-  cursorPosition?: Partial<ResolvedVimUi["cursorPosition"]>;
-  workbench?: Partial<ResolvedVimUi["workbench"]>;
-};
+type PartialUiOptions = VimUiEditorOptions;
 
 export type VimConfigLoadResult = {
   options: ResolvedVimEditorOptions;
@@ -485,7 +477,11 @@ function clonePromptTransforms(
 
 function cloneUi(ui: ResolvedVimUi = DEFAULT_VIM_UI): ResolvedVimUi {
   return {
-    status: { enabled: ui.status.enabled, items: [...ui.status.items] },
+    status: {
+      enabled: ui.status.enabled,
+      position: ui.status.position,
+      items: [...ui.status.items],
+    },
     mode: {
       enabled: ui.mode.enabled,
       labels: clonePlainRecord(ui.mode.labels),
@@ -1099,6 +1095,11 @@ function parseUi(
       if (typeof value.status.enabled === "boolean") status.enabled = value.status.enabled;
       else if (value.status.enabled !== undefined)
         warnings.push(`${sourceLabel}: piVimMode.ui.status.enabled must be a boolean`);
+      if (value.status.position === "left" || value.status.position === "right") {
+        status.position = value.status.position;
+      } else if (value.status.position !== undefined) {
+        warnings.push(`${sourceLabel}: piVimMode.ui.status.position must be "left" or "right"`);
+      }
       if (value.status.items !== undefined) {
         const items = parseActionStringArray<VimStatusItem>(
           value.status.items,

--- a/src/modal/view.ts
+++ b/src/modal/view.ts
@@ -70,10 +70,8 @@ export function modalStatus(input: ModalStatusInput): ModalStatus {
 
   if (input.recordingSlot && !recordingAdded) parts.unshift(`REC ${input.recordingSlot}`);
 
-  return {
-    left: parts.length > 0 ? ` ${parts.join(" ")} ` : "",
-    right: "",
-  };
+  const status = parts.length > 0 ? ` ${parts.join(" ")} ` : "";
+  return ui.status.position === "right" ? { left: "", right: status } : { left: status, right: "" };
 }
 
 function cursorPositionStatus(cursor: Position, ui: ResolvedVimUi): string {

--- a/src/types.ts
+++ b/src/types.ts
@@ -121,6 +121,7 @@ export type VimTextObject = {
 };
 
 export type VimStatusItem = "mode" | "pendingOperator" | "selection" | "cursorPosition";
+export type VimStatusPosition = "left" | "right";
 
 export type VimMacroKeymapOptions = {
   record?: readonly string[];
@@ -256,6 +257,7 @@ export type ResolvedVimSearch = VimSearchOptions;
 export type VimUiOptions = {
   status: {
     enabled: boolean;
+    position: VimStatusPosition;
     items: readonly VimStatusItem[];
   };
   mode: {
@@ -275,6 +277,18 @@ export type VimUiOptions = {
   workbench: {
     reservedRows: number;
   };
+};
+
+export type VimUiEditorOptions = {
+  status?: Partial<VimUiOptions["status"]>;
+  mode?: {
+    enabled?: boolean;
+    labels?: Partial<Record<VimMode, string>>;
+    narrowLabels?: Partial<Record<VimMode, string>>;
+  };
+  selection?: Partial<VimUiOptions["selection"]>;
+  cursorPosition?: Partial<VimUiOptions["cursorPosition"]>;
+  workbench?: Partial<VimUiOptions["workbench"]>;
 };
 
 export type ResolvedVimUi = VimUiOptions;
@@ -331,7 +345,7 @@ export type VimEditorOptions = {
   startMode?: StartupMode;
   cursor?: Partial<CursorStyles>;
   keymap?: VimKeymapOptions;
-  ui?: Partial<ResolvedVimUi>;
+  ui?: VimUiEditorOptions;
   macros?: Partial<ResolvedVimMacros>;
   marks?: Partial<ResolvedVimMarks>;
   search?: Partial<ResolvedVimSearch>;

--- a/src/vim-editor.ts
+++ b/src/vim-editor.ts
@@ -174,7 +174,7 @@ export function fitStatusBorder(
   border: (text: string) => string = (text) => text,
 ): string {
   if (width <= 0) return "";
-  if (width === 1) return border("─");
+  if (width <= 2) return border("─".repeat(width));
 
   let leftText = left;
   let rightText = right;

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -39,12 +39,29 @@ describe("vim config parsing", () => {
     const redoOptions = {
       keymap: { escape: ["<D-j>"], commands: { redo: ["ctrl+r"], showKeybindings: ["gk"] } },
     } satisfies VimEditorOptions;
+    const preChangeUiOptions = {
+      ui: {
+        status: { enabled: true, items: ["mode"] },
+        mode: {
+          enabled: true,
+          labels: { insert: "I", normal: "N", visual: "V", visualLine: "VL", visualBlock: "VB" },
+          narrowLabels: {
+            insert: "I",
+            normal: "N",
+            visual: "V",
+            visualLine: "VL",
+            visualBlock: "VB",
+          },
+        },
+      },
+    } satisfies VimEditorOptions;
     expect(options.keymap?.motions?.halfPageDown).toEqual(["<C-d>"]);
     expect(options.keymap?.commands?.replaceChar).toEqual(["R"]);
     expect(options.keymap?.commands?.toggleCase).toEqual(["~"]);
     expect(redoOptions.keymap?.escape).toEqual(["<D-j>"]);
     expect(redoOptions.keymap?.commands?.redo).toEqual(["ctrl+r"]);
     expect(redoOptions.keymap?.commands?.showKeybindings).toEqual(["gk"]);
+    expect(preChangeUiOptions.ui.mode.enabled).toBe(true);
     const backwardSearchOptions = {
       keymap: { commands: { startSearchBackward: ["?"] } },
     } satisfies VimEditorOptions;
@@ -55,7 +72,9 @@ describe("vim config parsing", () => {
   });
 
   test("uses defaults when settings are absent", () => {
-    expect(resolveVimOptions(undefined).options).toEqual(DEFAULT_VIM_OPTIONS);
+    const options = resolveVimOptions(undefined).options;
+    expect(options).toEqual(DEFAULT_VIM_OPTIONS);
+    expect(options.ui?.status.position).toBe("left");
   });
 
   test("resolved defaults do not share mutable nested config fields", () => {
@@ -155,17 +174,62 @@ describe("vim config parsing", () => {
     expect(result.options.keymap?.macros.record).toEqual(["q"]);
   });
 
-  test("parses configured mode labels", () => {
+  test("parses configured status position and mode labels", () => {
     const result = resolveVimOptions({
       piVimMode: {
-        ui: { mode: { labels: { normal: "COMMAND" }, narrowLabels: { normal: "C" } } },
+        ui: {
+          status: { position: "right" },
+          mode: {
+            labels: { normal: "COMMAND" },
+            narrowLabels: { normal: "C" },
+          },
+        },
       },
     });
 
     expect(result.warnings).toEqual([]);
+    expect(result.options.ui?.status.position).toBe("right");
     expect(result.options.ui?.mode.labels.normal).toBe("COMMAND");
     expect(result.options.ui?.mode.narrowLabels.normal).toBe("C");
     expect(result.options.ui?.mode.labels.insert).toBe("INSERT");
+  });
+
+  test("retains inherited status position when a later value is invalid", () => {
+    const result = resolveVimOptions(
+      { piVimMode: { ui: { status: { position: "right" } } } },
+      {
+        piVimMode: {
+          ui: {
+            status: { position: "center" },
+            mode: { enabled: false, labels: { normal: "COMMAND" } },
+          },
+        },
+      },
+    );
+
+    expect(result.options.ui?.status.position).toBe("right");
+    expect(result.options.ui?.mode.enabled).toBe(false);
+    expect(result.options.ui?.mode.labels.normal).toBe("COMMAND");
+    expect(result.warnings).toEqual([
+      'project settings: piVimMode.ui.status.position must be "left" or "right"',
+    ]);
+  });
+
+  test("merges status position across global, JS, and project fields", () => {
+    const result = resolveVimOptions(
+      { piVimMode: { ui: { status: { position: "right" } } } },
+      { piVimMode: { ui: { mode: { narrowLabels: { normal: "P" } } } } },
+      {
+        partial: {
+          ui: { status: { position: "left" }, mode: { labels: { normal: "JS" } } },
+        },
+      },
+    );
+
+    expect(result.warnings).toEqual([]);
+    expect(result.options.ui?.status.position).toBe("left");
+    expect(result.options.ui?.mode.labels.normal).toBe("JS");
+    expect(result.options.ui?.mode.narrowLabels.normal).toBe("P");
   });
 
   test("parses workbench reserved rows field-by-field", () => {

--- a/test/modal.test.ts
+++ b/test/modal.test.ts
@@ -2437,7 +2437,11 @@ describe("modal view state", () => {
       width: 40,
       pending: "d",
       ui: {
-        status: { enabled: true, items: ["cursorPosition", "mode", "pendingOperator"] },
+        status: {
+          enabled: true,
+          position: "left",
+          items: ["cursorPosition", "mode", "pendingOperator"],
+        },
         mode: {
           enabled: true,
           labels: {
@@ -2465,6 +2469,90 @@ describe("modal view state", () => {
     expect(status.right).toBe("");
   });
 
+  test("modal status moves the complete status group to the right", () => {
+    const ui = resolveVimOptions({
+      piVimMode: {
+        ui: {
+          status: {
+            position: "right",
+            items: ["cursorPosition", "mode", "pendingOperator"],
+          },
+        },
+      },
+    }).options.ui;
+    const status = modalStatus({
+      mode: "normal",
+      text: "abc",
+      cursor,
+      width: 40,
+      pending: "d",
+      recordingSlot: "a",
+      ui,
+    });
+    const visual = modalStatus({
+      mode: "visual",
+      text: "abc",
+      cursor: { line: 0, col: 1 },
+      visualAnchor: cursor,
+      width: 40,
+      ui: resolveVimOptions({
+        piVimMode: {
+          ui: { status: { position: "right", items: ["selection", "mode"] } },
+        },
+      }).options.ui,
+    });
+
+    expect(status).toEqual({ left: "", right: " 1:1 NORMAL REC a d… " });
+    expect(visual).toEqual({ left: "", right: " 2 chars · ab VISUAL " });
+  });
+
+  test("right-positioned status honors mode visibility and narrow labels", () => {
+    const configured = resolveVimOptions({
+      piVimMode: {
+        ui: {
+          status: { position: "right", items: ["mode"] },
+          mode: {
+            labels: { normal: "COMMAND" },
+            narrowLabels: { normal: "C" },
+          },
+        },
+      },
+    }).options.ui;
+    const narrow = modalStatus({ mode: "normal", text: "", cursor, width: 5, ui: configured });
+    const hidden = modalStatus({
+      mode: "normal",
+      text: "",
+      cursor,
+      width: 40,
+      ui: resolveVimOptions({
+        piVimMode: { ui: { status: { position: "right" }, mode: { enabled: false } } },
+      }).options.ui,
+    });
+    const omitted = modalStatus({
+      mode: "normal",
+      text: "",
+      cursor,
+      width: 40,
+      ui: resolveVimOptions({
+        piVimMode: { ui: { status: { position: "right", items: ["cursorPosition"] } } },
+      }).options.ui,
+    });
+    const disabled = modalStatus({
+      mode: "normal",
+      text: "",
+      cursor,
+      width: 40,
+      ui: resolveVimOptions({
+        piVimMode: { ui: { status: { enabled: false, position: "right" } } },
+      }).options.ui,
+    });
+
+    expect(narrow.right).toBe(" C ");
+    expect(hidden.right).toBe(" 1:1 ");
+    expect(omitted.right).toBe(" 1:1 ");
+    expect(disabled).toEqual({ left: "", right: "" });
+  });
+
   test("modal status shows active macro recording", () => {
     const status = modalStatus({
       mode: "normal",
@@ -2483,7 +2571,7 @@ describe("modal view state", () => {
       width: 10,
       recordingSlot: "a",
       ui: {
-        status: { enabled: true, items: ["selection"] },
+        status: { enabled: true, position: "right", items: ["selection"] },
         mode: {
           enabled: false,
           labels: {
@@ -2506,7 +2594,7 @@ describe("modal view state", () => {
         workbench: { reservedRows: 0 },
       },
     });
-    expect(modeHidden.left.trim()).toBe("REC a");
+    expect(modeHidden).toEqual({ left: "", right: " REC a " });
   });
 });
 

--- a/test/vim-editor.test.ts
+++ b/test/vim-editor.test.ts
@@ -913,13 +913,32 @@ describe("vim editor integration", () => {
     expect(editor.render(8).join("\n")).toContain("C");
   });
 
+  test("renders and clones a right-positioned status group", () => {
+    const options = resolveVimOptions({
+      piVimMode: {
+        startMode: "normal",
+        ui: {
+          status: { position: "right" },
+          mode: { labels: { normal: "COMMAND" } },
+        },
+      },
+    }).options;
+    const { editor } = createEditor(options);
+    options.ui!.status.position = "left";
+
+    const status = editor.render(30).at(-1) ?? "";
+    expect(status.startsWith("──")).toBe(true);
+    expect(status.endsWith(" COMMAND 1:1 ─")).toBe(true);
+    expect(visibleWidth(status)).toBe(30);
+  });
+
   test("renders configured cursor position status", () => {
     const { editor } = createEditor({
       ...DEFAULT_VIM_OPTIONS,
       startMode: "normal",
       ui: {
         ...DEFAULT_VIM_OPTIONS.ui!,
-        status: { enabled: true, items: ["mode", "cursorPosition"] },
+        status: { enabled: true, position: "left", items: ["mode", "cursorPosition"] },
         cursorPosition: { enabled: true, base: 1, format: "L{line}:C{column}" },
       },
     });
@@ -2098,15 +2117,23 @@ describe("status border fitting", () => {
     expect(line).toContain("NORMAL");
   });
 
-  test("truncates right side before primary mode", () => {
-    const line = fitStatusBorder(" N ", " very long visual selection preview ", 10);
-    expect(visibleWidth(line)).toBeLessThanOrEqual(10);
-    expect(line).toContain("N");
+  test("places right status at the far edge", () => {
+    const line = fitStatusBorder(" 1:1 ", " N ", 20);
+    expect(line.endsWith(" N ─")).toBe(true);
+    expect(visibleWidth(line)).toBe(20);
   });
 
-  test("handles extremely narrow widths", () => {
-    expect(visibleWidth(fitStatusBorder(" NORMAL ", "", 1))).toBe(1);
-    expect(visibleWidth(fitStatusBorder(" NORMAL ", "", 0))).toBe(0);
+  test("truncates right content before left content", () => {
+    const line = fitStatusBorder(" LEFT ", " MODE ", 8);
+    expect(visibleWidth(line)).toBe(8);
+    expect(line).toContain("LEFT");
+    expect(line).not.toContain("MODE");
+  });
+
+  test("handles zero and narrow widths without overflow", () => {
+    for (let width = 0; width <= 12; width += 1) {
+      expect(visibleWidth(fitStatusBorder(" LEFT ", " RIGHT ", width))).toBe(width);
+    }
   });
 });
 


### PR DESCRIPTION
## Summary

The status group currently begins at the left edge of the bottom border, directly beneath the prompt text. This proximity can make the status visually compete with the text being edited and reduce readability—even when short status labels are used.


<img width="118" height="65" alt="Screenshot 2026-07-13 at 8 22 49 PM" src="https://github.com/user-attachments/assets/3c739cf3-56c0-44b3-86fa-b37949c25191" />

_Current left-aligned status appearing directly beneath the prompt text._

This change adds a backwards-compatible `piVimMode.ui.status.position` setting. Users can move the complete ordered status group to the far-right edge, visually separating editor metadata from the prompt content. The default remains `"left"`.

## Changes

- Add typed `"left" | "right"` status positioning with `"left"` as the default.
- Preserve field-level global, trusted JS, and project configuration precedence and invalid-value warnings.
- Route the complete ordered status group to one border slot without splitting status items.
- Keep narrow borders width-safe, including widths 0, 1, and 2.
- Preserve nested-partial editor option compatibility.
- Update focused tests, settings/features documentation, and durable OpenSpec requirements.

## Testing

- [x] `bun test` passes — 740 tests, 0 failures
- [x] `bun run check-types` passes
- [x] `bun run lint` passes
- [x] Manually tested in Pi
  - explicit left and right alignment at 80 columns
  - right alignment at 8 columns with narrow mode label/truncation
  - right-aligned macro recording status
  - right-aligned visual selection status
- [x] Changed files pass `oxfmt --check`
- [x] `openspec validate --specs --strict` passes — 20/20 specs

## Related Issues

Related: https://github.com/alanpog/pi-vimmode/issues/1
