### PR TITLE
feat(config): catalog canonical config metadata

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -2,6 +2,21 @@
 
 ## What's new
 
+- Added configurable Vim leader mappings. Set `piVimMode.leader` in JSON or `vim.g.mapleader` in trusted JavaScript, then use `<leader>` at the start of mapping keys. Project settings can override or clear inherited leaders.
+
+```json
+{
+  "piVimMode": {
+    "leader": " ",
+    "keymap": {
+      "commands": {
+        "visualBlock": ["<leader>v"]
+      }
+    }
+  }
+}
+```
+
 - Added `piVimMode.ui.status.position` to place the complete editor-border status group on the left or right side of the editor. #21 @alanpog
 
 ```json

--- a/docs/solutions/architecture-patterns/pi-vimmode-canonical-config-action-metadata-2026-07-15.md
+++ b/docs/solutions/architecture-patterns/pi-vimmode-canonical-config-action-metadata-2026-07-15.md
@@ -1,0 +1,102 @@
+---
+title: Pi vimmode canonical config and action metadata
+date: 2026-07-15
+category: architecture-patterns
+module: pi-vimmode
+problem_type: architecture_pattern
+component: tooling
+severity: medium
+applies_when:
+  - "Adding finite config leaves or keymap actions"
+  - "Avoiding duplicated config/action enumerations across validation and diagnostics"
+  - "Defining mapping scopes for descriptor-backed actions"
+related_components:
+  - documentation
+  - development_workflow
+tags:
+  - pi-vimmode
+  - config-metadata
+  - action-metadata
+  - source-of-truth
+  - keymaps
+  - typed-registry
+---
+
+# Pi vimmode canonical config and action metadata
+
+## Context
+
+Issue #35 needed one typed description of every finite configuration leaf and semantic action without changing Pi vimmode behavior. Existing descriptors, prompt-transform actions, diagnostic actions, and protected-shortcut ownership were already authoritative; duplicating their values in another hand-maintained table would drift.
+
+## Guidance
+
+Compose catalog metadata from current owners. The catalog describes behavior; it does not become a second resolver or config parser.
+
+```ts
+...descriptorMetadata("insert", KEYMAP_INSERT_DESCRIPTORS, () => ["insert"]),
+...PROMPT_TRANSFORM_ACTIONS.map(({ id, modes }) => ({
+  id,
+  source: "prompt-transform-registry" as const,
+  defaults: [],
+  scopes: modes,
+  bindable: true,
+})),
+```
+
+Keep mapping grammar separate from stable editor state. `operatorPending` is a valid mapping scope, but not a `VimMode`.
+
+```ts
+export const VIM_MAPPING_SCOPES = [
+  "normal",
+  "visual",
+  "visualLine",
+  "visualBlock",
+  "insert",
+  "operatorPending",
+] as const;
+```
+
+Encode semantic exceptions at catalog construction. Mark setting begins a mark operation and cannot resolve while an operator is pending; mark jumps can.
+
+```ts
+action === "set" ? NORMAL_AND_VISUAL_SCOPES : [...NORMAL_AND_VISUAL_SCOPES, "operatorPending"];
+```
+
+Catalog parser-supported finite leaves even when their resolved default is absent. `keymap.actionPresets` is accepted by config parsing but intentionally has no default keymap value.
+
+```ts
+"keymap.actionPresets",
+```
+
+## Why This Matters
+
+Source-backed metadata prevents separate lists from silently diverging across default cloning, JSON and trusted-JS config, diagnostics, protected-shortcut handling, and command resolution. It preserves finite grammar ownership in existing parser/resolver code while letting consumers inspect one catalog.
+
+## When to Apply
+
+- Adding finite keymap/config options with existing source registries.
+- Exposing action/default/scope metadata to diagnostics or discovery features.
+- Auditing whether a parser-supported option is missing from a finite inventory.
+
+Do not use this for dynamic runtime state or as a replacement for `src/commands.ts` grammar resolution.
+
+## Examples
+
+Guard catalog coverage with semantic equivalence tests, not only shape snapshots:
+
+```ts
+expect(VIM_ACTION_METADATA.map(({ id }) => id).sort()).toEqual(expected);
+for (const leaf of CONFIG_LEAVES) {
+  expect(leaf.defaultValue).toEqual(valueAtPath(leaf.path));
+}
+expect(CONFIG_LEAVES.map(({ path }) => path)).toContain("keymap.actionPresets");
+```
+
+Verify behavior remains unchanged through config parsing, command resolution, diagnostics, and protected-shortcut tests. Issue #35 passed the full suite: 761 tests plus lint, formatting, and type checking.
+
+## Related
+
+- GitHub issue [#35](https://github.com/pekochan069/pi-vimmode/issues/35)
+- `docs/solutions/architecture-patterns/pi-vimmode-typed-action-registry-keybindings-2026-06-09.md` — bindable prompt-transform action registry boundary.
+- `docs/solutions/architecture-patterns/pi-vimmode-source-of-truth-seam-refactor-2026-06-25.md` — narrow-owner pattern for finite repeated facts.
+- `docs/solutions/architecture-patterns/pi-vimmode-runtime-help-docs-drift-guard-2026-06-05.md` — source-backed discovery/docs drift guards.

--- a/openspec/changes/ship-pi-vimmode-0-9-0/.openspec.yaml
+++ b/openspec/changes/ship-pi-vimmode-0-9-0/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-15

--- a/openspec/changes/ship-pi-vimmode-0-9-0/design.md
+++ b/openspec/changes/ship-pi-vimmode-0-9-0/design.md
@@ -1,0 +1,185 @@
+## Context
+
+pi-vimmode already has finite JSON settings, a small trusted JavaScript keymap builder, semantic action metadata, layered leader resolution, a stable lifecycle editor factory, finite Ex parsing, and an editor-owned read-only popup. Those seams are sufficient for 0.9.0, but current JavaScript evaluation mutates a partial settings result directly, mapping scope is not represented as a complete grammar concept, successful reload updates future editor construction rather than every active editor, and package build does not carry a validated release asset or public config declarations.
+
+The work spans configuration, keymap compilation, lifecycle state, public types, documentation generation, packaging, and popup rendering. It must preserve existing JSON behavior and valid JavaScript calls while keeping Pi application shortcuts and ordinary insert-mode typing under Pi ownership. Release work is split across GitHub issues #33–#45; cursor-setter migration and final performance/release gates remain deferred until Pi provides the required public cursor API.
+
+Relevant durable decisions remain in force: Ex input uses its dedicated command-line row; detailed docs live outside README; settings and finite metadata own customization truth; leader placeholders resolve with one final effective leader; `VimEditor` remains the Pi adapter; and lifecycle keeps one stable editor factory.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Represent every finite setting and bindable action once in typed canonical metadata.
+- Evaluate trusted global JavaScript into a closed, source-ordered transaction.
+- Compile every configuration layer into one immutable scoped plan before commit.
+- Support finite normal, visual, insert, and operator-pending mappings with deterministic conflicts and compatibility aliases.
+- Apply valid reloads to active editors atomically while preserving durable prompt state.
+- Publish declaration-only config types, generated references, checked examples, and package-level drift checks.
+- Package validated current-version release notes and expose them through manual `:changelog` in the existing read-only popup.
+- Establish reproducible performance and package verification foundations for later release gates.
+
+**Non-Goals:**
+
+- Full Vim/Neovim mapping semantics, recursive mappings, timeout resolution, arbitrary callbacks, broad insert remapping, Vimscript, or Lua.
+- Executable project config, sandboxing, file watching, or transitive helper hot reload.
+- Replacing JSON settings or changing project-over-global precedence.
+- Replacing the stable editor factory or creating a second action registry.
+- Automatic changelog notices, historical/network release browsing, or a general Markdown viewer.
+- Cursor restoration migration, final layout optimization, or release-candidate publishing before upstream Pi cursor support exists.
+
+## Decisions
+
+### 1. Canonical finite metadata feeds behavior, types, and generated references
+
+Settings metadata will describe each public leaf's domain path, accepted value shape, built-in default, replacement semantics, and JSON crosswalk. Action metadata will describe opaque descriptor factory, accepted arguments, supported scopes, compatibility aliases, and finite runtime action identity. Existing settings, prompt-transform action, diagnostics, and protected-shortcut sources will be consolidated or adapted rather than copied into a second registry.
+
+Target seams are configuration/types, semantic command metadata, customization diagnostics, and generated docs. Existing behavior-equivalence tests must pass before duplicate tables are removed.
+
+Alternatives rejected:
+
+- Hand-maintained docs/types tables: they drift across the complete surface.
+- Runtime introspection registry exposed to config: it creates unsupported API and arbitrary execution pressure.
+- One generic untyped property bag: it weakens field-local validation and editor assistance.
+
+### 2. JavaScript evaluation produces an operation log, not active options
+
+Each trusted config load will create a session seeded from built-in defaults plus valid global JSON. The session exposes validated domain properties, preset assignment, `vim.g.mapleader`, finite action factories, map, and unmap. It records source-ordered operations and returns frozen snapshots from reads. Arrays and records replace on assignment.
+
+Invalid or unknown leaf writes remain local warnings and preserve prior staged values plus valid siblings. Syntax, import, and uncaught export failures return a distinct fatal transaction result. Session closure happens in `finally`; later writes through retained references throw `config session closed`.
+
+Root modules are re-evaluated on reload. Imported helpers follow native ESM process caching, which is documented as requiring Pi restart after helper edits. Executable config remains global-only and unsandboxed with full Pi process privileges.
+
+Alternatives rejected:
+
+- Mutating a partial options object during evaluation: fatal async failure can leave ambiguous partial state.
+- Deep mutable getters: nested mutation bypasses validation and source ordering.
+- Sandboxing: outside 0.9.0 scope and incompatible with normal trusted ESM imports.
+- Cache-busting transitive imports: unreliable and broader than root reload promise.
+
+### 3. One compiler resolves all layers into immutable scoped lookup tables
+
+Compilation order is defaults, global JSON, global JavaScript operations, then project JSON. Global and project JSON are parsed once. JavaScript getters do not observe project JSON. The compiler retains leader expressions until final project-layer leader resolution, then expands accepted mapping keys and preflights scope, exact, prefix, replay, insert, operator-pending, and protected-shortcut rules.
+
+Output is an immutable plan containing resolved options, diagnostics, and per-scope exact/prefix lookup tables. Existing JSON keymaps adapt into this compiler. Project semantic action settings replace JavaScript mappings for that action across canonical scopes; unrelated JavaScript mappings survive; final project exact-key conflicts win.
+
+Alternatives rejected:
+
+- Independent JSON and JavaScript compilers: they duplicate collision and precedence logic.
+- Expanding leader at declaration time: contradicts final project authority and ADR 0004.
+- Incremental active-state mutation: makes fatal rollback and generation ordering unsafe.
+
+### 4. Mapping scope is separate from stable editor mode
+
+Canonical scopes are normal, visual family, insert, and operator-pending grammar. Short and long supported mode names normalize at API boundary; `x` aliases visual family and `o` aliases operator-pending. Operator-pending is not added as stable editor mode.
+
+Opaque immutable descriptors carry finite action identity internally. Config authors cannot construct, inspect as registry records, mutate, or execute them directly. Same-scope exact mapping uses latest valid operation. `null` removes only selected exact mappings. Later strict-prefix overlap in one scope is rejected because pi-vimmode has no timeout semantics; disjoint scopes may overlap.
+
+String RHS stays bounded and non-recursive outside insert scope. Insert scope accepts only finite insert descriptors on supported keys, preserving ordinary typing and autocomplete. Operator-pending accepts only valid motions/targets. Protected shortcut override is per binding and does not claim terminal delivery guarantees. Descriptions are diagnostic metadata only.
+
+Alternatives rejected:
+
+- Treating operator-pending as editor mode: leaks parser state into durable mode model.
+- Vim timeout/recursive behavior: adds ambiguous asynchronous grammar.
+- Arbitrary callbacks: bypasses finite validation and Pi shortcut ownership.
+
+### 5. Reload commits compiled plans to tracked editors in place
+
+Lifecycle keeps stable factory identity and tracks active editors. A successful load compiles fully before commit. `VimEditor.reconfigure(plan, diagnostics)` swaps resolved options and lookup tables atomically, reapplies terminal cursor style, and requests render without replacing editor component.
+
+Durable state preserved: prompt buffer, clamped cursor, stable mode, valid visual selection, registers, marks, macro contents, undo/redo, Ex history, and prompt-search history. Transient grammar cleared: pending count, operator, key prefix, character/register/mark/macro targets, active Ex/search input, and macro recording slot.
+
+Each async reload receives a generation. Only newest successful generation may update current plan, diagnostics, status, and active editors. Fatal live reload updates diagnostics only and preserves last-known-good plan. Fresh startup fatal JavaScript failure omits JavaScript layer while defaults, global JSON, and project JSON remain usable.
+
+Alternatives rejected:
+
+- Replacing editor component: risks prompt and undo state loss and violates lifecycle factory identity.
+- Mutating active editors before compilation: makes rollback partial.
+- Letting completion order decide: stale async config can overwrite newer intent.
+
+### 6. Public config typing is declaration-only
+
+Package exports `pi-vimmode/config` as declarations containing `VimConfig` and `VimConfigApi`. `VimConfig` covers synchronous and asynchronous default exports; `VimConfigApi` types root and imported helper/preset parameters. No runtime stub, `defineConfig`, action constructor, or registry API is shipped.
+
+Built-package consumers validate both Bundler and NodeNext resolution. Checked JavaScript examples are loaded through the real config loader and typechecked unchanged. Negative fixtures remain tests rather than shipped examples.
+
+Alternatives rejected:
+
+- Runtime helper wrapper: unnecessary for JSDoc/TypeScript and creates permanent runtime surface.
+- Source-tree-only type tests: can miss export-map and package inventory failures.
+
+### 7. Generated config reference extends documentation source-of-truth policy
+
+A canonical JavaScript config guide will contain minimal trusted setup, generated property/action reference blocks, advanced mapping/export/import workflows, and safety/precedence/reload semantics. `docs/settings.md` remains canonical for JSON. README, settings docs, and runtime help link to the JavaScript guide; README stays an index.
+
+Generated blocks are committed for GitHub readability and regenerated from canonical metadata. Guide, examples, helper, declarations, and export map are checked in built package. ADR 0002 will be amended to name the JavaScript guide as the specialized trusted-config source while preserving feature/settings ownership.
+
+Alternatives rejected:
+
+- Put full API in README: violates existing docs split and creates noise.
+- Make generated docs build-only: repository readers would not see complete reference.
+- Duplicate JSON reference in JavaScript guide: creates two authorities for JSON.
+
+### 8. `RELEASE.md` is sole authored changelog source and build input
+
+After package version moves to 0.9.0, build extracts content after first exact `# vX.Y.Z` heading through before next top-level release heading. It requires version equality, at least one second-level section, and non-empty well-formed current content. Build copies a package-relative runtime asset beside bundled entry and includes authored release source in package.
+
+Runtime never reads repository cwd or network. It defensively validates asset version/shape. Missing, unreadable, malformed, or mismatched asset produces ordinary popup content stating `Changelog unavailable for vX.Y.Z` plus repository release URL; stale notes are never shown as current.
+
+Alternatives rejected:
+
+- Duplicate generated summary: introduces a second authored source.
+- Cwd lookup: works in checkout but fails installed package behavior.
+- Network fetch: makes local help nondeterministic and unavailable offline.
+
+### 9. Changelog reuses finite Ex and read-only popup seams
+
+Exact `:changelog` with no unsupported arguments is added to finite Ex parsing. Prefilled visual source range `'<,'>` is accepted and ignored; other ranges are rejected. It opens manually only. Existing popup controls and 48×12 minimum remain. Title is `pi-vimmode vX.Y.Z changes`; outer release heading is omitted.
+
+A small Markdown row renderer handles headings, lists, links, prose, blank lines, and fenced code. Prose wraps to width; code indentation is preserved; only indivisible overlong code rows may truncate. Counters refer to rendered rows in the existing 10-row viewport.
+
+Opening, scrolling, and closing preserve prompt buffer, cursor, visual state, registers, marks, search, undo/redo, repeat, and macros. Popup display does not become repeatable change or pollute runtime message history.
+
+Alternatives rejected:
+
+- Generic Markdown dependency: unnecessary for finite release syntax and adds runtime weight.
+- Inline Ex row output: cannot show complete release content legibly.
+- New popup subsystem: duplicates existing editor-owned overlay/effect boundary.
+
+### 10. Performance and package checks are foundations, not speculative optimization
+
+A dependency-free harness records reproducible pre-change evidence using production paths and generated ASCII, multi-line, mixed-width, and scaling corpora. Setup remains outside timed regions and operations assert expected outcomes. Benchmarks remain outside package.
+
+A built-`dist`/tarball smoke seam runs from outside repository cwd and supports later declaration, docs/example, and release-asset checks. Version moves to 0.9.0 early, but publishing remains separate.
+
+Cursor migration and final layout optimization are not implemented by this change. They will become a later OpenSpec change/ticket set after upstream Pi publishes the normalized logical cursor setter.
+
+## Risks / Trade-offs
+
+- **[Metadata consolidation changes existing behavior]** → Land behavior-preserving metadata first and require equivalence tests before deleting duplicate tables.
+- **[Large finite config surface drifts across runtime, types, and docs]** → Generate declarations/references where practical and require clean regeneration plus built-package consumer tests.
+- **[Scoped compiler changes default grammar ownership]** → Adapt existing JSON paths, preserve protected shortcut checks, and assert default command equivalence before enabling new API behavior.
+- **[Reload corrupts active prompt state]** → Compile before commit, use one atomic editor reconfigure seam, and test explicit preserved/cleared state lists through real editor/lifecycle scenarios.
+- **[Async config races]** → Generation-guard every commit and test out-of-order completion.
+- **[Trusted config security is misunderstood]** → Put prominent unsandboxed full-process warning beside minimal setup and keep executable config global-only.
+- **[Package checks pass against repository files accidentally]** → Run temporary consumers and changelog smoke outside repository cwd against built artifact.
+- **[Markdown rendering grows into a general parser]** → Support only release-document constructs required by source and keep renderer pure and finite.
+- **[Existing uncommitted release work is overwritten]** → Preserve authored release content and limit release processing changes to extraction/validation/packaging.
+- **[Deferred Pi dependency is mistaken as complete release]** → State explicitly that this change covers #33–#45 only and cannot authorize publish.
+
+## Migration Plan
+
+1. Capture benchmark evidence and add package verification foundation; bump version to 0.9.0 without publishing (#33, #34).
+2. Establish canonical config metadata/scopes with behavior parity (#35).
+3. Add staged JavaScript transaction and one cross-layer compiler (#36, #37).
+4. Add complete option tree and scoped finite action mappings in parallel-compatible slices (#38, #39).
+5. Apply generation-guarded active-editor reconfiguration (#40).
+6. Ship declaration-only config types, generated references, complete guide, examples, discovery, and package checks (#41–#43).
+7. Add release extraction/package validation, then expose Markdown `:changelog` (#44, #45).
+8. Keep each issue independently revertible and green. Revert a failing slice rather than adding runtime feature flags.
+9. After upstream Pi setter release, create deferred cursor/performance/release-candidate tasks and run complete publish gate.
+
+## Open Questions
+
+- Which exact Pi release first satisfies the required normalized logical cursor setter contract? This remains an external blocker for deferred work and does not block #33–#45.
+- No unresolved design choice remains inside current #33–#45 scope; implementation discoveries that contradict these decisions require artifact update before continuing.

--- a/openspec/changes/ship-pi-vimmode-0-9-0/proposal.md
+++ b/openspec/changes/ship-pi-vimmode-0-9-0/proposal.md
@@ -1,0 +1,43 @@
+## Why
+
+pi-vimmode 0.9.0 needs a complete trusted JavaScript configuration contract, transactional live reload, package-backed documentation, and in-editor current-version release notes. Current behavior exposes only part of the finite settings and mapping surface, reload does not safely reconfigure active editors, and installed users cannot inspect validated release notes inside Pi.
+
+## What Changes
+
+- Add one staged trusted global JavaScript configuration API covering every finite `piVimMode` option through validated domain properties.
+- Add opaque finite action descriptors and true normal, visual, insert, and operator-pending mapping scopes while preserving existing JavaScript and JSON configuration compatibility.
+- Compile defaults, global JSON, JavaScript operations, and project JSON into one immutable plan before commit.
+- Reconfigure active editors transactionally on successful reload, preserve durable prompt state, clear invalid transient grammar state, and reject stale async generations.
+- Publish declaration-only config types, generated property/action references, checked examples, discovery links, and built-package drift checks.
+- Add strict build/runtime release-note validation and manual Markdown `:changelog` display through existing read-only popup behavior.
+- Add reproducible performance evidence and reusable built-package verification foundations for 0.9.0.
+- Keep the release additive: existing JSON settings, `vim.g.mapleader`, `vim.prompt.*`, and three-argument `vim.keymap.set` remain valid.
+- Defer cursor-setter migration, final render optimization, and release-candidate verification until Pi ships the required public normalized logical cursor setter.
+
+### Non-goals
+
+- Full Vim/Neovim parity, Vimscript, Neovim Lua, recursive mappings, mapping timeouts, arbitrary callbacks, or broad insert-mode remapping.
+- Project-local JavaScript config, sandboxing, watchers, or imported-helper hot reload.
+- Automatic changelog notices, historical release browsing, network-loaded notes, or a general Markdown viewer.
+- Private Pi cursor state, a slow cursor fallback, speculative caches, or native core work.
+
+## Capabilities
+
+### New Capabilities
+
+- `vim-trusted-javascript-configuration`: Complete finite trusted JavaScript option/action API, staged evaluation, cross-layer compilation, compatibility, and public type contract.
+- `vim-release-notes-popup`: Validated packaged current-version release notes and manual Markdown `:changelog` popup behavior.
+
+### Modified Capabilities
+
+- `vim-keymap-configuration`: Add true mapping scopes, finite action descriptors, deterministic scoped conflicts/unmapping, and cross-layer precedence.
+- `vim-extension-lifecycle`: Apply successful reloads transactionally to active editors with generation ordering and last-known-good fallback.
+- `vim-ex-command-line`: Recognize and dispatch the finite `:changelog` command without broadening Ex parsing.
+- `pi-vimmode-documentation`: Add canonical generated config reference, checked workflows, discovery links, public declarations, and package-content drift gates.
+
+## Impact
+
+- Affected seams: config parsing and types, finite action metadata, keymap compilation, lifecycle refresh, editor reconfiguration, Ex dispatch, read-only popup rendering, build asset generation, package exports, documentation generation, examples, and package smoke tests.
+- Runtime dependency impact: no new runtime dependencies. Package version moves to 0.9.0 without publishing in this change.
+- Compatibility: additive for existing valid JSON and JavaScript configuration. Deprecations, if introduced later, require at least one minor release warning; breaking trusted-config changes require a major release.
+- Delivery mapping: implementation tasks map to GitHub issues #33–#45. Upstream-Pi-dependent cursor and final release tasks remain deferred and are not part of this change's apply-ready task set.

--- a/openspec/changes/ship-pi-vimmode-0-9-0/specs/pi-vimmode-documentation/spec.md
+++ b/openspec/changes/ship-pi-vimmode-0-9-0/specs/pi-vimmode-documentation/spec.md
@@ -1,0 +1,124 @@
+## MODIFIED Requirements
+
+### Requirement: Documentation records source-of-truth policy
+
+The project SHALL keep an ADR under `docs/adr/` documenting that `docs/features.md` owns detailed behavior, `docs/settings.md` owns complete JSON settings reference, a canonical trusted JavaScript config guide owns executable-config setup/API/safety workflows, and README remains quickstart plus documentation index.
+
+#### Scenario: Maintainer updates docs later
+
+- **WHEN** a maintainer reads documentation source-of-truth ADR
+- **THEN** ADR identifies feature guide, JSON settings reference, trusted JavaScript config guide, and README responsibilities
+- **AND** instructs maintainers to verify claims against source files, canonical metadata, public declarations, OpenSpec specs, and focused tests
+
+#### Scenario: JSON settings remain canonical in settings guide
+
+- **WHEN** trusted JavaScript guide references corresponding JSON setting
+- **THEN** it links or crosswalks to `docs/settings.md`
+- **AND** does not become duplicate authority for JSON behavior
+
+## ADDED Requirements
+
+### Requirement: Canonical trusted JavaScript config guide covers complete contract
+
+The project SHALL provide canonical trusted JavaScript config guide ordered as basic setup, generated properties, advanced setup, and safety semantics.
+
+#### Scenario: User follows minimal setup
+
+- **WHEN** user opens beginning of guide
+- **THEN** guide shows exact global config location, primary JSDoc annotation, minimal default export, one validated assignment, and `/vimmode reload`
+- **AND** prominently warns that config is unsandboxed trusted code with full Pi process privileges
+
+#### Scenario: User learns advanced keymap API
+
+- **WHEN** user opens advanced setup
+- **THEN** guide documents supported mapping modes/scopes, action factories, arguments, compatibility aliases, conflicts, replay, unmapping, protected override, insert limits, and leader behavior
+
+#### Scenario: User learns export and import behavior
+
+- **WHEN** user configures synchronous, asynchronous, or imported helper workflow
+- **THEN** guide documents supported default exports, helper typing, root-only reload, and native imported-helper caching requiring Pi restart after helper edits
+
+#### Scenario: User learns safety and precedence semantics
+
+- **WHEN** user opens safety section
+- **THEN** guide documents trust boundary, global-only executable scope, layer precedence, source ordering, field-local warnings, fatal transactions, startup fallback, last-known-good reload, generation ordering, preserved/cleared editor state, compatibility, deprecation policy, and non-goals
+
+### Requirement: Config property and action references are generated from canonical metadata
+
+Committed guide SHALL contain generated property and action reference blocks derived from canonical finite metadata.
+
+#### Scenario: Property reference is complete
+
+- **WHEN** references are generated
+- **THEN** every public config leaf appears exactly once with stable anchor, accepted type/value shape, explicit built-in default, assignment/replacement semantics, and JSON crosswalk where available
+
+#### Scenario: Action reference is complete
+
+- **WHEN** references are generated
+- **THEN** every public finite action appears exactly once with stable anchor, supported scopes, arguments, and compatibility aliases
+
+#### Scenario: Generated blocks are readable in repository
+
+- **WHEN** user reads guide on GitHub without running build
+- **THEN** committed generated blocks contain complete current references
+
+#### Scenario: Reference drift fails validation
+
+- **WHEN** canonical metadata changes without regenerating committed reference or metadata contains missing/duplicate public entries
+- **THEN** validation fails with actionable drift error
+
+#### Scenario: Regeneration is deterministic
+
+- **WHEN** committed references match canonical metadata and generator runs
+- **THEN** working tree remains clean
+
+### Requirement: Trusted-config workflows are executable documentation
+
+The project SHALL ship checked basic, keymap, asynchronous, and imported-preset examples plus preset helper and SHALL validate examples through real loader and public declarations without rewriting them for tests.
+
+#### Scenario: Positive examples runtime-load
+
+- **WHEN** example suite loads each shipped config through real loader
+- **THEN** every example succeeds without warnings
+- **AND** demonstrates documented effective behavior
+
+#### Scenario: Positive examples typecheck unchanged
+
+- **WHEN** example suite typechecks shipped examples
+- **THEN** same files typecheck without test-only edits or wrappers
+
+#### Scenario: Negative fixtures reject invalid shapes
+
+- **WHEN** test fixtures use invalid leaves, values, modes, action arguments, or mapping options
+- **THEN** public type checks fail at expected expressions
+- **AND** negative fixtures are not shipped as user examples
+
+#### Scenario: Imported preset behavior is explicit
+
+- **WHEN** user follows imported-preset example
+- **THEN** helper is typed with public `VimConfigApi`
+- **AND** docs explain restart requirement after imported helper edits
+
+### Requirement: Trusted-config documentation is discoverable and packaged
+
+README, JSON settings guide, and runtime help SHALL link to canonical trusted JavaScript guide, and built package SHALL contain guide, checked examples/helper, declarations, and config type export.
+
+#### Scenario: Discovery links resolve
+
+- **WHEN** user follows trusted-config links from README, `docs/settings.md`, or runtime help
+- **THEN** links reach canonical guide or stable generated anchor
+
+#### Scenario: Built package contains promised documentation
+
+- **WHEN** package inventory is inspected after build
+- **THEN** guide, checked examples, preset helper, declarations, and config type export are present
+
+#### Scenario: Temporary consumers prove config type export
+
+- **WHEN** temporary Bundler and NodeNext consumers install or resolve built package
+- **THEN** both resolve declaration-only config subpath and typecheck documented basic config
+
+#### Scenario: Package drift fails validation
+
+- **WHEN** source docs/examples/types promise artifact omitted from built package
+- **THEN** package verification fails before release

--- a/openspec/changes/ship-pi-vimmode-0-9-0/specs/vim-ex-command-line/spec.md
+++ b/openspec/changes/ship-pi-vimmode-0-9-0/specs/vim-ex-command-line/spec.md
@@ -1,0 +1,59 @@
+## ADDED Requirements
+
+### Requirement: Ex command-line supports exact changelog command
+
+The Vim editor SHALL parse and execute exact `:changelog` as finite read-only Ex command that opens current-version packaged release notes in existing read-only popup.
+
+#### Scenario: Changelog command opens from normal mode
+
+- **WHEN** Ex command-line mode was opened from normal mode and user executes `:changelog`
+- **THEN** Ex input closes, editor remains in normal mode, and changelog popup opens
+
+#### Scenario: Changelog command opens from visual mode
+
+- **WHEN** Ex command-line mode was opened from visual, visual-line, or visual-block mode and user executes the prefilled `:'<,'>changelog`
+- **THEN** the visual source range is accepted without filtering release content
+- **AND** Ex input closes, original visual mode and valid captured selection are restored, and changelog popup opens
+
+#### Scenario: Unsupported changelog abbreviation is rejected
+
+- **WHEN** user executes `:change`, `:changel`, or another unsupported abbreviation
+- **THEN** finite Ex parser reports existing readable unsupported-command feedback
+- **AND** does not open changelog popup
+
+#### Scenario: Changelog arguments and unsupported ranges are rejected
+
+- **WHEN** user executes `:changelog` with unsupported argument or a range other than prefilled visual source range
+- **THEN** finite Ex parser reports readable error
+- **AND** leaves prompt text unchanged
+
+#### Scenario: Unavailable release content still uses popup
+
+- **WHEN** runtime release asset is missing, invalid, or version mismatched and user executes `:changelog`
+- **THEN** Ex command opens ordinary read-only popup with explicit unavailable content and repository release URL
+- **AND** does not crash or show stale release
+
+### Requirement: Changelog Ex command is side-effect bounded
+
+Executing, scrolling, and dismissing `:changelog` SHALL NOT mutate prompt-editing state beyond existing successful Ex history semantics and bounded popup state.
+
+#### Scenario: Changelog preserves normal editing state
+
+- **WHEN** user executes `:changelog` after repeatable edit
+- **THEN** prompt text, cursor, registers, marks, macros, search state, undo/redo, resolved options, diagnostics, and repeat target remain unchanged
+
+#### Scenario: Changelog preserves visual source state
+
+- **WHEN** user opens changelog from visual Ex command-line
+- **THEN** valid visual mode and selection are restored around popup behavior
+- **AND** prompt text remains unchanged
+
+#### Scenario: Changelog does not become repeat change
+
+- **WHEN** user closes changelog and invokes repeat-change command
+- **THEN** previous supported edit repeats rather than changelog command
+
+#### Scenario: Popup interaction does not pollute messages
+
+- **WHEN** user scrolls or dismisses changelog popup
+- **THEN** retained runtime message history does not grow solely due popup interaction

--- a/openspec/changes/ship-pi-vimmode-0-9-0/specs/vim-extension-lifecycle/spec.md
+++ b/openspec/changes/ship-pi-vimmode-0-9-0/specs/vim-extension-lifecycle/spec.md
@@ -1,0 +1,107 @@
+## ADDED Requirements
+
+### Requirement: Successful reload reconfigures active editors in place
+
+The Vim extension lifecycle SHALL compile a complete valid configuration plan before atomically reconfiguring every tracked active editor without replacing the registered editor component.
+
+#### Scenario: Active editor receives successful reload
+
+- **WHEN** `/vimmode reload` produces complete valid plan
+- **THEN** lifecycle commits plan as current
+- **AND** calls tracked editor reconfiguration with compiled plan and diagnostics
+- **AND** stable editor factory identity remains unchanged
+
+#### Scenario: Reconfiguration updates runtime behavior immediately
+
+- **WHEN** active editor accepts new compiled keymap and option plan
+- **THEN** subsequent input uses new settings without creating new prompt editor
+- **AND** editor reapplies terminal cursor style and requests render
+
+#### Scenario: New editor receives committed plan
+
+- **WHEN** lifecycle factory creates editor after successful reload
+- **THEN** new editor receives same current committed plan used by active editors
+
+#### Scenario: Plan compiles before editor mutation
+
+- **WHEN** loaded configuration contains compile error
+- **THEN** no tracked editor receives partial options or lookup tables
+- **AND** current committed plan remains unchanged
+
+### Requirement: Active editor reload preserves durable state and clears transient grammar
+
+Editor reconfiguration SHALL preserve durable prompt-editing state while clearing pending input state that may be invalid under new keymap.
+
+#### Scenario: Durable prompt state is preserved
+
+- **WHEN** active editor is reconfigured successfully
+- **THEN** prompt buffer, bounds-clamped cursor, stable mode, valid visual selection, registers, marks, macro contents, undo/redo, Ex history, and prompt-search history remain available
+
+#### Scenario: Invalid visual selection is normalized safely
+
+- **WHEN** reconfiguration receives editor state whose visual selection is no longer valid for current prompt bounds
+- **THEN** editor clamps or clears selection without mutating prompt text or history
+
+#### Scenario: Pending grammar is cleared
+
+- **WHEN** active editor is reconfigured while count, operator, key prefix, character target, register target, mark target, or macro target is pending
+- **THEN** all pending grammar state clears before next key is interpreted
+
+#### Scenario: Active workbench input is cleared
+
+- **WHEN** active editor is reconfigured during Ex command-line or prompt-search input
+- **THEN** active workbench input closes and clears
+- **AND** persisted Ex and prompt-search histories remain
+
+#### Scenario: Macro recording stops but contents persist
+
+- **WHEN** active editor is reconfigured while macro recording is active
+- **THEN** recording slot closes
+- **AND** previously recorded macro contents remain
+
+### Requirement: Reload generations prevent stale async commits
+
+The lifecycle SHALL assign reload generations and SHALL allow only newest successful generation to update current plan, diagnostics, status, and active editors.
+
+#### Scenario: Newer reload finishes first
+
+- **WHEN** two reloads overlap and newer generation finishes successfully before older generation
+- **THEN** newer plan commits
+- **AND** later completion of older generation cannot replace it or its diagnostics
+
+#### Scenario: Older reload finishes first
+
+- **WHEN** two reloads overlap and older generation finishes successfully before newer generation
+- **THEN** older result does not commit once newer generation exists
+- **AND** newest successful generation determines final state
+
+#### Scenario: Latest reload fails fatally
+
+- **WHEN** latest generation has fatal JavaScript evaluation failure
+- **THEN** lifecycle updates diagnostics/status to report failure
+- **AND** preserves last-known-good plan and active editor state
+
+#### Scenario: Fresh startup failure remains usable
+
+- **WHEN** first load has fatal JavaScript config failure
+- **THEN** lifecycle installs editor using plan compiled from defaults, global JSON, and project JSON
+- **AND** warning status reports omitted JavaScript layer
+
+### Requirement: Transactional reload is validated through lifecycle and real editor seams
+
+The change SHALL include automated coverage proving reload ordering and state reconciliation without private Pi state.
+
+#### Scenario: Lifecycle tests cover generation ordering
+
+- **WHEN** `bun test` runs
+- **THEN** lifecycle tests cover overlapping async completion, latest-success commit, fatal rollback, diagnostics/status updates, and stable factory identity
+
+#### Scenario: Real editor tests cover reconfiguration state
+
+- **WHEN** `bun test` runs
+- **THEN** real editor scenarios cover exact durable-state preservation, transient-state clearing, cursor clamping, cursor-style reapplication, and immediate new keymap behavior
+
+#### Scenario: Existing lifecycle behavior stays valid
+
+- **WHEN** lifecycle validation runs after reload implementation
+- **THEN** existing installation, delayed reinstall, busy/idle cursor policy, shutdown cleanup, and new-editor option refresh behavior continue to pass

--- a/openspec/changes/ship-pi-vimmode-0-9-0/specs/vim-keymap-configuration/spec.md
+++ b/openspec/changes/ship-pi-vimmode-0-9-0/specs/vim-keymap-configuration/spec.md
@@ -1,0 +1,222 @@
+## MODIFIED Requirements
+
+### Requirement: Trusted global JS keymap builder adds prompt built-in bindings
+
+The Vim editor SHALL load trusted global JavaScript config after global JSON and before project JSON, and SHALL let supported `vim.keymap.set(mode, lhs, rhs, options?)` calls add, replace, or remove finite scoped mappings using opaque action descriptors, bounded replay strings, or `null`.
+
+#### Scenario: JS builder uses prompt built-ins instead of internal action strings
+
+- **WHEN** the JS config default export calls `vim.keymap.set("n", "zq", vim.prompt.reflow({ width: 88 }))`
+- **THEN** the resolved normal keymap binds `zq` to reflow prompt transform with width `88`
+- **AND** raw string RHS values such as `"prompt.transform.reflow"` are treated only as replay text, not internal action IDs
+
+#### Scenario: JS builder additions preserve preset bindings
+
+- **WHEN** global JSON enables paragraph editing action preset and JavaScript adds `vim.keymap.set("n", "zq", vim.prompt.reflow())`
+- **THEN** both preset `gq` binding and JavaScript `zq` binding are accepted for reflow unless a later project layer replaces that semantic action
+
+#### Scenario: Project JSON remains authoritative for semantic action
+
+- **WHEN** JavaScript adds reflow mappings and project JSON sets `piVimMode.keymap.actions.prompt.transform.reflow` to an empty array
+- **THEN** final action keybindings contain no reflow mapping from JavaScript or lower layers
+- **AND** unrelated JavaScript mappings survive
+
+#### Scenario: JS string RHS replays key inputs
+
+- **WHEN** JavaScript calls `vim.keymap.set("n", "zz", "llll")`
+- **THEN** pressing `zz` in normal mode replays `l`, `l`, `l`, `l` through bounded existing macro replay path
+- **AND** replay does not recursively expand mappings
+
+#### Scenario: JS insert built-ins bind only insert scope
+
+- **WHEN** JavaScript calls `vim.keymap.set("i", "<A-w>", vim.prompt.deleteWordBackward())`
+- **THEN** insert mode treats `alt+w` as configured delete-word-backward action
+- **AND** using that insert descriptor in normal, visual, or operator-pending scope is rejected with warning
+
+#### Scenario: JS mapping is removed in selected scope
+
+- **WHEN** JavaScript calls `vim.keymap.set("n", "zq", null)`
+- **THEN** exact `zq` mapping visible at JavaScript layer is removed from normal scope
+- **AND** same key in disjoint scopes remains unchanged
+
+#### Scenario: Existing three-argument calls remain valid
+
+- **WHEN** pre-0.9.0 JavaScript calls `vim.keymap.set(mode, lhs, rhs)` without options
+- **THEN** call retains previously supported behavior without migration
+
+#### Scenario: JS config is trusted global code only
+
+- **WHEN** Pi loads settings for a project
+- **THEN** pi-vimmode does not load project-local executable JavaScript config
+- **AND** unsupported or fatal global JavaScript exports produce diagnostics instead of crashing startup
+
+## ADDED Requirements
+
+### Requirement: Finite action descriptors define bindable behavior
+
+The JavaScript keymap API SHALL expose opaque immutable descriptors for supported escape, operators, motions, commands, insert actions, macros, marks, text-object kinds/targets, and prompt transform actions.
+
+#### Scenario: Supported action factory returns descriptor
+
+- **WHEN** config calls supported domain action factory with valid finite arguments
+- **THEN** returned descriptor can be passed to `vim.keymap.set` in its declared scopes
+- **AND** descriptor resolves to existing finite runtime behavior
+
+#### Scenario: Descriptor cannot be forged or mutated
+
+- **WHEN** config passes arbitrary object, mutated descriptor-like value, or unsupported action argument as RHS
+- **THEN** mapping is rejected with warning
+- **AND** no arbitrary callback or internal action string is executed
+
+#### Scenario: Prompt factories remain aliases
+
+- **WHEN** config uses existing `vim.prompt.*` factory
+- **THEN** factory resolves to corresponding supported prompt action descriptor
+- **AND** compatibility alias remains valid in 0.9.0
+
+#### Scenario: Descriptor scope is enforced
+
+- **WHEN** config binds a valid descriptor in unsupported scope
+- **THEN** only that mapping is rejected with scope warning
+- **AND** valid sibling mappings remain usable
+
+### Requirement: JavaScript mappings use canonical finite scopes
+
+The keymap API SHALL normalize supported short and long mode names into normal, visual-family, insert, and operator-pending grammar scopes while keeping operator-pending separate from stable editor mode.
+
+#### Scenario: Normal scope stays normal only
+
+- **WHEN** config binds descriptor using `n` or supported normal long name
+- **THEN** mapping dispatches in normal scope
+- **AND** does not dispatch in visual, insert, or operator-pending scopes unless separately bound
+
+#### Scenario: Visual aliases cover all visual modes
+
+- **WHEN** config binds descriptor using `v`, `x`, or supported visual long name
+- **THEN** mapping dispatches in visual, visual-line, and visual-block modes
+- **AND** does not leak into normal or insert scope
+
+#### Scenario: Operator-pending alias addresses grammar state
+
+- **WHEN** config binds valid motion/target descriptor using `o` or supported operator-pending long name
+- **THEN** mapping participates only while finite operator grammar awaits target
+- **AND** no new stable editor mode is introduced
+
+#### Scenario: Unsupported Neovim mode is rejected
+
+- **WHEN** config uses command-line, select, terminal, language, or another unsupported Neovim mode
+- **THEN** mapping is rejected with warning
+- **AND** no implied parity behavior is added
+
+#### Scenario: Mode array applies independently
+
+- **WHEN** config passes supported mode array
+- **THEN** mapping is validated and applied to each selected concrete scope
+- **AND** invalid selected scope prevents only mapping operation according to documented validation
+
+### Requirement: Scoped mapping conflicts are deterministic
+
+The final compiler SHALL resolve exact mappings, unmapping, and strict-prefix conflicts per concrete scope without timeout semantics.
+
+#### Scenario: Latest valid exact mapping wins
+
+- **WHEN** source-ordered JavaScript operations bind same exact key in same scope more than once
+- **THEN** latest valid mapping replaces earlier mapping in that scope
+
+#### Scenario: Unmap removes exact mapping only
+
+- **WHEN** `null` RHS targets exact key in selected scope
+- **THEN** compiler removes that exact mapping visible at JavaScript layer
+- **AND** unrelated keys and disjoint scopes remain unchanged
+
+#### Scenario: Later strict-prefix overlap is rejected
+
+- **WHEN** later mapping key is strict prefix of existing executable mapping or has existing executable mapping as strict prefix in same scope
+- **THEN** later mapping is rejected with warning
+- **AND** existing finite grammar remains active without timeout
+
+#### Scenario: Disjoint scopes may overlap
+
+- **WHEN** normal and visual scopes bind exact or prefix-overlapping keys independently
+- **THEN** both mappings are accepted when each scope grammar is otherwise valid
+
+#### Scenario: Shared non-executable prefix remains valid
+
+- **WHEN** two same-scope mappings share prefix that is not executable mapping
+- **THEN** both mappings are accepted
+- **AND** runtime waits for complete finite key sequence
+
+### Requirement: Replay and insert mappings remain bounded
+
+The keymap API SHALL keep replay non-recursive and SHALL preserve ordinary insert typing plus Pi autocomplete ownership.
+
+#### Scenario: Normal replay is bounded
+
+- **WHEN** normal or visual mapping uses accepted string replay RHS
+- **THEN** runtime replays finite input through existing bounded macro replay path
+- **AND** replayed keys do not recursively invoke user mappings
+
+#### Scenario: Insert replay is rejected
+
+- **WHEN** insert mapping uses string replay RHS
+- **THEN** mapping is rejected with warning
+- **AND** ordinary typing remains Pi-owned
+
+#### Scenario: Printable or multi-key insert mapping is rejected
+
+- **WHEN** insert mapping attempts printable character or unsupported multi-key sequence
+- **THEN** mapping is rejected using existing insert-key validation
+- **AND** no insert pending-prefix state is added
+
+#### Scenario: Finite insert action is accepted
+
+- **WHEN** insert mapping uses supported insert descriptor on accepted insert key
+- **THEN** action dispatches in insert mode
+- **AND** existing autocomplete and protected shortcuts retain ownership outside accepted binding
+
+### Requirement: Mapping options are finite and per binding
+
+The optional mapping options object SHALL support only per-binding protected shortcut override and diagnostic description.
+
+#### Scenario: Protected override applies to one mapping
+
+- **WHEN** mapping explicitly opts into protected shortcut override
+- **THEN** that binding may pass pi-vimmode protected-shortcut validation
+- **AND** other mappings remain protected by default
+
+#### Scenario: Override does not guarantee terminal delivery
+
+- **WHEN** protected override is accepted
+- **THEN** diagnostics do not claim terminal or Pi will deliver chord distinctly
+
+#### Scenario: Description is diagnostic only
+
+- **WHEN** mapping supplies description
+- **THEN** resolved diagnostics may display description
+- **AND** description does not change dispatch or conflict semantics
+
+#### Scenario: Unknown option rejects mapping
+
+- **WHEN** mapping options contain unsupported key or invalid value
+- **THEN** that mapping is rejected with warning
+- **AND** valid sibling operations remain usable
+
+### Requirement: Final project layer controls semantic actions and exact keys
+
+The scoped compiler SHALL preserve project JSON authority while retaining unrelated valid JavaScript mappings.
+
+#### Scenario: Project semantic action replaces JavaScript mappings
+
+- **WHEN** JavaScript binds multiple keys for one semantic action and project JSON configures that action
+- **THEN** project action keys replace JavaScript mappings for that action across canonical scopes
+- **AND** unrelated JavaScript mappings remain
+
+#### Scenario: Project exact key wins final conflict
+
+- **WHEN** project JSON produces exact key conflicting with inherited JavaScript mapping in same scope
+- **THEN** final project mapping owns that exact key according to supported project precedence
+
+#### Scenario: Final leader moves retained JavaScript mappings
+
+- **WHEN** JavaScript declares `<leader>` mapping and project JSON changes leader
+- **THEN** retained JavaScript mapping expands using final project leader before scoped conflict resolution

--- a/openspec/changes/ship-pi-vimmode-0-9-0/specs/vim-release-notes-popup/spec.md
+++ b/openspec/changes/ship-pi-vimmode-0-9-0/specs/vim-release-notes-popup/spec.md
@@ -1,0 +1,121 @@
+## ADDED Requirements
+
+### Requirement: Current release notes have one authored source
+
+The package SHALL treat the first release in `RELEASE.md` as the sole authored source for current-version in-editor release notes.
+
+#### Scenario: Build extracts current release
+
+- **WHEN** `RELEASE.md` begins with exact top-level heading `# vX.Y.Z`
+- **THEN** build extracts content after that heading through before next top-level release heading
+- **AND** extraction includes every second-level section in source order
+
+#### Scenario: Outer heading is omitted from popup body
+
+- **WHEN** current release is extracted successfully
+- **THEN** runtime body omits outer `# vX.Y.Z` heading
+- **AND** retains all current-release section content below it
+
+#### Scenario: Release summary is not duplicated
+
+- **WHEN** package is built
+- **THEN** no separately authored or network-generated current-release summary is required
+
+### Requirement: Build validates and packages current release asset
+
+The 0.9.0 build SHALL fail unless current release heading exactly matches package version and extracted current release contains at least one second-level section plus non-empty well-formed content.
+
+#### Scenario: Valid release asset is packaged
+
+- **WHEN** package version and first release heading both equal 0.9.0 and current release content is valid
+- **THEN** build copies package-relative runtime asset beside bundled entry
+- **AND** package includes authored release source
+
+#### Scenario: Version mismatch fails build
+
+- **WHEN** package version differs from first release heading
+- **THEN** build fails with actionable version mismatch
+
+#### Scenario: Missing or malformed release fails build
+
+- **WHEN** release source is missing, empty, unreadable, lacks second-level section, or has malformed current release boundaries
+- **THEN** build fails before package is considered valid
+
+#### Scenario: Package smoke uses built artifact
+
+- **WHEN** release asset smoke test runs from outside repository cwd
+- **THEN** it loads current release from built package without source-tree fallback
+
+### Requirement: Runtime release loading is package relative and defensive
+
+The extension SHALL read current release notes only from package-relative asset and SHALL never depend on cwd-local files or network access.
+
+#### Scenario: Packaged asset loads current version
+
+- **WHEN** installed package contains valid asset matching package version
+- **THEN** runtime returns complete current-release content for popup rendering
+
+#### Scenario: Missing asset produces unavailable content
+
+- **WHEN** packaged asset is missing or unreadable
+- **THEN** runtime returns `Changelog unavailable for vX.Y.Z`
+- **AND** includes repository release URL
+- **AND** does not throw
+
+#### Scenario: Invalid or stale asset is never shown as current
+
+- **WHEN** packaged asset is malformed or version does not match package
+- **THEN** runtime returns unavailable content and repository release URL
+- **AND** stale release text is not presented as current
+
+### Requirement: Changelog popup renders complete finite Markdown content
+
+The changelog popup SHALL display complete current-release headings, lists, links, prose, blank lines, and fenced code examples in source order using width-safe rendered rows.
+
+#### Scenario: Markdown release content is rendered
+
+- **WHEN** valid current release contains second-level headings, bullets, links, inline formatting, prose, blank lines, and fenced examples
+- **THEN** popup preserves their semantic order and distinguishes headings, list rows, prose, and code rows
+
+#### Scenario: Prose wraps to popup width
+
+- **WHEN** prose exceeds available row width
+- **THEN** renderer wraps prose into width-safe rows without silently dropping text
+
+#### Scenario: Code indentation is preserved
+
+- **WHEN** fenced code contains indentation
+- **THEN** rendered code preserves indentation
+- **AND** only an indivisible overlong code row may truncate
+
+#### Scenario: Counters use rendered rows
+
+- **WHEN** wrapping expands source lines into multiple rendered rows
+- **THEN** visible range and hidden-row counters refer to rendered rows
+
+### Requirement: Changelog popup reuses read-only overlay behavior
+
+The editor SHALL display changelog in existing 10-row read-only popup titled `pi-vimmode vX.Y.Z changes` with existing scroll, close, and small-terminal behavior.
+
+#### Scenario: User scrolls and closes changelog
+
+- **WHEN** changelog popup is open
+- **THEN** `j`, `k`, down arrow, and up arrow scroll within rendered rows
+- **AND** `Esc`, `Ctrl-C`, and `Ctrl-G` close popup
+
+#### Scenario: Small terminal reports unavailable popup non-destructively
+
+- **WHEN** terminal is smaller than 48×12 and user requests changelog
+- **THEN** existing popup-unavailable feedback is shown
+- **AND** prompt-editing state remains unchanged
+
+#### Scenario: Popup preserves prompt state
+
+- **WHEN** user opens, scrolls, and closes changelog
+- **THEN** prompt buffer, cursor, mode, valid visual selection, registers, marks, search state, undo/redo, repeat, macros, and histories remain unchanged except normal successful Ex history semantics
+
+#### Scenario: Popup is manual only
+
+- **WHEN** extension starts or package version changes
+- **THEN** changelog does not open automatically
+- **AND** no persistent seen-version state is required

--- a/openspec/changes/ship-pi-vimmode-0-9-0/specs/vim-trusted-javascript-configuration/spec.md
+++ b/openspec/changes/ship-pi-vimmode-0-9-0/specs/vim-trusted-javascript-configuration/spec.md
@@ -1,0 +1,184 @@
+## ADDED Requirements
+
+### Requirement: Trusted JavaScript configuration has one explicit global boundary
+
+The extension SHALL load executable configuration only from `~/.pi/agent/pi-vimmode.config.js` as trusted unsandboxed ESM with full Pi process privileges, after global JSON and before project JSON.
+
+#### Scenario: Global config loads in resolved layer order
+
+- **WHEN** the global JavaScript config exports a supported synchronous or asynchronous default function
+- **THEN** the function evaluates against built-in defaults plus valid global JSON
+- **AND** valid project JSON remains the final configuration layer
+
+#### Scenario: Project executable config is ignored
+
+- **WHEN** a project contains a JavaScript file resembling pi-vimmode config
+- **THEN** the extension does not import or execute it
+- **AND** project JSON remains the only supported project-local configuration surface
+
+#### Scenario: Trust warning is discoverable
+
+- **WHEN** a user follows the canonical JavaScript config setup documentation
+- **THEN** the setup states prominently that the file is unsandboxed trusted code with Pi process privileges
+
+#### Scenario: Root reload follows native helper caching
+
+- **WHEN** `/vimmode reload` re-evaluates the root config after an imported helper module changed
+- **THEN** the root module is re-evaluated
+- **AND** native ESM process caching may retain the imported helper until Pi restarts
+
+### Requirement: Trusted configuration exposes every finite option through validated domains
+
+The trusted JavaScript API SHALL expose each existing finite `piVimMode` capability through domain-grouped properties covering preset, startup mode, leader, cursor, UI, macros, marks, search, Ex behavior, feedback, prompt structures, prompt transforms, action presets, and operator motions.
+
+#### Scenario: Getter starts from defaults and global JSON
+
+- **WHEN** a config function reads a supported property before writing it
+- **THEN** the value reflects built-in defaults with valid global JSON applied
+- **AND** it does not include project JSON
+
+#### Scenario: Valid writes compose in source order
+
+- **WHEN** a config function assigns a preset and then assigns one supported leaf
+- **THEN** the preset applies at its source position
+- **AND** the later leaf overrides only its supported value
+
+#### Scenario: Later preset may replace earlier leaf
+
+- **WHEN** a config function assigns a leaf and later assigns a preset that defines the same capability
+- **THEN** the later preset value becomes staged value for that capability
+
+#### Scenario: Arrays and records replace on assignment
+
+- **WHEN** a config function assigns a valid array or record property
+- **THEN** the assigned value replaces the prior staged value rather than merging through nested mutation
+
+#### Scenario: Reads cannot bypass validation
+
+- **WHEN** a config function reads an array, record, or nested domain value
+- **THEN** it receives a frozen snapshot
+- **AND** mutating that snapshot cannot alter staged or active configuration
+
+### Requirement: Invalid JavaScript option writes remain field local
+
+The trusted configuration session SHALL validate each known leaf independently and SHALL retain prior staged values plus valid siblings when one write is invalid or unknown.
+
+#### Scenario: Invalid leaf preserves prior value
+
+- **WHEN** a config function assigns an unsupported value to one known leaf
+- **THEN** the session records a non-fatal warning
+- **AND** the prior staged value for that leaf remains effective
+
+#### Scenario: Unknown leaf does not discard siblings
+
+- **WHEN** a config function attempts an unknown property write between two valid writes
+- **THEN** the unknown write records a warning and has no configuration effect
+- **AND** both valid writes remain staged
+
+#### Scenario: Invalid nested value does not partially merge
+
+- **WHEN** a config function assigns an invalid array or record value
+- **THEN** no portion of that assignment changes staged state
+- **AND** the previous complete value remains effective
+
+### Requirement: JavaScript evaluation is a closed transaction
+
+Each config evaluation SHALL record source-ordered operations in an isolated session, SHALL close that session when the default export settles, and SHALL distinguish fatal evaluation failure from field-local warnings.
+
+#### Scenario: Successful async export commits staged operations
+
+- **WHEN** an asynchronous default export completes successfully after valid writes
+- **THEN** the loader returns its ordered operations and warnings for final compilation
+- **AND** no active editor state was mutated during evaluation
+
+#### Scenario: Syntax or import failure is fatal
+
+- **WHEN** the root config has a syntax error or an import fails
+- **THEN** the loader returns a fatal transaction result
+- **AND** no JavaScript operation from that evaluation is eligible for commit
+
+#### Scenario: Uncaught export failure is fatal
+
+- **WHEN** a synchronous or asynchronous default export throws or rejects
+- **THEN** the loader returns a fatal transaction result
+- **AND** no partial staged operation is eligible for commit
+
+#### Scenario: Session closes after export settles
+
+- **WHEN** a config function retains its API reference and writes after the export has settled
+- **THEN** the write throws exactly `config session closed`
+- **AND** staged and active configuration remain unchanged
+
+### Requirement: Configuration layers compile before commit
+
+The extension SHALL compile defaults, global JSON, successful global JavaScript operations, and project JSON into one immutable plan before updating lifecycle or editor state.
+
+#### Scenario: Successful layers resolve in order
+
+- **WHEN** all layers contain valid overlapping values
+- **THEN** resolution order is defaults, global JSON, global JavaScript, then project JSON
+- **AND** the committed plan contains the final project-authoritative values
+
+#### Scenario: Final leader resolves after all layers
+
+- **WHEN** inherited JavaScript mappings use `<leader>` and project JSON changes the leader
+- **THEN** retained mappings expand with the final project leader before conflict compilation
+
+#### Scenario: Fresh startup survives fatal JavaScript config
+
+- **WHEN** JavaScript evaluation fails fatally during fresh startup
+- **THEN** defaults, valid global JSON, and valid project JSON still compile into usable plan
+- **AND** diagnostics report JavaScript failure
+
+#### Scenario: Compile failure has no partial effects
+
+- **WHEN** staged operations cannot compile into valid finite plan
+- **THEN** no active plan or editor is partially updated
+- **AND** diagnostics identify rejected operations or fatal result according to failure class
+
+### Requirement: Public trusted-config types are declaration only
+
+The package SHALL export a declaration-only `pi-vimmode/config` subpath containing `VimConfig` and `VimConfigApi` without runtime config helper surface.
+
+#### Scenario: Root config imports VimConfig through JSDoc
+
+- **WHEN** a JavaScript config annotates its default export with `VimConfig`
+- **THEN** supported synchronous and asynchronous exports typecheck against complete public API
+
+#### Scenario: Helper module imports VimConfigApi
+
+- **WHEN** an imported preset/helper annotates its session parameter with `VimConfigApi`
+- **THEN** supported option and keymap operations typecheck without importing runtime helper
+
+#### Scenario: Built package resolves declarations
+
+- **WHEN** temporary consumers resolve `pi-vimmode/config` from built package using TypeScript Bundler and NodeNext modes
+- **THEN** both consumers typecheck successfully
+- **AND** no runtime JavaScript module is required for config subpath
+
+#### Scenario: Invalid public API shapes fail typechecking
+
+- **WHEN** negative fixtures use unsupported leaves, values, modes, action arguments, or mapping options
+- **THEN** typechecking fails at expected invalid expressions
+- **AND** valid sibling expressions remain accepted
+
+### Requirement: Existing trusted-config calls remain compatible
+
+Version 0.9.0 SHALL preserve existing valid `vim.g.mapleader`, `vim.prompt.*`, and three-argument `vim.keymap.set` behavior and SHALL keep existing JSON settings behavior unchanged.
+
+#### Scenario: Existing JavaScript config loads unchanged
+
+- **WHEN** a valid pre-0.9.0 config uses mapleader, prompt action factories, and three-argument keymap calls
+- **THEN** it loads without requiring migration
+- **AND** its previously supported behavior remains effective
+
+#### Scenario: Existing JSON remains authoritative
+
+- **WHEN** users configure only supported global and project JSON settings
+- **THEN** 0.9.0 resolves those settings with existing field-local validation and precedence
+
+#### Scenario: Future breaking change is versioned
+
+- **WHEN** a future release removes or changes a supported trusted-config API
+- **THEN** deprecation is warned for at least one minor release when feasible
+- **AND** an incompatible trusted-config contract requires a major release

--- a/openspec/changes/ship-pi-vimmode-0-9-0/tasks.md
+++ b/openspec/changes/ship-pi-vimmode-0-9-0/tasks.md
@@ -1,0 +1,33 @@
+## 1. Release Foundations
+
+- [ ] 1.1 Implement [#33](https://github.com/pekochan069/pi-vimmode/issues/33): capture reproducible 0.9.0 production-path benchmark baseline, committed pre-change evidence, profiling instructions, and unpublished generated corpora. **Blocked by:** none.
+- [ ] 1.2 Implement [#34](https://github.com/pekochan069/pi-vimmode/issues/34): bump package to 0.9.0 without publishing and add built-`dist`/tarball inventory plus temporary-consumer smoke foundation outside repository cwd. **Blocked by:** none.
+- [ ] 1.3 Implement [#35](https://github.com/pekochan069/pi-vimmode/issues/35): establish canonical finite option/action metadata and normal, visual, insert, and operator-pending mapping scopes with existing behavior equivalence tests. **Blocked by:** none.
+
+## 2. Trusted Configuration Core
+
+- [ ] 2.1 Implement [#36](https://github.com/pekochan069/pi-vimmode/issues/36): stage trusted JavaScript config as closed source-ordered transaction with frozen reads, field-local warnings, fatal results, exact late-write failure, and legacy API parity. **Blocked by:** #35.
+- [ ] 2.2 Implement [#37](https://github.com/pekochan069/pi-vimmode/issues/37): compile defaults, global JSON, JavaScript operations, and project JSON into one immutable scoped plan with final leader and project authority. **Blocked by:** #35 and #36.
+
+## 3. Public Config Behavior and Reload
+
+- [ ] 3.1 Implement [#38](https://github.com/pekochan069/pi-vimmode/issues/38): expose every finite `piVimMode` option through validated domain-grouped trusted JavaScript properties and prove source-order/replacement/fallback behavior. **Blocked by:** #37.
+- [ ] 3.2 Implement [#39](https://github.com/pekochan069/pi-vimmode/issues/39): add opaque action descriptors and finite mode-scoped mappings with unmapping, deterministic conflicts, bounded replay, insert/operator restrictions, protected override, compatibility aliases, and project precedence. **Blocked by:** #37; may run parallel with #38.
+- [ ] 3.3 Implement [#40](https://github.com/pekochan069/pi-vimmode/issues/40): reconfigure tracked active editors atomically on generation-guarded reload, preserving durable state and clearing specified transient grammar through lifecycle and real-editor tests. **Blocked by:** #38 and #39.
+
+## 4. Public Types and Canonical Documentation
+
+- [ ] 4.1 Implement [#41](https://github.com/pekochan069/pi-vimmode/issues/41): publish declaration-only `pi-vimmode/config` types with checked basic example and built-package Bundler/NodeNext consumers, without runtime helper API. **Blocked by:** #34, #38, and #39.
+- [ ] 4.2 Implement [#42](https://github.com/pekochan069/pi-vimmode/issues/42): generate committed complete property/action references from canonical metadata with stable anchors and clean-tree drift checks. **Blocked by:** #35 and #41.
+- [ ] 4.3 Implement [#43](https://github.com/pekochan069/pi-vimmode/issues/43): ship complete trusted-config guide, checked basic/keymap/async/imported-preset workflows, negative fixtures, ADR/discovery links, and built-package content gates. **Blocked by:** #40 and #42.
+
+## 5. Packaged Current-Version Changelog
+
+- [ ] 5.1 Implement [#44](https://github.com/pekochan069/pi-vimmode/issues/44): validate first `RELEASE.md` release against package version, package current-release runtime asset, and prove defensive package-relative loading outside repository cwd. **Blocked by:** #34.
+- [ ] 5.2 Implement [#45](https://github.com/pekochan069/pi-vimmode/issues/45): add exact manual `:changelog` command and width-safe Markdown rendering through existing read-only popup while preserving all prompt-editing state. **Blocked by:** #44.
+
+## 6. Change Validation
+
+- [ ] 6.1 After #33–#45 are complete, run `bun test`, `bun run check-types`, `bun run lint`, `bun run format:check`, built-package inventory/consumer/changelog smoke checks, generated-reference clean-tree check, `openspec validate ship-pi-vimmode-0-9-0 --strict`, and `openspec validate --specs --strict`; record failures against owning ticket rather than adding release features.
+
+Deferred cursor-setter migration, final render optimization, and release-candidate verification are intentionally excluded until upstream Pi publishes the required normalized logical cursor setter.

--- a/src/config-metadata.ts
+++ b/src/config-metadata.ts
@@ -1,0 +1,167 @@
+import { DEFAULT_VIM_OPTIONS, VIM_MOTION_OPERATOR_ACTIONS } from "./config.ts";
+import { PROTECTED_SHORTCUTS } from "./customization.ts";
+import { DIAGNOSTIC_ACTIONS } from "./diagnostic-actions.ts";
+import {
+  KEYMAP_COMMAND_DESCRIPTORS,
+  KEYMAP_INSERT_DESCRIPTORS,
+  KEYMAP_MARK_DESCRIPTORS,
+  KEYMAP_MACRO_DESCRIPTORS,
+  KEYMAP_MOTION_DESCRIPTORS,
+  KEYMAP_OPERATOR_DESCRIPTORS,
+  KEYMAP_TEXT_OBJECT_KIND_DESCRIPTORS,
+  KEYMAP_TEXT_OBJECT_TARGET_DESCRIPTORS,
+} from "./keymap-descriptors.ts";
+import { PROMPT_TRANSFORM_ACTIONS } from "./prompt-transform-actions.ts";
+
+export const VIM_MAPPING_SCOPES = [
+  "normal",
+  "visual",
+  "visualLine",
+  "visualBlock",
+  "insert",
+  "operatorPending",
+] as const;
+
+export type VimMappingScope = (typeof VIM_MAPPING_SCOPES)[number];
+
+type ActionSource = "keymap-descriptor" | "prompt-transform-registry" | "diagnostic-registry";
+
+export type VimActionMetadata = {
+  id: string;
+  source: ActionSource;
+  defaults: readonly string[];
+  scopes: readonly VimMappingScope[];
+  bindable: boolean;
+};
+
+const VISUAL_SCOPES = ["visual", "visualLine", "visualBlock"] as const;
+const NORMAL_AND_VISUAL_SCOPES = ["normal", ...VISUAL_SCOPES] as const;
+function descriptorMetadata(
+  family: string,
+  descriptors: Record<string, { defaults: readonly string[] }>,
+  scopes: (action: string) => readonly VimMappingScope[],
+): VimActionMetadata[] {
+  return Object.entries(descriptors).map(([action, descriptor]) => ({
+    id: `${family}.${action}`,
+    source: "keymap-descriptor",
+    defaults: descriptor.defaults,
+    scopes: scopes(action),
+    bindable: true,
+  }));
+}
+
+export const VIM_ACTION_METADATA: readonly VimActionMetadata[] = [
+  ...descriptorMetadata("operator", KEYMAP_OPERATOR_DESCRIPTORS, () => NORMAL_AND_VISUAL_SCOPES),
+  ...descriptorMetadata("motion", KEYMAP_MOTION_DESCRIPTORS, (action) =>
+    action === "halfPageDown" || action === "halfPageUp"
+      ? NORMAL_AND_VISUAL_SCOPES
+      : [...NORMAL_AND_VISUAL_SCOPES, "operatorPending"],
+  ),
+  ...descriptorMetadata("command", KEYMAP_COMMAND_DESCRIPTORS, () => ["normal"]),
+  ...descriptorMetadata("macro", KEYMAP_MACRO_DESCRIPTORS, () => ["normal"]),
+  ...descriptorMetadata("mark", KEYMAP_MARK_DESCRIPTORS, (action) =>
+    action === "set" ? NORMAL_AND_VISUAL_SCOPES : [...NORMAL_AND_VISUAL_SCOPES, "operatorPending"],
+  ),
+  ...descriptorMetadata("insert", KEYMAP_INSERT_DESCRIPTORS, () => ["insert"]),
+  ...descriptorMetadata("textObject.kind", KEYMAP_TEXT_OBJECT_KIND_DESCRIPTORS, () => [
+    "operatorPending",
+  ]),
+  ...descriptorMetadata("textObject.target", KEYMAP_TEXT_OBJECT_TARGET_DESCRIPTORS, () => [
+    "operatorPending",
+  ]),
+  ...PROMPT_TRANSFORM_ACTIONS.map(({ id, modes }) => ({
+    id,
+    source: "prompt-transform-registry" as const,
+    defaults: [],
+    scopes: modes,
+    bindable: true,
+  })),
+  ...DIAGNOSTIC_ACTIONS.map(({ id }) => ({
+    id,
+    source: "diagnostic-registry" as const,
+    defaults: [],
+    scopes: [],
+    bindable: false,
+  })),
+];
+
+export type ConfigLeaf = {
+  path: string;
+  defaultValue: unknown;
+  protectedShortcuts?: typeof PROTECTED_SHORTCUTS;
+};
+
+function valueAtPath(path: string): unknown {
+  return path
+    .split(".")
+    .reduce<unknown>((value, key) => (value as Record<string, unknown>)[key], DEFAULT_VIM_OPTIONS);
+}
+
+function leaves(paths: readonly string[]): ConfigLeaf[] {
+  return paths.map((path) => ({
+    path,
+    defaultValue: valueAtPath(path),
+    ...(path === "keymap.allowProtectedOverrides"
+      ? { protectedShortcuts: PROTECTED_SHORTCUTS }
+      : {}),
+  }));
+}
+
+const modes = ["insert", "normal", "visual", "visualLine", "visualBlock"];
+
+export const CONFIG_LEAVES: readonly ConfigLeaf[] = leaves([
+  "preset",
+  "leader",
+  "startMode",
+  ...modes.map((mode) => `cursor.${mode}`),
+  "keymap.escape",
+  ...Object.keys(KEYMAP_OPERATOR_DESCRIPTORS).map((action) => `keymap.operators.${action}`),
+  ...Object.keys(KEYMAP_MOTION_DESCRIPTORS).map((action) => `keymap.motions.${action}`),
+  ...Object.keys(KEYMAP_COMMAND_DESCRIPTORS).map((action) => `keymap.commands.${action}`),
+  ...Object.keys(KEYMAP_MACRO_DESCRIPTORS).map((action) => `keymap.macros.${action}`),
+  ...Object.keys(KEYMAP_MARK_DESCRIPTORS).map((action) => `keymap.marks.${action}`),
+  ...Object.keys(KEYMAP_TEXT_OBJECT_KIND_DESCRIPTORS).map(
+    (action) => `keymap.textObjects.kinds.${action}`,
+  ),
+  ...Object.keys(KEYMAP_TEXT_OBJECT_TARGET_DESCRIPTORS).map(
+    (action) => `keymap.textObjects.targets.${action}`,
+  ),
+  ...VIM_MOTION_OPERATOR_ACTIONS.map((action) => `keymap.operatorMotions.${action}`),
+  ...Object.keys(KEYMAP_INSERT_DESCRIPTORS).map((action) => `keymap.insert.${action}`),
+  "keymap.actionPresets",
+  "keymap.actions.accepted",
+  "keymap.remaps.accepted",
+  "keymap.allowProtectedOverrides",
+  "ui.status.enabled",
+  "ui.status.position",
+  "ui.status.items",
+  "ui.mode.enabled",
+  ...modes.flatMap((mode) => [`ui.mode.labels.${mode}`, `ui.mode.narrowLabels.${mode}`]),
+  "ui.selection.enabled",
+  "ui.selection.previewMaxChars",
+  "ui.cursorPosition.enabled",
+  "ui.cursorPosition.base",
+  "ui.cursorPosition.format",
+  "ui.workbench.reservedRows",
+  "macros.enabled",
+  "macros.slots",
+  "macros.maxReplaySteps",
+  "marks.enabled",
+  "marks.slots",
+  "search.highlight",
+  "search.highlightCurrent",
+  "search.clearOnCancel",
+  "search.clearOnInsert",
+  "search.maxHighlights",
+  "exCommand.autocomplete",
+  "feedback.noop",
+  "promptStructures.enabled",
+  ...Object.keys(DEFAULT_VIM_OPTIONS.promptStructures!.targets).map(
+    (target) => `promptStructures.targets.${target}`,
+  ),
+  "promptTransforms.enabled",
+  ...PROMPT_TRANSFORM_ACTIONS.flatMap(({ action }) => [
+    `promptTransforms.actions.${action}`,
+    `promptTransforms.commands.${action}`,
+  ]),
+]);

--- a/src/config.ts
+++ b/src/config.ts
@@ -47,6 +47,7 @@ import {
   deriveDefaultKeyBindings,
   deriveSet,
   KEYMAP_COMMAND_DESCRIPTORS,
+  KEYMAP_INSERT_DESCRIPTORS,
   KEYMAP_MARK_DESCRIPTORS,
   KEYMAP_MACRO_DESCRIPTORS,
   KEYMAP_MOTION_DESCRIPTORS,
@@ -56,6 +57,7 @@ import {
 } from "./keymap-descriptors.ts";
 import { grammarBindingsForKeymap, grammarConflictForActionKey } from "./keymap-grammar.ts";
 import {
+  PROMPT_TRANSFORM_ACTIONS as PROMPT_TRANSFORM_ACTION_REGISTRY,
   bindablePromptTransformActionIds,
   normalizePromptTransformActionArgs,
   promptTransformActionForId,
@@ -111,32 +113,15 @@ export const PROMPT_STRUCTURE_TARGETS = [
   "tag",
   "errorBlock",
 ] as const satisfies readonly PromptStructureTarget[];
-export const PROMPT_TRANSFORM_ACTIONS = [
-  "quote",
-  "unquote",
-  "bulletize",
-  "fence",
-  "indent",
-  "dedent",
-  "reflow",
-] as const satisfies readonly PromptTransformAction[];
+export const PROMPT_TRANSFORM_ACTIONS = PROMPT_TRANSFORM_ACTION_REGISTRY.map(
+  ({ action }) => action,
+) as PromptTransformAction[];
 
 const MOTION_OPERATOR_ACTION_SET = new Set<string>(VIM_MOTION_OPERATOR_ACTIONS);
 const OPERATOR_ACTION_SET = deriveSet(KEYMAP_OPERATOR_DESCRIPTORS);
 const MOTION_ACTION_SET = deriveSet(KEYMAP_MOTION_DESCRIPTORS);
 const COMMAND_ACTION_SET = deriveSet(KEYMAP_COMMAND_DESCRIPTORS);
-const INSERT_ACTION_SET = new Set<string>([
-  "openLineBelow",
-  "openLineAbove",
-  "deleteWordBackward",
-  "deleteWordForward",
-  "deleteLineBackward",
-  "deleteLineForward",
-  "moveWordBackward",
-  "moveWordForward",
-  "moveLineStart",
-  "moveLineEnd",
-]);
+const INSERT_ACTION_SET = deriveSet(KEYMAP_INSERT_DESCRIPTORS);
 const LOWERCASE_SLOT_KEYS = "abcdefghijklmnopqrstuvwxyz".split("");
 const OPERATOR_MOTION_ACTIONS = VIM_MOTION_ACTIONS.filter(
   (action) => action !== "halfPageDown" && action !== "halfPageUp",
@@ -178,18 +163,7 @@ export const DEFAULT_VIM_KEYMAP = Object.freeze({
       VIM_MOTION_OPERATOR_ACTIONS.map((action) => [action, OPERATOR_MOTION_ACTIONS]),
     ),
   ),
-  insert: Object.freeze({
-    openLineBelow: Object.freeze([]),
-    openLineAbove: Object.freeze([]),
-    deleteWordBackward: Object.freeze([]),
-    deleteWordForward: Object.freeze([]),
-    deleteLineBackward: Object.freeze([]),
-    deleteLineForward: Object.freeze([]),
-    moveWordBackward: Object.freeze([]),
-    moveWordForward: Object.freeze([]),
-    moveLineStart: Object.freeze([]),
-    moveLineEnd: Object.freeze([]),
-  }),
+  insert: freezeArrayRecord(deriveDefaultKeyBindings(KEYMAP_INSERT_DESCRIPTORS)),
   actions: Object.freeze({
     accepted: Object.freeze([]),
   }),

--- a/test/config-metadata.test.ts
+++ b/test/config-metadata.test.ts
@@ -18,6 +18,9 @@ import {
 } from "../src/keymap-descriptors.ts";
 import { PROMPT_TRANSFORM_ACTIONS } from "../src/prompt-transform-actions.ts";
 
+type Assert<T extends true> = T;
+type OperatorPendingIsNotVimMode = Assert<"operatorPending" extends VimMode ? false : true>;
+
 const descriptorIds = (family: string, descriptors: Record<string, unknown>) =>
   Object.keys(descriptors).map((action) => `${family}.${action}`);
 
@@ -54,8 +57,29 @@ describe("canonical config metadata", () => {
       "operatorPending",
     ]);
     expect(VIM_ACTION_METADATA.flatMap(({ scopes }) => scopes)).toContain("operatorPending");
-    const stableModes: VimMode[] = ["insert", "normal", "visual", "visualLine", "visualBlock"];
-    expect(stableModes).not.toContain("operatorPending");
+    const operatorPendingIsNotVimMode: OperatorPendingIsNotVimMode = true;
+    expect(operatorPendingIsNotVimMode).toBe(true);
+  });
+
+  test("scopes mark setting separately from operator mark jumps", () => {
+    const scopesFor = (id: string) =>
+      VIM_ACTION_METADATA.find((action) => action.id === id)?.scopes;
+
+    expect(scopesFor("mark.set")).toEqual(["normal", "visual", "visualLine", "visualBlock"]);
+    expect(scopesFor("mark.jumpExact")).toEqual([
+      "normal",
+      "visual",
+      "visualLine",
+      "visualBlock",
+      "operatorPending",
+    ]);
+    expect(scopesFor("mark.jumpLine")).toEqual([
+      "normal",
+      "visual",
+      "visualLine",
+      "visualBlock",
+      "operatorPending",
+    ]);
   });
 
   test("has one source-backed default for every catalogued config leaf", () => {

--- a/test/config-metadata.test.ts
+++ b/test/config-metadata.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, test } from "bun:test";
+
+import type { VimMode } from "../src/types.ts";
+
+import { CONFIG_LEAVES, VIM_ACTION_METADATA, VIM_MAPPING_SCOPES } from "../src/config-metadata.ts";
+import { DEFAULT_VIM_OPTIONS } from "../src/config.ts";
+import { PROTECTED_SHORTCUTS } from "../src/customization.ts";
+import { DIAGNOSTIC_ACTIONS } from "../src/diagnostic-actions.ts";
+import {
+  KEYMAP_COMMAND_DESCRIPTORS,
+  KEYMAP_INSERT_DESCRIPTORS,
+  KEYMAP_MARK_DESCRIPTORS,
+  KEYMAP_MACRO_DESCRIPTORS,
+  KEYMAP_MOTION_DESCRIPTORS,
+  KEYMAP_OPERATOR_DESCRIPTORS,
+  KEYMAP_TEXT_OBJECT_KIND_DESCRIPTORS,
+  KEYMAP_TEXT_OBJECT_TARGET_DESCRIPTORS,
+} from "../src/keymap-descriptors.ts";
+import { PROMPT_TRANSFORM_ACTIONS } from "../src/prompt-transform-actions.ts";
+
+const descriptorIds = (family: string, descriptors: Record<string, unknown>) =>
+  Object.keys(descriptors).map((action) => `${family}.${action}`);
+
+const valueAtPath = (path: string): unknown =>
+  path
+    .split(".")
+    .reduce<unknown>((value, key) => (value as Record<string, unknown>)[key], DEFAULT_VIM_OPTIONS);
+
+describe("canonical config metadata", () => {
+  test("catalogs every existing semantic action from its current source", () => {
+    const expected = [
+      ...descriptorIds("operator", KEYMAP_OPERATOR_DESCRIPTORS),
+      ...descriptorIds("motion", KEYMAP_MOTION_DESCRIPTORS),
+      ...descriptorIds("command", KEYMAP_COMMAND_DESCRIPTORS),
+      ...descriptorIds("macro", KEYMAP_MACRO_DESCRIPTORS),
+      ...descriptorIds("mark", KEYMAP_MARK_DESCRIPTORS),
+      ...descriptorIds("insert", KEYMAP_INSERT_DESCRIPTORS),
+      ...descriptorIds("textObject.kind", KEYMAP_TEXT_OBJECT_KIND_DESCRIPTORS),
+      ...descriptorIds("textObject.target", KEYMAP_TEXT_OBJECT_TARGET_DESCRIPTORS),
+      ...PROMPT_TRANSFORM_ACTIONS.map(({ id }) => id),
+      ...DIAGNOSTIC_ACTIONS.map(({ id }) => id),
+    ].sort();
+
+    expect(VIM_ACTION_METADATA.map(({ id }) => id).sort()).toEqual(expected);
+  });
+
+  test("keeps operator-pending as mapping grammar, not a stable editor mode", () => {
+    expect(VIM_MAPPING_SCOPES).toEqual([
+      "normal",
+      "visual",
+      "visualLine",
+      "visualBlock",
+      "insert",
+      "operatorPending",
+    ]);
+    expect(VIM_ACTION_METADATA.flatMap(({ scopes }) => scopes)).toContain("operatorPending");
+    const stableModes: VimMode[] = ["insert", "normal", "visual", "visualLine", "visualBlock"];
+    expect(stableModes).not.toContain("operatorPending");
+  });
+
+  test("has one source-backed default for every catalogued config leaf", () => {
+    expect(new Set(CONFIG_LEAVES.map(({ path }) => path)).size).toBe(CONFIG_LEAVES.length);
+    for (const leaf of CONFIG_LEAVES) expect(leaf.defaultValue).toEqual(valueAtPath(leaf.path));
+    expect(CONFIG_LEAVES.map(({ path }) => path)).toContain("keymap.actionPresets");
+    expect(
+      CONFIG_LEAVES.find(({ path }) => path === "keymap.allowProtectedOverrides")
+        ?.protectedShortcuts,
+    ).toBe(PROTECTED_SHORTCUTS);
+  });
+});


### PR DESCRIPTION
## Summary

Adds canonical metadata for supported Vim configuration, letting docs, diagnostics, defaults, and future settings UI use one source of truth. Separates mark-setting scope from mark-jump scope; operator-pending remains mapping grammar, not editor mode.

## Changes

- Add catalog for config leaves and semantic keybinding actions.
- Derive config defaults from catalog and add regression coverage.
- Add OpenSpec requirements and release documentation.

## Testing

- [x] `bun test` passes
- [x] `bun run check-types` passes
- [x] `bun run lint` passes
- [x] Manually tested in Pi

## Related Issues

Closes #35
