### PR TITLE
keep insert-after within logical line instead of starting new line

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,5 +33,4 @@ report.[0-9]_.[0-9]_.[0-9]_.[0-9]_.json
 # Finder (MacOS) folder config
 .DS_Store
 
-graphify-out/cost.json
-graphify-out/cache/
+.pi-subagents/

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -17,3 +17,5 @@
 ```
 
 ## Bug fixes
+
+- Fixed normal-mode `a` crossing into the next logical line when invoked at end of line, including on wrapped prompts followed by a blank line.

--- a/TODOS.md
+++ b/TODOS.md
@@ -2,15 +2,7 @@
 
 ## Next Version
 
-- [x] Add safe insert editing layer
-  - [x] Write OpenSpec change `safe-insert-editing-layer`.
-  - [x] Add finite named insert actions: `deleteWordBackward`, `deleteWordForward`, `deleteLineBackward`, `deleteLineForward`, `moveWordBackward`, `moveWordForward`, `moveLineStart`, `moveLineEnd`.
-  - [x] Reuse existing Vim small-word semantics for word movement/deletion.
-  - [x] Ensure insert delete actions never write Vim registers.
-  - [x] Make `deleteLineForward` at EOL delete exactly one newline, preserving spaces.
-  - [x] Add docs examples for readline-style chords and home-row-mod chords.
-  - [x] Test configured actions, rejected raw chords, autocomplete delegation, duplicate bindings, no-register writes, newline join behavior, and no-op prompt boundaries.
-- [x] Bug - Arrow keys in normal mode doesn't move cursor
+- [ ] leader key (default none)
 
 ## Deferred
 
@@ -22,8 +14,6 @@
 ## Ideas
 
 - [ ] Keybinding presets (qwerty, dvorak, colemak, colemak-dh, etc) after finite insert actions prove useful.
-- [ ] Explore a full user-defined action/plugin surface for pi-vimmode after the finite named prompt action/transform keybinding layer proves demand.
-  - [ ] javascript/typescript based config files in `~/.pi/agent/`
 - [ ] Add registry-backed diagnostic action entries and a fuller Neovim quickref classification after M1 prompt transform action keybindings ship. Context: /plan-eng-review intentionally cut `vimmode.*` diagnostic metadata and quickref polish from the first code PR so resolver/config/dispatch risk stays bounded.
 - [ ] Explore config-hacker and extension-author workflows: action registry introspection, recipes, community presets, and future extension seams.
 - [ ] Make pi-vimmode controllable with ex commands?

--- a/docs/features.md
+++ b/docs/features.md
@@ -201,7 +201,7 @@ W moves to --flag=value; E moves to the end of that WORD; gE from /tmp/a-b moves
 | Key                 | Action                                                                  |
 | ------------------- | ----------------------------------------------------------------------- |
 | `i`                 | enter insert at cursor                                                  |
-| `a`                 | move right, then insert                                                 |
+| `a`                 | insert after cursor without crossing current logical line               |
 | `I` / `A`           | move to line start/end, then insert                                     |
 | `o` / `O`           | open blank line below/above, then insert                                |
 | `x` / `X`           | delete character under/before cursor                                    |

--- a/docs/solutions/architecture-patterns/finite-vim-keybinding-parser-buffer-helpers-2026-05-26.md
+++ b/docs/solutions/architecture-patterns/finite-vim-keybinding-parser-buffer-helpers-2026-05-26.md
@@ -1,7 +1,7 @@
 ---
 title: Finite Vim keybinding parser with pure buffer helpers
 date: 2026-05-26
-last_updated: 2026-06-19
+last_updated: 2026-07-14
 category: docs/solutions/architecture-patterns
 module: pi-vimmode
 problem_type: architecture_pattern
@@ -445,7 +445,7 @@ Validation for the buffer helper deduplication used `bun test`, `bun test test/b
 - `src/vim-editor.ts` — Pi `CustomEditor` adapter and effect interpreter
 - `test/commands.test.ts`, `test/buffer.test.ts`, `test/modal.test.ts`, `test/vim-editor.test.ts` — layered test coverage
 - `scripts/measure-insert-fast-path.ts` — local insert-path measurement for snapshot and delegation cost
-- `docs/solutions/logic-errors/vim-behavior-contract-drift-2026-05-28.md` — concrete bug where line-command repeat state and live option cloning drifted from this architecture
+- `docs/solutions/logic-errors/vim-behavior-contract-drift-2026-05-28.md` — concrete bugs where line-command repeat state, live option cloning, and `a` logical-line movement drifted from this architecture
 - `docs/solutions/logic-errors/pi-vimmode-config-keymap-precedence-2026-06-17.md` — descriptor/config precedence guardrails for semantic keymaps
 - `docs/solutions/developer-experience/pi-vimmode-ctrl-d-ctrl-u-half-page-scroll-2026-06-18.md` — recent motion-addition recipe using descriptor entries, buffer helpers, modal wiring, docs, and drift tests
 - `docs/solutions/developer-experience/pi-vimmode-auto-activation-2026-05-26.md` — same editor component, focused on lifecycle/activation reliability rather than keybinding behavior

--- a/docs/solutions/architecture-patterns/pi-vimmode-prompt-buffer-operation-api-2026-05-27.md
+++ b/docs/solutions/architecture-patterns/pi-vimmode-prompt-buffer-operation-api-2026-05-27.md
@@ -1,6 +1,7 @@
 ---
 title: Prompt buffer operation API for Vim editor adapters
 date: 2026-05-27
+last_updated: 2026-07-14
 category: docs/solutions/architecture-patterns
 module: pi-vimmode
 problem_type: architecture_pattern
@@ -165,3 +166,4 @@ Cover operation contracts, not helper internals:
 ## Related
 
 - [Finite Vim keybinding parser with pure buffer helpers](./finite-vim-keybinding-parser-buffer-helpers-2026-05-26.md) — earlier architecture pattern for parser, buffer helper, modal engine, and adapter separation. This doc deepens the buffer boundary into operation-level public APIs.
+- [Vim behavior contracts drifted from live adapter behavior](../logic-errors/vim-behavior-contract-drift-2026-05-28.md) — concrete boundary failures, including gating `a` movement from logical line state before emitting native Right.

--- a/docs/solutions/logic-errors/vim-behavior-contract-drift-2026-05-28.md
+++ b/docs/solutions/logic-errors/vim-behavior-contract-drift-2026-05-28.md
@@ -1,7 +1,7 @@
 ---
 title: Vim behavior contracts drifted from live adapter behavior
 date: 2026-05-28
-last_updated: 2026-06-02
+last_updated: 2026-07-14
 category: docs/solutions/logic-errors
 module: pi-vimmode
 problem_type: logic_error
@@ -11,6 +11,7 @@ symptoms:
   - "Configured prompt-native structure and transform behavior was not preserved through live `VimEditor` construction"
   - "Line edits and prompt-native text objects had edge-case drift from Vim-style contracts"
   - "README and settings docs drifted from actual supported Vim behavior"
+  - "Normal-mode `a` crossed a logical line boundary when invoked at end of line"
 root_cause: logic_error
 resolution_type: code_fix
 severity: medium
@@ -36,6 +37,8 @@ tags:
 
 The same change set also exposed smaller behavior-contract drifts: `dil` on list items could join unrelated lines, `:reflow` could rewrite code when the visual range started inside an existing fence, text-object key config allowed impossible multi-key bindings, and docs still listed supported commands as unsupported.
 
+A later behavior-contract regression affected normal-mode `a`: `insertAfter` always delegated one native Right movement. At logical EOL, Pi correctly moved to the next logical line, but Vim append semantics must enter insert mode without leaving the current logical line.
+
 ## Symptoms
 
 - `piVimMode.marks.enabled: false` was not honored by live `VimEditor` instances.
@@ -48,6 +51,7 @@ The same change set also exposed smaller behavior-contract drifts: `dil` on list
 - `dil` on a single-line list item deleted the item content plus the following newline, joining the next line onto the list marker.
 - Visual `:reflow` inside an existing Markdown code fence treated the selected code line as prose when the selected range did not include the fence delimiters.
 - README or settings limitations described some now-supported behavior, such as `:nohlsearch`, as unsupported.
+- At any non-final logical EOL, pressing `a` could move into the next line before inserted text was applied; a wrapped line followed by a blank line exposed the regression.
 
 ## What Didn't Work
 
@@ -57,8 +61,27 @@ The same change set also exposed smaller behavior-contract drifts: `dil` on list
 - Treating every prompt-structure delete like a whole-line delete was too broad. Inner list item content starts after the list marker, so consuming a following newline changes unrelated text.
 - Reflowing only the selected slice lost lexical context. Fence preservation depends on whether the selected range starts inside a fence opened on an earlier line.
 - Allowing multi-key text-object kind/target bindings contradicted the implemented grammar (`operator + kind key + target key`). Without prefix states, multi-key bindings parse but cannot execute predictably.
+- Treating `a` as unconditional native Right movement was too broad. Native Right may cross a logical line boundary; Vim `a` may not.
 
 ## Solution
+
+### Keep insert-after movement inside the logical line
+
+Decide whether `a` may move from the modal snapshot before emitting an adapter command. Terminal wrapping is irrelevant; compare the cursor column with the current logical line length.
+
+```ts
+case "insertAfter":
+  return modeUpdate(
+    nextState,
+    "insert",
+    options,
+    snapshot.cursor.col < (snapshot.lines[snapshot.cursor.line] ?? "").length
+      ? [{ type: "adapterCommand", command: "right" }, { type: "invalidate" }]
+      : [],
+  );
+```
+
+This preserves ordinary append-after-character behavior while entering insert mode directly at EOL and on empty lines.
 
 ### Preserve every live option branch
 
@@ -232,6 +255,8 @@ When Ex support changes, update both feature docs and settings limitations. In t
 
 ## Why This Works
 
+Keeping the guard at the `insertAfter` command seam preserves shared native Right behavior while enforcing Vim append semantics from logical buffer state.
+
 `VimEditor` now passes the full resolved behavior configuration into modal state decisions and Ex command parsing. `marksForOptions(options)`, `promptStructuresForOptions(options)`, and `promptTransformsForOptions(options)` see the caller-provided branches, so disabled features, restricted slots, renamed commands, and disabled transforms affect live behavior.
 
 Line commands now remain semantic across record and replay. `dd` and `cc` are stored as `lineCommand` repeatable changes, then replayed through `applyLineCommand()`. That preserves linewise register behavior, cursor placement, count handling, and insert-mode transition for `cc`.
@@ -251,6 +276,7 @@ Text-object config validation now matches the implemented grammar. Unsupported m
 - For range transforms such as reflow, decide whether behavior depends on context outside the selected lines. If it does, pass enough full-buffer context into the pure helper.
 - Keep keymap config validation aligned with parser grammar. If the parser has no prefix state for a binding class, reject multi-key bindings for that class.
 - Update README and `docs/settings.md` limitations during behavior-contract changes so docs describe the prompt buffer contract, not stale roadmap assumptions.
+- Gate command-specific native movement from the logical buffer snapshot. Do not weaken shared Right semantics to repair one Vim command.
 
 Regression tests to keep:
 
@@ -263,14 +289,15 @@ Regression tests to keep:
 - Text-object keymap rejects multi-key kind/target bindings.
 - Cross-group keymap conflict warnings include text-object bindings.
 - Documented nested prompt config examples typecheck.
+- Cover `a` before EOL, at EOL, and on an empty line at the modal level, plus one wrapped non-final line through a real `VimEditor`.
 
-Validation used for the latest fix:
+Validation used for the insert-after boundary fix:
 
-- `bun test` — 259 pass
+- `bun test` — 743 pass
 - `bun run check-types`
 - `bun run lint`
-- `bun run format:check`
-- `openspec validate prompt-native-structure-editing --strict`
+- `bunx oxfmt --check docs/features.md src/modal/normal.ts test/modal.test.ts test/vim-editor.test.ts openspec/changes/fix-insert-after-line-boundary`
+- `openspec validate --specs --strict`
 
 ## Related Issues
 
@@ -279,3 +306,4 @@ Validation used for the latest fix:
 - `docs/solutions/architecture-patterns/pi-vimmode-finite-ex-line-commands-architecture-2026-06-01.md` — related finite Ex parser / buffer / modal architecture; relevant to prompt transforms and `:nohlsearch` docs.
 - `docs/solutions/architecture-patterns/finite-vim-keybinding-parser-buffer-helpers-2026-05-26.md` — broader modal parser / buffer / adapter architecture pattern.
 - `docs/solutions/logic-errors/visual-line-paste-swallowed-by-modal-handler-2026-05-27.md` — related modal-routing bug pattern for commands swallowed by mode-specific handlers.
+- `docs/solutions/logic-errors/pi-vimmode-lowercase-small-word-motion-2026-06-15.md` — related case where native editor movement did not match Vim-specific logical boundaries.

--- a/openspec/changes/fix-insert-after-line-boundary/.openspec.yaml
+++ b/openspec/changes/fix-insert-after-line-boundary/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-14

--- a/openspec/changes/fix-insert-after-line-boundary/design.md
+++ b/openspec/changes/fix-insert-after-line-boundary/design.md
@@ -1,0 +1,72 @@
+## Context
+
+pi-vimmode implements normal-mode `a` by transitioning to insert mode and returning an `adapterCommand` effect for Pi's native right-arrow behavior. Pi's editor models cursor positions as insertion points and intentionally lets Right move from one logical line's EOL to the next line's start. That behavior is correct for Pi but not for Vim's `a`, which must append within the current logical line.
+
+This is visible in long wrapped prompts because scrolling and wrapping make the following blank logical line easy to overlook. Wrapping itself is not causal; the bug occurs whenever `a` runs from an EOL insertion position before another logical line.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Keep `a` on the current logical line when the snapshot cursor is already at EOL.
+- Preserve `a` immediately-after-character behavior elsewhere.
+- Keep the decision in modal semantics and Pi cursor execution in the adapter.
+- Cover the exact live-editor regression involving a following blank line and a long wrapped prompt.
+
+**Non-Goals:**
+
+- Change Pi's native right-arrow semantics.
+- Change `l`, Right, visual movement, operator movement, `i`, `I`, or `A`.
+- Add configuration for newline crossing.
+- Enforce full Vim cursor invariants throughout pi-vimmode.
+
+## Decisions
+
+### Decide movement from the modal snapshot
+
+**Target seams:** `src/modal/normal.ts`, focused modal tests.
+
+For `insertAfter`, return the rightward `adapterCommand` only when `snapshot.cursor.col` is less than the current logical line's length. At EOL or on an empty line, transition directly to insert mode without a cursor movement effect.
+
+This uses state already available to modal command handling, keeps the condition independent of terminal width and viewport scroll, and preserves `ModalEffect` as the Pi adapter boundary.
+
+**Alternatives rejected:**
+
+- Guard Right inside `VimEditor.applyAdapterCommand`: rejected because that would change shared normal/visual right motions and make the adapter own command-specific Vim semantics.
+- Add a new cursor-setting effect or pure buffer edit: rejected because no text changes and the existing optional adapter movement is sufficient.
+- Fix Pi's editor: rejected because crossing logical lines is valid native right-arrow behavior.
+
+### Keep behavior unconditional and unconfigured
+
+**Target seams:** no changes to `src/config.ts`, `src/types.ts`, option cloning, or settings docs.
+
+`a` will consistently follow its supported Vim meaning. No option will restore newline crossing.
+
+**Alternatives rejected:**
+
+- Add an `insertAfter` line-crossing setting: rejected because it would preserve known incorrect semantics, expand config propagation and live-editor testing obligations, and duplicate behavior available through Pi's native editing outside this command.
+
+### Validate modal contract and real adapter behavior
+
+**Target seams:** `test/modal.test.ts`, `test/vim-editor.test.ts`, `docs/features.md`.
+
+Focused modal tests will assert effect presence after an existing character and effect absence at EOL. One real `VimEditor` regression test will use a long wrapped non-final logical line with a following blank line, invoke `a`, type text, and verify text remains on the original line. This single case covers adapter effect application, terminal wrapping, and viewport scrolling.
+
+The feature guide remains the user-facing source of truth and will describe `a` as appending within the current logical line.
+
+## Risks / Trade-offs
+
+- **Risk: Cursor columns use Pi insertion-point semantics rather than a strict Vim character cursor.** Mitigation: predicate directly against current logical line length and test both existing-character and EOL positions.
+- **Risk: Modal-only tests pass while adapter effect application still crosses lines.** Mitigation: include real `VimEditor` regression coverage.
+- **Risk: Broader right-motion inconsistency remains.** Mitigation: keep it explicitly out of scope and address separately only if reported or specified.
+- **Trade-off: No compatibility option for current behavior.** This is intentional because current behavior is a bug and no documented contract promises it.
+
+Side effects remain unchanged: `a` writes no registers or marks, does not alter dot-repeat payloads, visual state, Ex messages, or Pi delegation, and keeps existing mode-transition clearing for search highlights and transient state. Only cursor placement changes at logical EOL.
+
+## Migration Plan
+
+Ship as a non-breaking patch. No data, settings, keymap, runtime dependency, or peer dependency migration is required. Rollback consists of reverting the conditional effect if an unforeseen adapter regression appears.
+
+## Open Questions
+
+None.

--- a/openspec/changes/fix-insert-after-line-boundary/proposal.md
+++ b/openspec/changes/fix-insert-after-line-boundary/proposal.md
@@ -1,0 +1,36 @@
+## Why
+
+The normal-mode `a` command currently delegates an unconditional right-arrow to Pi. When the cursor is already at a logical line end and another prompt line follows, Pi correctly moves to the next line, but pi-vimmode thereby violates `a` semantics by entering insert mode on the following line.
+
+## What Changes
+
+- Keep `a` on the current logical line when invoked at that line's end, including before blank lines in long wrapped prompts.
+- Preserve current `a` behavior when the cursor points at an existing character: enter insert mode immediately after that character.
+- Add focused modal-effect coverage for both paths and a live `VimEditor` regression for EOL before a following line.
+- Clarify `a` behavior in the feature guide.
+
+### Non-goals
+
+- Changing Pi's native right-arrow behavior.
+- Changing normal or visual `l`/Right motion behavior.
+- Adding a configuration option for newline crossing.
+- Claiming broader Vim/Neovim cursor parity beyond this practical prompt-editing command.
+
+## Capabilities
+
+### New Capabilities
+
+None.
+
+### Modified Capabilities
+
+- `vim-mode-editor`: Define that normal-mode `a` enters insert mode after the current character without crossing the current logical line boundary.
+
+## Impact
+
+- **Modal semantics:** `src/modal/normal.ts` will conditionally request rightward adapter movement based on the current logical line and cursor position.
+- **Adapter integration:** `src/vim-editor.ts` remains unchanged unless live-editor regression testing exposes an adapter-specific need; Pi continues to own native cursor movement.
+- **Tests:** focused modal tests and real-editor tests will cover insertion after an existing character, insertion at logical EOL before a following blank line, and long wrapped prompt behavior.
+- **Documentation:** `docs/features.md` will describe the line-boundary behavior of `a`.
+- **Compatibility:** bug fix, non-breaking; no settings migration and no keymap change.
+- **Dependencies:** no new runtime or peer dependencies.

--- a/openspec/changes/fix-insert-after-line-boundary/specs/vim-mode-editor/spec.md
+++ b/openspec/changes/fix-insert-after-line-boundary/specs/vim-mode-editor/spec.md
@@ -1,0 +1,45 @@
+## MODIFIED Requirements
+
+### Requirement: Normal mode supports core Vim editing
+
+The Vim editor SHALL support practical normal-mode editing commands using an extension-local unnamed register.
+
+#### Scenario: Enter insert from normal mode
+
+- **WHEN** the editor is in normal mode and the user presses `i`, `a`, `I`, or `A`
+- **THEN** the editor enters insert mode at the current cursor, after the current cursor within the same logical line, at line start, or at line end respectively
+
+#### Scenario: Append after an existing character
+
+- **WHEN** the editor is in normal mode, the cursor points at an existing character, and the user presses `a`
+- **THEN** the editor enters insert mode immediately after that character
+
+#### Scenario: Append at logical line end
+
+- **WHEN** the editor is in normal mode, the cursor is already at the current logical line's end, another logical line follows, and the user presses `a`
+- **THEN** the editor enters insert mode at the current line's end and MUST NOT move to the following line
+
+#### Scenario: Append in a wrapped prompt
+
+- **WHEN** a logical line spans multiple terminal rows, the cursor is at that logical line's end before a following blank line, and the user presses `a`
+- **THEN** terminal wrapping and prompt scrolling do not cause the cursor to cross into the following logical line
+
+#### Scenario: Delete character under cursor
+
+- **WHEN** the editor is in normal mode and the user presses `x`
+- **THEN** the character under the cursor is deleted when one exists
+
+#### Scenario: Delete current line
+
+- **WHEN** the editor is in normal mode and the user presses `dd`
+- **THEN** the current line is removed, the removed text is stored in the unnamed register as linewise text, and the prompt remains editable
+
+#### Scenario: Yank and paste current line
+
+- **WHEN** the editor is in normal mode and the user presses `yy` followed by `p`
+- **THEN** the current line is copied to the unnamed register and pasted after the current line
+
+#### Scenario: Undo delegates to Pi editor
+
+- **WHEN** the editor is in normal mode and the user presses `u`
+- **THEN** the editor invokes Pi's default undo behavior

--- a/openspec/changes/fix-insert-after-line-boundary/tasks.md
+++ b/openspec/changes/fix-insert-after-line-boundary/tasks.md
@@ -1,0 +1,21 @@
+## 1. Modal Integration
+
+- [x] 1.1 Add focused modal tests proving `insertAfter` requests right movement after an existing character but not at EOL or on an empty line.
+- [x] 1.2 Include one state-rich EOL assertion confirming the transition enters insert mode, clears transient/search state as before, and preserves unrelated modal state.
+- [x] 1.3 Update `src/modal/normal.ts` so `insertAfter` emits the rightward adapter command only when the snapshot cursor points before the current logical line's end.
+
+## 2. Adapter and Live Editor Regression
+
+- [x] 2.1 Add one real `VimEditor` regression test using a long wrapped non-final logical line followed by a blank line; render a constrained viewport, invoke `a`, type text, and verify insertion stays on the original logical line.
+
+## 3. Documentation
+
+- [x] 3.1 Update `docs/features.md` to describe `a` as entering insert mode after the current character without crossing the current logical line.
+
+## 4. Validation
+
+- [x] 4.1 Run `bun test`.
+- [x] 4.2 Run `bun run check-types`.
+- [x] 4.3 Run `bun run lint`.
+- [ ] 4.4 Run `bun run format:check`.
+- [x] 4.5 Run `openspec validate --specs --strict`.

--- a/src/modal/normal.ts
+++ b/src/modal/normal.ts
@@ -390,10 +390,14 @@ export function applyCommand(
     case "insertBefore":
       return modeUpdate(nextState, "insert", options);
     case "insertAfter":
-      return modeUpdate(nextState, "insert", options, [
-        { type: "adapterCommand", command: "right" },
-        { type: "invalidate" },
-      ]);
+      return modeUpdate(
+        nextState,
+        "insert",
+        options,
+        snapshot.cursor.col < (snapshot.lines[snapshot.cursor.line] ?? "").length
+          ? [{ type: "adapterCommand", command: "right" }, { type: "invalidate" }]
+          : [],
+      );
     case "insertLineStart":
       return modeUpdate(nextState, "insert", options, [
         { type: "adapterCommand", command: "lineStart" },

--- a/test/modal.test.ts
+++ b/test/modal.test.ts
@@ -2622,6 +2622,53 @@ describe("modal engine", () => {
     });
   });
 
+  test("insert after moves only when cursor points before logical line end", () => {
+    expect(
+      handleModalInput(
+        { mode: "normal" },
+        { text: "abc\n", lines: ["abc", ""], cursor: p(0, 2) },
+        options,
+        "a",
+      ).effects,
+    ).toContainEqual({ type: "adapterCommand", command: "right" });
+
+    for (const atBoundary of [
+      { text: "abc\n", lines: ["abc", ""], cursor: p(0, 3) },
+      { text: "\n", lines: ["", ""], cursor: p(0, 0) },
+    ]) {
+      expect(
+        handleModalInput({ mode: "normal" }, atBoundary, options, "a").effects,
+      ).not.toContainEqual({ type: "adapterCommand", command: "right" });
+    }
+  });
+
+  test("insert after at line end preserves persistent modal state", () => {
+    const state: ModalState = {
+      mode: "normal",
+      register: { type: "char", text: "saved" },
+      namedRegisters: { a: { type: "line", text: "line" } },
+      marks: { a: p(0, 1) },
+      macros: { a: ["x"] },
+      lastRepeatableChange: { type: "command", command: "deleteChar" },
+      searchHighlight: { query: "abc", current: p(0, 0) },
+      exMessage: { kind: "info", text: "clear me" },
+    };
+
+    expect(
+      handleModalInput(state, { text: "abc\n", lines: ["abc", ""], cursor: p(0, 3) }, options, "a"),
+    ).toEqual({
+      state: {
+        mode: "insert",
+        register: state.register,
+        namedRegisters: state.namedRegisters,
+        marks: state.marks,
+        macros: state.macros,
+        lastRepeatableChange: state.lastRepeatableChange,
+      },
+      effects: [{ type: "terminalCursor", style: "bar" }, { type: "invalidate" }],
+    });
+  });
+
   test("normal showKeybindings semantic command opens popup without modal side effects", () => {
     const configured = resolveVimOptions({
       piVimMode: { keymap: { commands: { showKeybindings: ["gk"] } } },

--- a/test/vim-editor.test.ts
+++ b/test/vim-editor.test.ts
@@ -958,6 +958,32 @@ describe("vim editor integration", () => {
     expect(editor.getText()).toBe("a");
   });
 
+  test("insert after keeps wrapped logical line before following blank line", () => {
+    const { editor } = createEditor(
+      { ...DEFAULT_VIM_OPTIONS, startMode: "normal" },
+      { warnings: [] },
+      false,
+      { rows: 10 },
+    );
+    const line = "a".repeat(200);
+    editor.setText(`${line}\n`);
+    editor.render(20);
+    editor.handleInput("k");
+    editor.handleInput("$");
+    editor.render(20);
+
+    expect(editor.getCursor()).toEqual({ line: 0, col: line.length });
+
+    editor.handleInput("a");
+    editor.handleInput("X");
+
+    expectEditorState(editor, {
+      text: `${line}X\n`,
+      cursor: { line: 0, col: line.length + 1 },
+      mode: "insert",
+    });
+  });
+
   test("insert render avoids combining bar overlay at wrap boundary", () => {
     const { editor } = createEditor();
     editor.focused = true;


### PR DESCRIPTION
## Summary

<!-- What does this PR do? Why? -->

Normal-mode `a` now enters insert mode at current logical line’s end instead of crossing into following line. Existing append-after-character behavior remains unchanged.

Boundary logic stays within modal command semantics, preserving Pi’s native Right behavior for other commands. Regression coverage includes EOL, empty lines, persistent modal state, and wrapped prompts followed by blank lines.

Also prunes completed TODOs and ignores local subagent artifacts.

## Changes

## Testing

- [x] `bun test` passes
- [x] `bun run check-types` passes
- [x] `bun run lint` passes
- [x] Manually tested in Pi

## Related Issues

Closes #
