### PR TITLE
feat(config): add trusted JS config transactions

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -2,6 +2,16 @@
 
 ## What's new
 
+- Added trusted JavaScript configuration via `~/.pi/agent/pi-vimmode.config.js`. Configure presets, leader, prompt actions, insert actions, replay mappings, and scoped unmaps with a small `vim` API. Configuration writes are staged atomically, so failed config files leave existing settings unchanged.
+
+```js
+export default (vim) => {
+  vim.g.mapleader = " ";
+  vim.keymap.set("n", "<leader>q", vim.prompt.quote());
+  vim.keymap.set("n", "zq", null);
+};
+```
+
 - Added configurable Vim leader mappings. Set `piVimMode.leader` in JSON or `vim.g.mapleader` in trusted JavaScript, then use `<leader>` at the start of mapping keys. Project settings can override or clear inherited leaders.
 
 ```json

--- a/docs/solutions/design-patterns/pi-vimmode-trusted-js-config-transactions-2026-07-16.md
+++ b/docs/solutions/design-patterns/pi-vimmode-trusted-js-config-transactions-2026-07-16.md
@@ -1,0 +1,60 @@
+---
+title: Trusted JavaScript config transactions
+date: 2026-07-16
+category: design-patterns
+module: pi-vimmode-config
+problem_type: design_pattern
+component: tooling
+severity: medium
+applies_when:
+  - "Adding trusted JavaScript configuration that changes multiple Vim settings or mappings"
+tags: [javascript-config, transactions, keymaps, pi-vimmode]
+---
+
+# Trusted JavaScript config transactions
+
+## Context
+
+Trusted JavaScript config needs to expose the same mapping controls as JSON config without leaving partial state when evaluation throws. Scoped unmaps must also remove inherited mappings rather than only suppressing local writes.
+
+## Guidance
+
+Stage every config mutation while evaluating user code. Commit staged preset, mapping, remap, and unmap operations only after evaluation succeeds. Close retained configuration APIs after evaluation so delayed calls cannot mutate active state.
+
+```js
+export default (vim) => {
+  vim.g.mapleader = " ";
+  vim.keymap.set("n", "<leader>q", vim.prompt.quote());
+  vim.keymap.set("n", "zq", null);
+};
+```
+
+Treat `null` in `vim.keymap.set()` as an unmap operation for its selected mode and scope. Preserve declaration order when applying staged operations.
+
+## Why This Matters
+
+Immediate mutation makes one config error produce a mixed old/new keymap. Transactional evaluation preserves last known-good configuration. Recording unmaps as operations makes inherited mappings removable and keeps JavaScript configuration behavior aligned with JSON configuration.
+
+## When to Apply
+
+- Trusted user configuration can execute arbitrary JavaScript.
+- Evaluation can fail after modifying more than one setting.
+- A child config scope must override or remove inherited mappings.
+
+## Examples
+
+A failed config leaves existing settings unchanged:
+
+```js
+export default (vim) => {
+  vim.g.mapleader = " ";
+  throw new Error("invalid config");
+};
+```
+
+A successful config commits both operations together; a failed config commits neither.
+
+## Related
+
+- `RELEASE.md`
+- Issue #36

--- a/src/config-js.ts
+++ b/src/config-js.ts
@@ -4,17 +4,17 @@ import { join } from "node:path";
 import { pathToFileURL } from "node:url";
 
 import type { BindablePromptTransformActionId } from "./prompt-transform-actions.ts";
-import type { VimActionBindingMode, VimEditorOptions, VimInsertAction, VimMode } from "./types.ts";
+import type {
+  VimActionBindingMode,
+  VimEditorOptions,
+  VimInsertAction,
+  VimMode,
+  VimPreset,
+} from "./types.ts";
 
 import { protectedShortcutForKey } from "./customization.ts";
 
 export const DEFAULT_JS_CONFIG_PATH = join(homedir(), ".pi", "agent", "pi-vimmode.config.js");
-
-export type VimJsConfigLoadResult = {
-  partial?: VimEditorOptions;
-  warnings: string[];
-  appendKeymap?: boolean;
-};
 
 type BuiltinCommand =
   | { kind: "insert"; action: VimInsertAction }
@@ -24,9 +24,42 @@ type BuiltinCommand =
       args?: Record<string, unknown>;
     };
 
-type BuilderState = {
-  partial: VimEditorOptions;
-  warnings: string[];
+export type VimJsConfigMapOperation =
+  | { kind: "insert"; action: VimInsertAction; key: string }
+  | {
+      kind: "action";
+      actionId: BindablePromptTransformActionId;
+      key: string;
+      args?: Readonly<Record<string, unknown>>;
+      modes: readonly VimActionBindingMode[];
+    }
+  | {
+      kind: "remap";
+      key: string;
+      inputs: readonly string[];
+      modes: readonly VimActionBindingMode[];
+    };
+
+export type VimJsConfigOperation =
+  | { kind: "preset"; preset: VimPreset }
+  | { kind: "leaf"; path: "leader"; value: string | null }
+  | { kind: "map"; mapping: VimJsConfigMapOperation }
+  | { kind: "unmap"; target: string };
+
+export type VimJsConfigLoadResult =
+  | { kind: "missing"; warnings: readonly string[] }
+  | { kind: "success"; operations: readonly VimJsConfigOperation[]; warnings: readonly string[] }
+  | { kind: "fatal"; warnings: readonly string[] };
+
+type ConfigSession = {
+  vim: object;
+  assertOpen(): void;
+  close(): void;
+  readLeader(): string | null | undefined;
+  setMapleader(value: unknown): void;
+  warning(message: string): void;
+  recordMap(mapping: VimJsConfigMapOperation): void;
+  success(): Extract<VimJsConfigLoadResult, { kind: "success" }>;
 };
 
 const MODE_ALIASES: Record<string, readonly VimMode[]> = {
@@ -53,8 +86,27 @@ const INSERT_ACTIONS = new Set<VimInsertAction>([
   "moveLineEnd",
 ]);
 
+const RHS_INPUT_ALIASES: Record<string, string> = {
+  cr: "\r",
+  enter: "\r",
+  return: "\r",
+  esc: "\x1b",
+  escape: "\x1b",
+  tab: "\t",
+};
+
+let rootLoadId = 0;
+
 function warning(message: string): string {
   return `global JS config: ${message}`;
+}
+
+function frozenSnapshot<T>(value: T): T {
+  if (Array.isArray(value)) return Object.freeze(value.map(frozenSnapshot)) as T;
+  if (!value || typeof value !== "object") return value;
+  return Object.freeze(
+    Object.fromEntries(Object.entries(value).map(([key, child]) => [key, frozenSnapshot(child)])),
+  ) as T;
 }
 
 function modesFor(rawMode: unknown): readonly VimMode[] | undefined {
@@ -83,21 +135,6 @@ function builtinPromptTransform(action: string, args?: Record<string, unknown>):
 function builtinInsert(action: VimInsertAction): BuiltinCommand {
   return { kind: "insert", action };
 }
-
-function addInsertBinding(state: BuilderState, lhs: string, action: VimInsertAction): void {
-  const keymap = (state.partial.keymap ??= {});
-  const insert = (keymap.insert ??= {});
-  insert[action] = [...(insert[action] ?? []), lhs];
-}
-
-const RHS_INPUT_ALIASES: Record<string, string> = {
-  cr: "\r",
-  enter: "\r",
-  return: "\r",
-  esc: "\x1b",
-  escape: "\x1b",
-  tab: "\t",
-};
 
 function normalizeKey(value: string): string | undefined {
   const angleMatch = value.match(/^<(.+)>$/);
@@ -144,91 +181,83 @@ function tokenizeReplayInputs(value: string): string[] | undefined {
   return keys.map((key) => RHS_INPUT_ALIASES[key] ?? key);
 }
 
-function addActionBinding(
-  state: BuilderState,
-  lhs: string,
-  command: Extract<BuiltinCommand, { kind: "promptTransform" }>,
-  modes: readonly VimMode[],
-): void {
-  const actionModes = modes.filter((mode) => mode !== "insert") as Exclude<VimMode, "insert">[];
-  if (actionModes.length === 0) {
-    state.warnings.push(warning(`${command.actionId} does not support insert mode`));
-    return;
-  }
-  const keymap = (state.partial.keymap ??= {});
-  const actions = (keymap.actions ??= {});
-  actions[command.actionId] = [
-    ...(actions[command.actionId] ?? []),
-    { key: lhs, args: command.args, modes: actionModes },
-  ];
-}
-
-function compileMapping(state: BuilderState, mode: unknown, lhs: unknown, rhs: unknown): void {
+function compileMapping(session: ConfigSession, mode: unknown, lhs: unknown, rhs: unknown): void {
+  session.assertOpen();
   const modes = modesFor(mode);
   if (!modes) {
-    state.warnings.push(warning(`unsupported mode ${String(mode)}`));
+    session.warning(`unsupported mode ${String(mode)}`);
     return;
   }
   if (typeof lhs !== "string" || lhs.length === 0) {
-    state.warnings.push(warning("keymap lhs must be a non-empty string"));
+    session.warning("keymap lhs must be a non-empty string");
     return;
   }
   const lhsKeys = tokenizeLhsKeys(lhs);
   if (!lhsKeys || lhsKeys.length === 0) {
-    state.warnings.push(warning("keymap lhs must contain supported key syntax"));
+    session.warning("keymap lhs must contain supported key syntax");
     return;
   }
-  const normalizedLhs = lhsKeys.join("");
-  const protectedKey = lhsKeys.find((key) => protectedShortcutForKey(key));
+  const key = lhsKeys.join("");
+  const protectedKey = lhsKeys.find((candidate) => protectedShortcutForKey(candidate));
   const protectedShortcut = protectedKey ? protectedShortcutForKey(protectedKey) : undefined;
   if (protectedKey && protectedShortcut) {
-    state.warnings.push(
-      warning(`keymap lhs contains protected key ${protectedKey} (${protectedShortcut.reason})`),
+    session.warning(
+      `keymap lhs contains protected key ${protectedKey} (${protectedShortcut.reason})`,
     );
     return;
   }
   if (typeof rhs === "string") {
-    addStringRemap(state, normalizedLhs, rhs, modes);
+    recordStringRemap(session, key, rhs, modes);
     return;
   }
   if (!isBuiltinCommand(rhs)) {
-    state.warnings.push(warning("keymap rhs must be a vim.prompt.* builtin command or key string"));
+    session.warning("keymap rhs must be a vim.prompt.* builtin command or key string");
     return;
   }
   if (rhs.kind === "insert") {
     if (!modes.includes("insert") || modes.length !== 1) {
-      state.warnings.push(warning(`vim.prompt.${rhs.action}() only supports insert mode`));
+      session.warning(`vim.prompt.${rhs.action}() only supports insert mode`);
       return;
     }
     if (!INSERT_ACTIONS.has(rhs.action)) {
-      state.warnings.push(warning(`unsupported insert action ${rhs.action}`));
+      session.warning(`unsupported insert action ${rhs.action}`);
       return;
     }
-    addInsertBinding(state, normalizedLhs, rhs.action);
+    session.recordMap({ kind: "insert", action: rhs.action, key });
     return;
   }
-  addActionBinding(state, normalizedLhs, rhs, modes);
+
+  const actionModes = modes.filter((candidate) => candidate !== "insert") as VimActionBindingMode[];
+  if (actionModes.length === 0) {
+    session.warning(`${rhs.actionId} does not support insert mode`);
+    return;
+  }
+  session.recordMap({
+    kind: "action",
+    actionId: rhs.actionId,
+    key,
+    args: rhs.args,
+    modes: actionModes,
+  });
 }
 
-function addStringRemap(
-  state: BuilderState,
-  lhs: string,
+function recordStringRemap(
+  session: ConfigSession,
+  key: string,
   rhs: string,
   modes: readonly VimMode[],
 ): void {
   const actionModes = modes.filter((mode) => mode !== "insert") as VimActionBindingMode[];
   if (actionModes.length === 0) {
-    state.warnings.push(warning("string rhs keymaps only support normal and visual modes"));
+    session.warning("string rhs keymaps only support normal and visual modes");
     return;
   }
   const inputs = tokenizeReplayInputs(rhs);
   if (!inputs || inputs.length === 0) {
-    state.warnings.push(warning("string rhs must contain supported key syntax"));
+    session.warning("string rhs must contain supported key syntax");
     return;
   }
-  const keymap = (state.partial.keymap ??= {});
-  const remaps = (keymap.remaps ??= { accepted: [] });
-  remaps.accepted = [...remaps.accepted, { key: lhs, inputs, modes: actionModes }];
+  session.recordMap({ kind: "remap", key, inputs, modes: actionModes });
 }
 
 export function isPrintableLeader(value: unknown): value is string {
@@ -240,16 +269,47 @@ export function isPrintableLeader(value: unknown): value is string {
   );
 }
 
-function setMapleader(state: BuilderState, value: unknown): void {
-  if (value === null || isPrintableLeader(value)) {
-    state.partial.leader = value;
-    return;
-  }
-  state.warnings.push(warning("vim.g.mapleader must be one printable character or null"));
-}
-
-function buildVim() {
-  const state: BuilderState = { partial: {}, warnings: [] };
+function createSession(seed: Pick<VimEditorOptions, "leader"> = {}): ConfigSession {
+  let closed = false;
+  let leader = seed.leader;
+  const warnings: string[] = [];
+  const operations: VimJsConfigOperation[] = [];
+  const assertOpen = () => {
+    if (closed) throw new Error("config session closed");
+  };
+  const session: ConfigSession = {
+    vim: {},
+    assertOpen,
+    close: () => {
+      closed = true;
+    },
+    readLeader: () => {
+      assertOpen();
+      return leader;
+    },
+    setMapleader: (value) => {
+      assertOpen();
+      if (value === null || isPrintableLeader(value)) {
+        leader = value;
+        operations.push({ kind: "leaf", path: "leader", value });
+        return;
+      }
+      warnings.push(warning("vim.g.mapleader must be one printable character or null"));
+    },
+    warning: (message) => {
+      assertOpen();
+      warnings.push(warning(message));
+    },
+    recordMap: (mapping) => {
+      assertOpen();
+      operations.push({ kind: "map", mapping: frozenSnapshot(mapping) });
+    },
+    success: () => ({
+      kind: "success",
+      operations: frozenSnapshot(operations),
+      warnings: frozenSnapshot(warnings),
+    }),
+  };
   const prompt = {
     quote: () => builtinPromptTransform("quote"),
     unquote: () => builtinPromptTransform("unquote"),
@@ -269,43 +329,79 @@ function buildVim() {
     moveLineStart: () => builtinInsert("moveLineStart"),
     moveLineEnd: () => builtinInsert("moveLineEnd"),
   };
-  return {
-    state,
-    vim: {
-      g: {
-        get mapleader() {
-          return state.partial.leader;
-        },
-        set mapleader(value: unknown) {
-          setMapleader(state, value);
-        },
+  const g = new Proxy(
+    {
+      get mapleader() {
+        return session.readLeader();
       },
-      prompt,
-      keymap: {
-        set: (mode: unknown, lhs: unknown, rhs: unknown) => compileMapping(state, mode, lhs, rhs),
+      set mapleader(value: unknown) {
+        session.setMapleader(value);
       },
     },
-  };
+    {
+      set(target, property, value, receiver) {
+        if (property === "mapleader") return Reflect.set(target, property, value, receiver);
+        session.warning(`unknown vim.g property ${String(property)}`);
+        return true;
+      },
+    },
+  );
+  session.vim = new Proxy(
+    {
+      g,
+      prompt: Object.freeze(prompt),
+      keymap: Object.freeze({
+        set: (mode: unknown, lhs: unknown, rhs: unknown) => compileMapping(session, mode, lhs, rhs),
+      }),
+    },
+    {
+      set(_target, property) {
+        session.warning(`unknown vim property ${String(property)}`);
+        return true;
+      },
+    },
+  );
+  return session;
+}
+
+function fatal(error: unknown): Extract<VimJsConfigLoadResult, { kind: "fatal" }> {
+  const message = error instanceof Error ? error.message : String(error);
+  return { kind: "fatal", warnings: frozenSnapshot([warning(`failed to load (${message})`)]) };
+}
+
+function isThenable(value: unknown): value is PromiseLike<unknown> {
+  return (
+    value !== null &&
+    (typeof value === "object" || typeof value === "function") &&
+    typeof (value as PromiseLike<unknown>).then === "function"
+  );
 }
 
 export async function loadVimJsConfig(
   configPath = DEFAULT_JS_CONFIG_PATH,
+  seed: Pick<VimEditorOptions, "leader"> = {},
 ): Promise<VimJsConfigLoadResult> {
-  if (!existsSync(configPath)) return { warnings: [] };
+  if (!existsSync(configPath)) return { kind: "missing", warnings: [] };
 
+  let exported: unknown;
   try {
     const mtime = statSync(configPath).mtimeMs;
-    const moduleUrl = `${pathToFileURL(configPath).href}?mtime=${mtime}`;
+    const moduleUrl = `${pathToFileURL(configPath).href}?mtime=${mtime}&load=${++rootLoadId}`;
     const module = (await import(moduleUrl)) as { default?: unknown };
-    const exported = module.default;
-    if (typeof exported !== "function") {
-      return { warnings: [warning("default export must be a function")] };
-    }
-    const { state, vim } = buildVim();
-    await exported(vim);
-    return { partial: state.partial, warnings: state.warnings, appendKeymap: true };
+    exported = module.default;
   } catch (error) {
-    const message = error instanceof Error ? error.message : String(error);
-    return { warnings: [warning(`failed to load (${message})`)] };
+    return fatal(error);
+  }
+  if (typeof exported !== "function") return fatal(new Error("default export must be a function"));
+
+  const session = createSession(seed);
+  try {
+    const result = exported(session.vim);
+    if (isThenable(result)) await result;
+    return session.success();
+  } catch (error) {
+    return fatal(error);
+  } finally {
+    session.close();
   }
 }

--- a/src/config-js.ts
+++ b/src/config-js.ts
@@ -13,6 +13,7 @@ import type {
 } from "./types.ts";
 
 import { protectedShortcutForKey } from "./customization.ts";
+import { VIM_PRESETS } from "./types.ts";
 
 export const DEFAULT_JS_CONFIG_PATH = join(homedir(), ".pi", "agent", "pi-vimmode.config.js");
 
@@ -88,7 +89,7 @@ const INSERT_ACTIONS = new Set<VimInsertAction>([
   "moveLineEnd",
 ]);
 
-const VIM_PRESETS = new Set<VimPreset>(["minimal", "prompt-safe", "vim-heavy"]);
+const VIM_PRESET_SET = new Set<VimPreset>(VIM_PRESETS);
 
 const RHS_INPUT_ALIASES: Record<string, string> = {
   cr: "\r",
@@ -315,6 +316,10 @@ function createGlobalApi(session: ConfigSession): object {
         session.warning(`unknown vim.g property ${String(property)}`);
         return true;
       },
+      defineProperty(target, property, descriptor) {
+        session.assertOpen();
+        return Reflect.defineProperty(target, property, descriptor);
+      },
     },
   );
 }
@@ -339,6 +344,10 @@ function createVimApi(session: ConfigSession, g: object): object {
         if (property === "preset") return Reflect.set(target, property, value, receiver);
         session.warning(`unknown vim property ${String(property)}`);
         return true;
+      },
+      defineProperty(target, property, descriptor) {
+        session.assertOpen();
+        return Reflect.defineProperty(target, property, descriptor);
       },
     },
   );
@@ -373,7 +382,7 @@ function createSession(seed: Pick<VimEditorOptions, "leader"> = {}): ConfigSessi
     },
     setPreset: (value) => {
       assertOpen();
-      if (typeof value === "string" && VIM_PRESETS.has(value as VimPreset)) {
+      if (typeof value === "string" && VIM_PRESET_SET.has(value as VimPreset)) {
         operations.push({ kind: "preset", preset: value as VimPreset });
         return;
       }

--- a/src/config-js.ts
+++ b/src/config-js.ts
@@ -44,7 +44,7 @@ export type VimJsConfigOperation =
   | { kind: "preset"; preset: VimPreset }
   | { kind: "leaf"; path: "leader"; value: string | null }
   | { kind: "map"; mapping: VimJsConfigMapOperation }
-  | { kind: "unmap"; target: string };
+  | { kind: "unmap"; key: string; modes: readonly VimMode[] };
 
 export type VimJsConfigLoadResult =
   | { kind: "missing"; warnings: readonly string[] }
@@ -57,8 +57,10 @@ type ConfigSession = {
   close(): void;
   readLeader(): string | null | undefined;
   setMapleader(value: unknown): void;
+  setPreset(value: unknown): void;
   warning(message: string): void;
   recordMap(mapping: VimJsConfigMapOperation): void;
+  recordUnmap(key: string, modes: readonly VimMode[]): void;
   success(): Extract<VimJsConfigLoadResult, { kind: "success" }>;
 };
 
@@ -85,6 +87,8 @@ const INSERT_ACTIONS = new Set<VimInsertAction>([
   "moveLineStart",
   "moveLineEnd",
 ]);
+
+const VIM_PRESETS = new Set<VimPreset>(["minimal", "prompt-safe", "vim-heavy"]);
 
 const RHS_INPUT_ALIASES: Record<string, string> = {
   cr: "\r",
@@ -206,6 +210,10 @@ function compileMapping(session: ConfigSession, mode: unknown, lhs: unknown, rhs
     );
     return;
   }
+  if (rhs === null) {
+    session.recordUnmap(key, modes);
+    return;
+  }
   if (typeof rhs === "string") {
     recordStringRemap(session, key, rhs, modes);
     return;
@@ -269,6 +277,73 @@ export function isPrintableLeader(value: unknown): value is string {
   );
 }
 
+function createPromptApi() {
+  return Object.freeze({
+    quote: () => builtinPromptTransform("quote"),
+    unquote: () => builtinPromptTransform("unquote"),
+    bulletize: () => builtinPromptTransform("bulletize"),
+    fence: (args: { language?: string } = {}) => builtinPromptTransform("fence", args),
+    indent: () => builtinPromptTransform("indent"),
+    dedent: () => builtinPromptTransform("dedent"),
+    reflow: (args: { width?: number } = {}) => builtinPromptTransform("reflow", args),
+    openLineBelow: () => builtinInsert("openLineBelow"),
+    openLineAbove: () => builtinInsert("openLineAbove"),
+    deleteWordBackward: () => builtinInsert("deleteWordBackward"),
+    deleteWordForward: () => builtinInsert("deleteWordForward"),
+    deleteLineBackward: () => builtinInsert("deleteLineBackward"),
+    deleteLineForward: () => builtinInsert("deleteLineForward"),
+    moveWordBackward: () => builtinInsert("moveWordBackward"),
+    moveWordForward: () => builtinInsert("moveWordForward"),
+    moveLineStart: () => builtinInsert("moveLineStart"),
+    moveLineEnd: () => builtinInsert("moveLineEnd"),
+  });
+}
+
+function createGlobalApi(session: ConfigSession): object {
+  return new Proxy(
+    {
+      get mapleader() {
+        return session.readLeader();
+      },
+      set mapleader(value: unknown) {
+        session.setMapleader(value);
+      },
+    },
+    {
+      set(target, property, value, receiver) {
+        if (property === "mapleader") return Reflect.set(target, property, value, receiver);
+        session.warning(`unknown vim.g property ${String(property)}`);
+        return true;
+      },
+    },
+  );
+}
+
+function createVimApi(session: ConfigSession, g: object): object {
+  return new Proxy(
+    {
+      g,
+      get preset() {
+        return undefined;
+      },
+      set preset(value: unknown) {
+        session.setPreset(value);
+      },
+      prompt: createPromptApi(),
+      keymap: Object.freeze({
+        set: (mode: unknown, lhs: unknown, rhs: unknown) => compileMapping(session, mode, lhs, rhs),
+      }),
+    },
+    {
+      set(target, property, value, receiver) {
+        if (property === "preset") return Reflect.set(target, property, value, receiver);
+        session.warning(`unknown vim property ${String(property)}`);
+        return true;
+      },
+    },
+  );
+}
+
 function createSession(seed: Pick<VimEditorOptions, "leader"> = {}): ConfigSession {
   let closed = false;
   let leader = seed.leader;
@@ -296,6 +371,14 @@ function createSession(seed: Pick<VimEditorOptions, "leader"> = {}): ConfigSessi
       }
       warnings.push(warning("vim.g.mapleader must be one printable character or null"));
     },
+    setPreset: (value) => {
+      assertOpen();
+      if (typeof value === "string" && VIM_PRESETS.has(value as VimPreset)) {
+        operations.push({ kind: "preset", preset: value as VimPreset });
+        return;
+      }
+      warnings.push(warning("vim.preset must be a supported preset"));
+    },
     warning: (message) => {
       assertOpen();
       warnings.push(warning(message));
@@ -304,63 +387,17 @@ function createSession(seed: Pick<VimEditorOptions, "leader"> = {}): ConfigSessi
       assertOpen();
       operations.push({ kind: "map", mapping: frozenSnapshot(mapping) });
     },
+    recordUnmap: (key, modes) => {
+      assertOpen();
+      operations.push({ kind: "unmap", key, modes: frozenSnapshot(modes) });
+    },
     success: () => ({
       kind: "success",
       operations: frozenSnapshot(operations),
       warnings: frozenSnapshot(warnings),
     }),
   };
-  const prompt = {
-    quote: () => builtinPromptTransform("quote"),
-    unquote: () => builtinPromptTransform("unquote"),
-    bulletize: () => builtinPromptTransform("bulletize"),
-    fence: (args: { language?: string } = {}) => builtinPromptTransform("fence", args),
-    indent: () => builtinPromptTransform("indent"),
-    dedent: () => builtinPromptTransform("dedent"),
-    reflow: (args: { width?: number } = {}) => builtinPromptTransform("reflow", args),
-    openLineBelow: () => builtinInsert("openLineBelow"),
-    openLineAbove: () => builtinInsert("openLineAbove"),
-    deleteWordBackward: () => builtinInsert("deleteWordBackward"),
-    deleteWordForward: () => builtinInsert("deleteWordForward"),
-    deleteLineBackward: () => builtinInsert("deleteLineBackward"),
-    deleteLineForward: () => builtinInsert("deleteLineForward"),
-    moveWordBackward: () => builtinInsert("moveWordBackward"),
-    moveWordForward: () => builtinInsert("moveWordForward"),
-    moveLineStart: () => builtinInsert("moveLineStart"),
-    moveLineEnd: () => builtinInsert("moveLineEnd"),
-  };
-  const g = new Proxy(
-    {
-      get mapleader() {
-        return session.readLeader();
-      },
-      set mapleader(value: unknown) {
-        session.setMapleader(value);
-      },
-    },
-    {
-      set(target, property, value, receiver) {
-        if (property === "mapleader") return Reflect.set(target, property, value, receiver);
-        session.warning(`unknown vim.g property ${String(property)}`);
-        return true;
-      },
-    },
-  );
-  session.vim = new Proxy(
-    {
-      g,
-      prompt: Object.freeze(prompt),
-      keymap: Object.freeze({
-        set: (mode: unknown, lhs: unknown, rhs: unknown) => compileMapping(session, mode, lhs, rhs),
-      }),
-    },
-    {
-      set(_target, property) {
-        session.warning(`unknown vim property ${String(property)}`);
-        return true;
-      },
-    },
-  );
+  session.vim = createVimApi(session, createGlobalApi(session));
   return session;
 }
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -22,6 +22,7 @@ import type {
   VimActionBindingMode,
   VimActionKeybindingPreset,
   VimCommandAction,
+  VimEditorOptions,
   ResolvedVimEditorOptions,
   VimFeedbackOptions,
   VimMode,
@@ -39,7 +40,12 @@ import {
   actionKeybindingPresetActions,
   isActionKeybindingPreset,
 } from "./action-keybinding-recipes.ts";
-import { DEFAULT_JS_CONFIG_PATH, isPrintableLeader, loadVimJsConfig } from "./config-js.ts";
+import {
+  DEFAULT_JS_CONFIG_PATH,
+  isPrintableLeader,
+  loadVimJsConfig,
+  type VimJsConfigOperation,
+} from "./config-js.ts";
 import { protectedShortcutForKey } from "./customization.ts";
 import {
   deriveActionKeys,
@@ -2238,10 +2244,52 @@ function mergePartialOptions(target: ResolvedVimEditorOptions, partial: PartialV
   }
 }
 
+function partialFromJsOperations(operations: readonly VimJsConfigOperation[]): VimEditorOptions {
+  const partial: VimEditorOptions = {};
+  for (const operation of operations) {
+    if (operation.kind === "preset") {
+      partial.preset = operation.preset;
+      continue;
+    }
+    if (operation.kind === "leaf") {
+      partial.leader = operation.value;
+      continue;
+    }
+    if (operation.kind !== "map") continue;
+    const keymap = (partial.keymap ??= {});
+    const mapping = operation.mapping;
+    if (mapping.kind === "insert") {
+      const insert = (keymap.insert ??= {});
+      insert[mapping.action] = [...(insert[mapping.action] ?? []), mapping.key];
+      continue;
+    }
+    if (mapping.kind === "action") {
+      const actions = (keymap.actions ??= {});
+      actions[mapping.actionId] = [
+        ...(actions[mapping.actionId] ?? []),
+        { key: mapping.key, args: mapping.args, modes: mapping.modes },
+      ];
+      continue;
+    }
+    const remaps = (keymap.remaps ??= { accepted: [] });
+    remaps.accepted = [
+      ...remaps.accepted,
+      { key: mapping.key, inputs: mapping.inputs, modes: mapping.modes },
+    ];
+  }
+  return partial;
+}
+
 export function resolveVimOptions(
   globalSettings: unknown,
   projectSettings?: unknown,
-  jsConfig?: { partial?: unknown; warnings?: readonly string[]; appendKeymap?: boolean },
+  jsConfig?: {
+    kind?: "success" | "fatal" | "missing";
+    operations?: readonly VimJsConfigOperation[];
+    partial?: unknown;
+    warnings?: readonly string[];
+    appendKeymap?: boolean;
+  },
 ): VimConfigLoadResult {
   const options = cloneDefaultOptions();
   const warnings: string[] = [];
@@ -2259,9 +2307,13 @@ export function resolveVimOptions(
   if (parsedGlobal.partial.keymap) keymapLayers.push(parsedGlobal.partial.keymap);
   warnings.push(...parsedGlobal.warnings);
 
-  const parsedJs = parsePiVimMode(jsConfig?.partial, "global JS config");
+  const jsPartialSource = jsConfig?.operations
+    ? partialFromJsOperations(jsConfig.operations)
+    : jsConfig?.partial;
+  const parsedJs = parsePiVimMode(jsPartialSource, "global JS config");
+  const appendJsKeymap = jsConfig?.kind === "success" || jsConfig?.appendKeymap;
   const jsPartial =
-    jsConfig?.appendKeymap && parsedJs.partial.keymap
+    appendJsKeymap && parsedJs.partial.keymap
       ? { ...parsedJs.partial, keymap: additiveKeymapLayer(keymapLayers, parsedJs.partial.keymap) }
       : parsedJs.partial;
   mergePartialOptions(options, jsPartial);
@@ -2348,7 +2400,8 @@ export async function loadVimOptions(paths: VimConfigPaths = {}): Promise<VimCon
 
   const globalRead = readJsonFile(globalPath, "global settings");
   const projectRead = readJsonFile(projectPath, "project settings");
-  const jsRead = await loadVimJsConfig(jsConfigPath);
+  const globalSeed = resolveVimOptions(globalRead.settings).options;
+  const jsRead = await loadVimJsConfig(jsConfigPath, { leader: globalSeed.leader });
   const resolved = resolveVimOptions(globalRead.settings, projectRead.settings, jsRead);
 
   return {

--- a/src/config.ts
+++ b/src/config.ts
@@ -327,6 +327,7 @@ type PartialKeymapOptions = {
   actionPresets?: VimActionKeybindingPreset[];
   actions?: Partial<Record<BindablePromptTransformActionId, ResolvedVimActionBinding[]>>;
   remaps?: ResolvedVimKeymap["remaps"];
+  unmaps?: Array<{ key: string; modes: readonly VimMode[] }>;
   allowProtectedOverrides?: string[];
 };
 
@@ -1620,6 +1621,23 @@ function removeTopLevelKeymapSequences(target: ResolvedVimKeymap, sequences: Set
 }
 
 function mergeKeymap(target: ResolvedVimKeymap, partial: PartialKeymapOptions): void {
+  for (const unmap of partial.unmaps ?? []) {
+    if (unmap.modes.includes("insert")) {
+      for (const action of Object.keys(target.insert) as Array<keyof ResolvedVimInsertKeymap>) {
+        target.insert[action] = target.insert[action].filter((key) => key !== unmap.key);
+      }
+    }
+    target.actions.accepted = target.actions.accepted.flatMap((binding) => {
+      if (binding.key !== unmap.key) return [binding];
+      const modes = binding.modes?.filter((mode) => !unmap.modes.includes(mode));
+      return modes?.length ? [{ ...binding, modes }] : [];
+    });
+    target.remaps.accepted = target.remaps.accepted.flatMap((mapping) => {
+      if (mapping.key !== unmap.key) return [mapping];
+      const modes = mapping.modes?.filter((mode) => !unmap.modes.includes(mode));
+      return modes?.length ? [{ ...mapping, modes }] : [];
+    });
+  }
   removeTopLevelKeymapSequences(target, configuredTopLevelKeymapSequences(partial));
   if (partial.escape) target.escape = [...partial.escape];
   if (partial.operators) target.operators = { ...target.operators, ...partial.operators };
@@ -1642,6 +1660,18 @@ function mergeKeymap(target: ResolvedVimKeymap, partial: PartialKeymapOptions): 
   if (partial.actions) mergeActionBindings(target, partial.actions);
   if (partial.remaps) {
     target.remaps = { accepted: [...target.remaps.accepted, ...partial.remaps.accepted] };
+  }
+  for (const unmap of partial.unmaps ?? []) {
+    target.actions.accepted = target.actions.accepted.flatMap((binding) => {
+      if (binding.key !== unmap.key) return [binding];
+      const modes = binding.modes?.filter((mode) => !unmap.modes.includes(mode));
+      return modes?.length ? [{ ...binding, modes }] : [];
+    });
+    target.remaps.accepted = target.remaps.accepted.flatMap((mapping) => {
+      if (mapping.key !== unmap.key) return [mapping];
+      const modes = mapping.modes?.filter((mode) => !unmap.modes.includes(mode));
+      return modes?.length ? [{ ...mapping, modes }] : [];
+    });
   }
 }
 
@@ -1710,6 +1740,7 @@ function mergeKeymapOverlay(target: PartialKeymapOptions, partial: PartialKeymap
   if (partial.remaps) {
     target.remaps = { accepted: [...(target.remaps?.accepted ?? []), ...partial.remaps.accepted] };
   }
+  if (partial.unmaps) target.unmaps = [...(target.unmaps ?? []), ...partial.unmaps];
 }
 
 function keymapOverlayFromLayers(layers: readonly PartialKeymapOptions[]): PartialKeymapOptions {
@@ -2289,6 +2320,8 @@ function partialFromJsOperations(operations: readonly VimJsConfigOperation[]): V
     const keymap = (partial.keymap ??= {});
     if (operation.kind === "unmap") {
       removeJsMappings(keymap as PartialKeymapOptions, operation.key, operation.modes);
+      const unmaps = ((keymap as PartialKeymapOptions).unmaps ??= []);
+      unmaps.push({ key: operation.key, modes: operation.modes });
       continue;
     }
     const mapping = operation.mapping;
@@ -2351,9 +2384,19 @@ export function resolveVimOptions(
     mergePartialOptions(options, preset);
     if (preset.keymap) keymapLayers.push(preset.keymap);
   }
+  const jsUnmaps = jsConfig?.operations
+    ? (partialFromJsOperations(jsConfig.operations).keymap as PartialKeymapOptions | undefined)
+        ?.unmaps
+    : undefined;
   const jsPartial =
     appendJsKeymap && parsedJs.partial.keymap
-      ? { ...parsedJs.partial, keymap: additiveKeymapLayer(keymapLayers, parsedJs.partial.keymap) }
+      ? {
+          ...parsedJs.partial,
+          keymap: {
+            ...additiveKeymapLayer(keymapLayers, parsedJs.partial.keymap),
+            unmaps: jsUnmaps,
+          },
+        }
       : parsedJs.partial;
   mergePartialOptions(options, jsPartial);
   if (jsPartial.keymap) keymapLayers.push(jsPartial.keymap);

--- a/src/config.ts
+++ b/src/config.ts
@@ -2244,6 +2244,37 @@ function mergePartialOptions(target: ResolvedVimEditorOptions, partial: PartialV
   }
 }
 
+function removeJsMappings(
+  keymap: PartialKeymapOptions,
+  key: string,
+  modes: readonly VimMode[],
+): void {
+  const removesMode = (mode: VimMode) => modes.includes(mode);
+  if (keymap.insert && removesMode("insert")) {
+    for (const action of Object.keys(keymap.insert) as Array<keyof ResolvedVimInsertKeymap>) {
+      keymap.insert[action] = keymap.insert[action]?.filter((binding) => binding !== key);
+    }
+  }
+  if (keymap.actions) {
+    for (const [actionId, bindings] of Object.entries(keymap.actions)) {
+      keymap.actions[actionId as BindablePromptTransformActionId] = (bindings ?? []).flatMap(
+        (binding) => {
+          if (binding.key !== key) return [binding];
+          const remainingModes = binding.modes?.filter((mode) => !removesMode(mode));
+          return remainingModes?.length ? [{ ...binding, modes: remainingModes }] : [];
+        },
+      );
+    }
+  }
+  if (keymap.remaps) {
+    keymap.remaps.accepted = keymap.remaps.accepted.flatMap((mapping) => {
+      if (mapping.key !== key) return [mapping];
+      const remainingModes = mapping.modes?.filter((mode) => !removesMode(mode));
+      return remainingModes?.length ? [{ ...mapping, modes: remainingModes }] : [];
+    });
+  }
+}
+
 function partialFromJsOperations(operations: readonly VimJsConfigOperation[]): VimEditorOptions {
   const partial: VimEditorOptions = {};
   for (const operation of operations) {
@@ -2255,8 +2286,11 @@ function partialFromJsOperations(operations: readonly VimJsConfigOperation[]): V
       partial.leader = operation.value;
       continue;
     }
-    if (operation.kind !== "map") continue;
     const keymap = (partial.keymap ??= {});
+    if (operation.kind === "unmap") {
+      removeJsMappings(keymap as PartialKeymapOptions, operation.key, operation.modes);
+      continue;
+    }
     const mapping = operation.mapping;
     if (mapping.kind === "insert") {
       const insert = (keymap.insert ??= {});
@@ -2312,6 +2346,11 @@ export function resolveVimOptions(
     : jsConfig?.partial;
   const parsedJs = parsePiVimMode(jsPartialSource, "global JS config");
   const appendJsKeymap = jsConfig?.kind === "success" || jsConfig?.appendKeymap;
+  if (parsedJs.partial.preset) {
+    const preset = presetOptions(parsedJs.partial.preset);
+    mergePartialOptions(options, preset);
+    if (preset.keymap) keymapLayers.push(preset.keymap);
+  }
   const jsPartial =
     appendJsKeymap && parsedJs.partial.keymap
       ? { ...parsedJs.partial, keymap: additiveKeymapLayer(keymapLayers, parsedJs.partial.keymap) }

--- a/src/config.ts
+++ b/src/config.ts
@@ -68,6 +68,7 @@ import {
   normalizePromptTransformActionArgs,
   promptTransformActionForId,
 } from "./prompt-transform-actions.ts";
+import { VIM_PRESETS } from "./types.ts";
 
 const VIM_MODES = [
   "insert",
@@ -139,7 +140,13 @@ const TEXT_OBJECT_TARGET_SET = deriveSet(KEYMAP_TEXT_OBJECT_TARGET_DESCRIPTORS);
 const PROMPT_STRUCTURE_TARGET_SET = new Set<string>(PROMPT_STRUCTURE_TARGETS);
 const PROMPT_TRANSFORM_ACTION_SET = new Set<string>(PROMPT_TRANSFORM_ACTIONS);
 const BINDABLE_PROMPT_TRANSFORM_ACTION_SET = new Set<string>(bindablePromptTransformActionIds());
-const VIM_PRESETS = new Set<VimPreset>(["minimal", "prompt-safe", "vim-heavy"]);
+const VIM_PRESET_SET = new Set<VimPreset>(VIM_PRESETS);
+const ACTION_BINDING_MODES: readonly VimActionBindingMode[] = [
+  "normal",
+  "visual",
+  "visualLine",
+  "visualBlock",
+];
 const NOOP_FEEDBACK_VALUES = new Set<VimFeedbackOptions["noop"]>(["off", "status"]);
 const WORKBENCH_RESERVED_ROWS_MAX = 5;
 
@@ -1493,7 +1500,7 @@ function parsePiVimMode(
 
   const preset = value.preset;
   if (preset !== undefined) {
-    if (typeof preset === "string" && VIM_PRESETS.has(preset as VimPreset)) {
+    if (typeof preset === "string" && VIM_PRESET_SET.has(preset as VimPreset)) {
       partial.preset = preset as VimPreset;
     } else {
       warnings.push(`${sourceLabel}: unsupported piVimMode.preset`);
@@ -1620,6 +1627,29 @@ function removeTopLevelKeymapSequences(target: ResolvedVimKeymap, sequences: Set
   };
 }
 
+function remainingScopedModes(
+  modes: readonly VimActionBindingMode[] | undefined,
+  removedModes: readonly VimMode[],
+): readonly VimActionBindingMode[] {
+  return (modes ?? ACTION_BINDING_MODES).filter((mode) => !removedModes.includes(mode));
+}
+
+function removeScopedKeymapBindings(
+  target: ResolvedVimKeymap,
+  unmap: { key: string; modes: readonly VimMode[] },
+): void {
+  target.actions.accepted = target.actions.accepted.flatMap((binding) => {
+    if (binding.key !== unmap.key) return [binding];
+    const modes = remainingScopedModes(binding.modes, unmap.modes);
+    return modes.length ? [{ ...binding, modes }] : [];
+  });
+  target.remaps.accepted = target.remaps.accepted.flatMap((mapping) => {
+    if (mapping.key !== unmap.key) return [mapping];
+    const modes = remainingScopedModes(mapping.modes, unmap.modes);
+    return modes.length ? [{ ...mapping, modes }] : [];
+  });
+}
+
 function mergeKeymap(target: ResolvedVimKeymap, partial: PartialKeymapOptions): void {
   for (const unmap of partial.unmaps ?? []) {
     if (unmap.modes.includes("insert")) {
@@ -1627,16 +1657,7 @@ function mergeKeymap(target: ResolvedVimKeymap, partial: PartialKeymapOptions): 
         target.insert[action] = target.insert[action].filter((key) => key !== unmap.key);
       }
     }
-    target.actions.accepted = target.actions.accepted.flatMap((binding) => {
-      if (binding.key !== unmap.key) return [binding];
-      const modes = binding.modes?.filter((mode) => !unmap.modes.includes(mode));
-      return modes?.length ? [{ ...binding, modes }] : [];
-    });
-    target.remaps.accepted = target.remaps.accepted.flatMap((mapping) => {
-      if (mapping.key !== unmap.key) return [mapping];
-      const modes = mapping.modes?.filter((mode) => !unmap.modes.includes(mode));
-      return modes?.length ? [{ ...mapping, modes }] : [];
-    });
+    removeScopedKeymapBindings(target, unmap);
   }
   removeTopLevelKeymapSequences(target, configuredTopLevelKeymapSequences(partial));
   if (partial.escape) target.escape = [...partial.escape];
@@ -1661,18 +1682,7 @@ function mergeKeymap(target: ResolvedVimKeymap, partial: PartialKeymapOptions): 
   if (partial.remaps) {
     target.remaps = { accepted: [...target.remaps.accepted, ...partial.remaps.accepted] };
   }
-  for (const unmap of partial.unmaps ?? []) {
-    target.actions.accepted = target.actions.accepted.flatMap((binding) => {
-      if (binding.key !== unmap.key) return [binding];
-      const modes = binding.modes?.filter((mode) => !unmap.modes.includes(mode));
-      return modes?.length ? [{ ...binding, modes }] : [];
-    });
-    target.remaps.accepted = target.remaps.accepted.flatMap((mapping) => {
-      if (mapping.key !== unmap.key) return [mapping];
-      const modes = mapping.modes?.filter((mode) => !unmap.modes.includes(mode));
-      return modes?.length ? [{ ...mapping, modes }] : [];
-    });
-  }
+  for (const unmap of partial.unmaps ?? []) removeScopedKeymapBindings(target, unmap);
 }
 
 function additiveKeymapLayer(
@@ -2291,8 +2301,8 @@ function removeJsMappings(
       keymap.actions[actionId as BindablePromptTransformActionId] = (bindings ?? []).flatMap(
         (binding) => {
           if (binding.key !== key) return [binding];
-          const remainingModes = binding.modes?.filter((mode) => !removesMode(mode));
-          return remainingModes?.length ? [{ ...binding, modes: remainingModes }] : [];
+          const remainingModes = remainingScopedModes(binding.modes, modes);
+          return remainingModes.length ? [{ ...binding, modes: remainingModes }] : [];
         },
       );
     }
@@ -2300,10 +2310,22 @@ function removeJsMappings(
   if (keymap.remaps) {
     keymap.remaps.accepted = keymap.remaps.accepted.flatMap((mapping) => {
       if (mapping.key !== key) return [mapping];
-      const remainingModes = mapping.modes?.filter((mode) => !removesMode(mode));
-      return remainingModes?.length ? [{ ...mapping, modes: remainingModes }] : [];
+      const remainingModes = remainingScopedModes(mapping.modes, modes);
+      return remainingModes.length ? [{ ...mapping, modes: remainingModes }] : [];
     });
   }
+}
+
+function restoreJsUnmaps(
+  keymap: PartialKeymapOptions,
+  key: string,
+  modes: readonly VimMode[],
+): void {
+  keymap.unmaps = keymap.unmaps?.flatMap((unmap) => {
+    if (unmap.key !== key) return [unmap];
+    const remainingModes = unmap.modes.filter((mode) => !modes.includes(mode));
+    return remainingModes.length ? [{ ...unmap, modes: remainingModes }] : [];
+  });
 }
 
 function partialFromJsOperations(operations: readonly VimJsConfigOperation[]): VimEditorOptions {
@@ -2326,11 +2348,13 @@ function partialFromJsOperations(operations: readonly VimJsConfigOperation[]): V
     }
     const mapping = operation.mapping;
     if (mapping.kind === "insert") {
+      restoreJsUnmaps(keymap as PartialKeymapOptions, mapping.key, ["insert"]);
       const insert = (keymap.insert ??= {});
       insert[mapping.action] = [...(insert[mapping.action] ?? []), mapping.key];
       continue;
     }
     if (mapping.kind === "action") {
+      restoreJsUnmaps(keymap as PartialKeymapOptions, mapping.key, mapping.modes);
       const actions = (keymap.actions ??= {});
       actions[mapping.actionId] = [
         ...(actions[mapping.actionId] ?? []),
@@ -2338,6 +2362,7 @@ function partialFromJsOperations(operations: readonly VimJsConfigOperation[]): V
       ];
       continue;
     }
+    restoreJsUnmaps(keymap as PartialKeymapOptions, mapping.key, mapping.modes);
     const remaps = (keymap.remaps ??= { accepted: [] });
     remaps.accepted = [
       ...remaps.accepted,
@@ -2345,6 +2370,17 @@ function partialFromJsOperations(operations: readonly VimJsConfigOperation[]): V
     ];
   }
   return partial;
+}
+
+function compileJsConfig(jsConfig: Parameters<typeof resolveVimOptions>[2]): {
+  source: unknown;
+  unmaps: PartialKeymapOptions["unmaps"] | undefined;
+} {
+  const compiled = jsConfig?.operations ? partialFromJsOperations(jsConfig.operations) : undefined;
+  return {
+    source: compiled ?? jsConfig?.partial,
+    unmaps: (compiled?.keymap as PartialKeymapOptions | undefined)?.unmaps,
+  };
 }
 
 export function resolveVimOptions(
@@ -2374,27 +2410,21 @@ export function resolveVimOptions(
   if (parsedGlobal.partial.keymap) keymapLayers.push(parsedGlobal.partial.keymap);
   warnings.push(...parsedGlobal.warnings);
 
-  const jsPartialSource = jsConfig?.operations
-    ? partialFromJsOperations(jsConfig.operations)
-    : jsConfig?.partial;
-  const parsedJs = parsePiVimMode(jsPartialSource, "global JS config");
+  const compiledJs = compileJsConfig(jsConfig);
+  const parsedJs = parsePiVimMode(compiledJs.source, "global JS config");
   const appendJsKeymap = jsConfig?.kind === "success" || jsConfig?.appendKeymap;
   if (parsedJs.partial.preset) {
     const preset = presetOptions(parsedJs.partial.preset);
     mergePartialOptions(options, preset);
     if (preset.keymap) keymapLayers.push(preset.keymap);
   }
-  const jsUnmaps = jsConfig?.operations
-    ? (partialFromJsOperations(jsConfig.operations).keymap as PartialKeymapOptions | undefined)
-        ?.unmaps
-    : undefined;
   const jsPartial =
     appendJsKeymap && parsedJs.partial.keymap
       ? {
           ...parsedJs.partial,
           keymap: {
             ...additiveKeymapLayer(keymapLayers, parsedJs.partial.keymap),
-            unmaps: jsUnmaps,
+            unmaps: compiledJs.unmaps,
           },
         }
       : parsedJs.partial;

--- a/src/types.ts
+++ b/src/types.ts
@@ -8,7 +8,8 @@ export type CursorStyle = "block" | "bar" | "underline";
 
 export type CursorStyles = Record<VimMode, CursorStyle>;
 
-export type VimPreset = "minimal" | "prompt-safe" | "vim-heavy";
+export const VIM_PRESETS = ["minimal", "prompt-safe", "vim-heavy"] as const;
+export type VimPreset = (typeof VIM_PRESETS)[number];
 
 export type VimNoopFeedback = "off" | "status";
 

--- a/test/config-js.test.ts
+++ b/test/config-js.test.ts
@@ -403,6 +403,61 @@ export default (vim) => {
     }
   });
 
+  test("stages preset and scoped unmap operations in source order", async () => {
+    const f = fixture();
+    try {
+      f.write(`
+export default (vim) => {
+  vim.preset = "minimal";
+  vim.g.mapleader = ",";
+  vim.keymap.set("n", "zq", vim.prompt.quote());
+  vim.keymap.set("v", "zq", vim.prompt.reflow());
+  vim.keymap.set("n", "zq", null);
+};
+`);
+      const loaded = await loadVimJsConfig(f.path);
+      expect(operations(loaded)).toEqual([
+        { kind: "preset", preset: "minimal" },
+        { kind: "leaf", path: "leader", value: "," },
+        {
+          kind: "map",
+          mapping: {
+            kind: "action",
+            actionId: "prompt.transform.quote",
+            key: "zq",
+            args: undefined,
+            modes: ["normal"],
+          },
+        },
+        {
+          kind: "map",
+          mapping: {
+            kind: "action",
+            actionId: "prompt.transform.reflow",
+            key: "zq",
+            args: {},
+            modes: ["visual", "visualLine", "visualBlock"],
+          },
+        },
+        { kind: "unmap", key: "zq", modes: ["normal"] },
+      ]);
+
+      const resolved = resolveVimOptions(undefined, undefined, loaded);
+      expect(resolved.options.macros?.enabled).toBe(false);
+      expect(resolved.options.marks?.enabled).toBe(false);
+      expect(resolved.options.keymap?.actions.accepted).toEqual([
+        {
+          actionId: "prompt.transform.reflow",
+          key: "zq",
+          args: { action: "reflow" },
+          modes: ["visual", "visualLine", "visualBlock"],
+        },
+      ]);
+    } finally {
+      f.cleanup();
+    }
+  });
+
   test("re-evaluates root config on every load", async () => {
     const f = fixture();
     const loadKey = "__piVimModeRootLoadCount";

--- a/test/config-js.test.ts
+++ b/test/config-js.test.ts
@@ -458,6 +458,26 @@ export default (vim) => {
     }
   });
 
+  test("unmaps inherited mappings in only selected scopes", async () => {
+    const f = fixture();
+    try {
+      f.write(`export default (vim) => vim.keymap.set("n", "zq", null);`);
+      const loaded = await loadVimJsConfig(f.path);
+      const resolved = resolveVimOptions(
+        {
+          piVimMode: {
+            keymap: { actions: { "prompt.transform.quote": [{ key: "zq", modes: ["normal"] }] } },
+          },
+        },
+        undefined,
+        loaded,
+      );
+      expect(resolved.options.keymap?.actions.accepted).toEqual([]);
+    } finally {
+      f.cleanup();
+    }
+  });
+
   test("re-evaluates root config on every load", async () => {
     const f = fixture();
     const loadKey = "__piVimModeRootLoadCount";

--- a/test/config-js.test.ts
+++ b/test/config-js.test.ts
@@ -16,10 +16,16 @@ function fixture() {
   };
 }
 
+function operations(result: Awaited<ReturnType<typeof loadVimJsConfig>>) {
+  expect(result.kind).toBe("success");
+  if (result.kind !== "success") throw new Error("expected successful JS config");
+  return result.operations;
+}
+
 describe("vim JS config loading", () => {
   test("missing JS config is quiet", async () => {
     const result = await loadVimJsConfig(join(tmpdir(), "missing-pi-vimmode.config.js"));
-    expect(result).toEqual({ warnings: [] });
+    expect(result).toEqual({ kind: "missing", warnings: [] });
   });
 
   test("loads vim.prompt builtins through string keybindings", async () => {
@@ -34,18 +40,28 @@ export default (vim) => {
 `);
       const result = await loadVimJsConfig(f.path);
       expect(result.warnings).toEqual([]);
-      expect(result.appendKeymap).toBe(true);
-      expect(result.partial).toEqual({
-        keymap: {
-          insert: { deleteWordBackward: ["alt+w"] },
-          actions: {
-            "prompt.transform.reflow": [{ key: "zq", args: { width: 88 }, modes: ["normal"] }],
-            "prompt.transform.quote": [
-              { key: "z>", args: undefined, modes: ["visual", "visualLine", "visualBlock"] },
-            ],
+      expect(operations(result)).toEqual([
+        { kind: "map", mapping: { kind: "insert", action: "deleteWordBackward", key: "alt+w" } },
+        {
+          kind: "map",
+          mapping: {
+            kind: "action",
+            actionId: "prompt.transform.reflow",
+            key: "zq",
+            args: { width: 88 },
+            modes: ["normal"],
           },
         },
-      });
+        {
+          kind: "map",
+          mapping: {
+            kind: "action",
+            actionId: "prompt.transform.quote",
+            key: "z>",
+            modes: ["visual", "visualLine", "visualBlock"],
+          },
+        },
+      ]);
     } finally {
       f.cleanup();
     }
@@ -65,12 +81,34 @@ export default (vim) => {
 `);
       const loaded = await loadVimJsConfig(f.path);
       expect(loaded.warnings).toEqual([]);
-      expect(loaded.partial?.leader).toBe(" ");
-      expect(loaded.partial?.keymap?.actions?.["prompt.transform.quote"]?.[0]).toEqual({
-        key: "<leader>q",
-        args: undefined,
-        modes: ["normal"],
-      });
+      expect(operations(loaded)).toEqual([
+        { kind: "leaf", path: "leader", value: "," },
+        {
+          kind: "map",
+          mapping: {
+            kind: "action",
+            actionId: "prompt.transform.quote",
+            key: "<leader>q",
+            args: undefined,
+            modes: ["normal"],
+          },
+        },
+        { kind: "leaf", path: "leader", value: " " },
+        {
+          kind: "map",
+          mapping: {
+            kind: "action",
+            actionId: "prompt.transform.reflow",
+            key: "<leader>r",
+            args: {},
+            modes: ["normal"],
+          },
+        },
+        {
+          kind: "map",
+          mapping: { kind: "remap", key: "<leader>x", inputs: ["leader"], modes: ["normal"] },
+        },
+      ]);
 
       const resolved = resolveVimOptions(undefined, undefined, loaded);
       expect(resolved.options.leader).toBe(" ");
@@ -93,12 +131,13 @@ export default (vim) => {
 export default (vim) => {
   vim.g.mapleader = ",";
   vim.g.mapleader = "too-long";
+  if (vim.g.mapleader !== ",") throw new Error("invalid write replaced staged leader");
   vim.keymap.set("n", "<leader>q", vim.prompt.quote());
   vim.g.mapleader = null;
 };
 `);
       const loaded = await loadVimJsConfig(f.path);
-      expect(loaded.partial?.leader).toBeNull();
+      expect(operations(loaded).at(-1)).toEqual({ kind: "leaf", path: "leader", value: null });
       expect(loaded.warnings).toEqual([
         "global JS config: vim.g.mapleader must be one printable character or null",
       ]);
@@ -274,21 +313,25 @@ export default (vim) => {
 };
 `);
       const result = await loadVimJsConfig(f.path);
-      expect(result.partial).toEqual({
-        keymap: {
-          remaps: {
-            accepted: [
-              { key: "zz", inputs: ["l", "l", "l", "l"], modes: ["normal"] },
-              {
-                key: "ZD",
-                inputs: [":", "v", "i", "m", "d", "o", "c", "t", "o", "r", "\r"],
-                modes: ["normal"],
-              },
-              { key: "ZE", inputs: ["i", "\x1b", "\t"], modes: ["normal"] },
-            ],
+      expect(operations(result)).toEqual([
+        {
+          kind: "map",
+          mapping: { kind: "remap", key: "zz", inputs: ["l", "l", "l", "l"], modes: ["normal"] },
+        },
+        {
+          kind: "map",
+          mapping: {
+            kind: "remap",
+            key: "ZD",
+            inputs: [":", "v", "i", "m", "d", "o", "c", "t", "o", "r", "\r"],
+            modes: ["normal"],
           },
         },
-      });
+        {
+          kind: "map",
+          mapping: { kind: "remap", key: "ZE", inputs: ["i", "\x1b", "\t"], modes: ["normal"] },
+        },
+      ]);
       expect(result.warnings).toEqual([]);
     } finally {
       f.cleanup();
@@ -306,7 +349,7 @@ export default (vim) => {
 };
 `);
       const result = await loadVimJsConfig(f.path);
-      expect(result.partial).toEqual({ leader: "," });
+      expect(operations(result)).toEqual([{ kind: "leaf", path: "leader", value: "," }]);
       expect(result.warnings).toEqual([
         expect.stringContaining("keymap lhs contains protected key ctrl+p"),
         expect.stringContaining("keymap lhs contains protected key ctrl+p"),
@@ -321,10 +364,178 @@ export default (vim) => {
     try {
       f.write(`export default (vim) => vim.keymap.set("i", "aa", "bb");`);
       const result = await loadVimJsConfig(f.path);
-      expect(result.partial).toEqual({});
+      expect(operations(result)).toEqual([]);
       expect(result.warnings).toEqual([
         "global JS config: string rhs keymaps only support normal and visual modes",
       ]);
+    } finally {
+      f.cleanup();
+    }
+  });
+
+  test("unknown leaf writes warn without discarding valid staged siblings", async () => {
+    const f = fixture();
+    try {
+      f.write(`
+export default (vim) => {
+  vim.g.mapleader = ",";
+  vim.g.unknown = true;
+  vim.keymap.set("n", "zq", vim.prompt.quote());
+};
+`);
+      const loaded = await loadVimJsConfig(f.path);
+      expect(loaded.warnings).toEqual(["global JS config: unknown vim.g property unknown"]);
+      expect(operations(loaded)).toEqual([
+        { kind: "leaf", path: "leader", value: "," },
+        {
+          kind: "map",
+          mapping: {
+            kind: "action",
+            actionId: "prompt.transform.quote",
+            key: "zq",
+            args: undefined,
+            modes: ["normal"],
+          },
+        },
+      ]);
+    } finally {
+      f.cleanup();
+    }
+  });
+
+  test("re-evaluates root config on every load", async () => {
+    const f = fixture();
+    const loadKey = "__piVimModeRootLoadCount";
+    try {
+      f.write(`
+export default (vim) => {
+  globalThis[${JSON.stringify(loadKey)}] = (globalThis[${JSON.stringify(loadKey)}] ?? 0) + 1;
+  vim.g.mapleader = globalThis[${JSON.stringify(loadKey)}] === 1 ? "," : " ";
+};
+`);
+      const first = await loadVimJsConfig(f.path);
+      const second = await loadVimJsConfig(f.path);
+      expect(operations(first)).toEqual([{ kind: "leaf", path: "leader", value: "," }]);
+      expect(operations(second)).toEqual([{ kind: "leaf", path: "leader", value: " " }]);
+    } finally {
+      Reflect.deleteProperty(globalThis, loadKey);
+      f.cleanup();
+    }
+  });
+
+  test("returns fatal results without staged operations after import or export failure", async () => {
+    const importFailure = fixture();
+    const syntaxFailure = fixture();
+    const exportFailure = fixture();
+    try {
+      importFailure.write(`import "./missing-helper.js"; export default () => {};`);
+      const failedImport = await loadVimJsConfig(importFailure.path);
+      expect(failedImport.kind).toBe("fatal");
+      expect(failedImport.warnings[0]).toContain("failed to load");
+
+      syntaxFailure.write(`export default (`);
+      const failedSyntax = await loadVimJsConfig(syntaxFailure.path);
+      expect(failedSyntax.kind).toBe("fatal");
+      expect(failedSyntax.warnings[0]).toContain("failed to load");
+
+      exportFailure.write(`
+export default async (vim) => {
+  vim.g.mapleader = ",";
+  await Promise.resolve();
+  throw new Error("export failure");
+};
+`);
+      const failedExport = await loadVimJsConfig(exportFailure.path);
+      expect(failedExport).toEqual({
+        kind: "fatal",
+        warnings: ["global JS config: failed to load (export failure)"],
+      });
+
+      const resolved = resolveVimOptions(
+        { piVimMode: { startMode: "normal" } },
+        { piVimMode: { leader: " " } },
+        failedExport,
+      );
+      expect(resolved.options.startMode).toBe("normal");
+      expect(resolved.options.leader).toBe(" ");
+      expect(resolved.options.keymap?.actions.accepted).toEqual([]);
+    } finally {
+      importFailure.cleanup();
+      syntaxFailure.cleanup();
+      exportFailure.cleanup();
+    }
+  });
+
+  test("closes retained APIs after synchronous and asynchronous exports", async () => {
+    for (const asyncExport of [false, true]) {
+      const f = fixture();
+      const retainedKey = `__piVimModeRetained${asyncExport}`;
+      try {
+        f.write(`
+export default ${asyncExport ? "async " : ""}(vim) => {
+  globalThis[${JSON.stringify(retainedKey)}] = vim;
+  vim.g.mapleader = ",";
+  ${asyncExport ? "return Promise.resolve();" : ""}
+};
+`);
+        const loaded = await loadVimJsConfig(f.path);
+        const retained = Reflect.get(globalThis, retainedKey) as {
+          g: { mapleader: string | null };
+          keymap: { set(mode: string, lhs: string, rhs: string): void };
+        };
+        expect(() => {
+          retained.g.mapleader = " ";
+        }).toThrow("config session closed");
+        expect(() => retained.keymap.set("n", "zq", "q")).toThrow("config session closed");
+        expect(operations(loaded)).toEqual([{ kind: "leaf", path: "leader", value: "," }]);
+      } finally {
+        Reflect.deleteProperty(globalThis, retainedKey);
+        f.cleanup();
+      }
+    }
+  });
+
+  test("closes synchronous exports before queued writes run", async () => {
+    const f = fixture();
+    const errorKey = "__piVimModeQueuedWriteError";
+    try {
+      f.write(`
+export default (vim) => {
+  vim.g.mapleader = ",";
+  queueMicrotask(() => {
+    try {
+      vim.g.mapleader = " ";
+    } catch (error) {
+      globalThis[${JSON.stringify(errorKey)}] = error.message;
+    }
+  });
+};
+`);
+      const loaded = await loadVimJsConfig(f.path);
+      expect(Reflect.get(globalThis, errorKey)).toBe("config session closed");
+      expect(operations(loaded)).toEqual([{ kind: "leaf", path: "leader", value: "," }]);
+    } finally {
+      Reflect.deleteProperty(globalThis, errorKey);
+      f.cleanup();
+    }
+  });
+
+  test("uses global JSON leader as staged read seed and freezes operation snapshots", async () => {
+    const f = fixture();
+    try {
+      f.write(`
+export default (vim) => {
+  if (vim.g.mapleader !== ",") throw new Error("missing global seed");
+  vim.keymap.set("n", "zq", vim.prompt.quote());
+};
+`);
+      const loaded = await loadVimJsConfig(f.path, { leader: "," });
+      const stagedOperations = operations(loaded);
+      expect(Object.isFrozen(stagedOperations)).toBe(true);
+      expect(Object.isFrozen(stagedOperations[0])).toBe(true);
+      expect(
+        Object.isFrozen(stagedOperations[0]?.kind === "map" ? stagedOperations[0].mapping : {}),
+      ).toBe(true);
     } finally {
       f.cleanup();
     }

--- a/test/config-js.test.ts
+++ b/test/config-js.test.ts
@@ -466,13 +466,41 @@ export default (vim) => {
       const resolved = resolveVimOptions(
         {
           piVimMode: {
-            keymap: { actions: { "prompt.transform.quote": [{ key: "zq", modes: ["normal"] }] } },
+            keymap: { actions: { "prompt.transform.quote": [{ key: "zq" }] } },
           },
         },
         undefined,
         loaded,
       );
-      expect(resolved.options.keymap?.actions.accepted).toEqual([]);
+      expect(resolved.options.keymap?.actions.accepted).toEqual([
+        {
+          actionId: "prompt.transform.quote",
+          key: "zq",
+          args: { action: "quote" },
+          modes: ["visual", "visualLine", "visualBlock"],
+        },
+      ]);
+    } finally {
+      f.cleanup();
+    }
+  });
+
+  test("keeps mappings declared after an unmap", async () => {
+    const f = fixture();
+    try {
+      f.write(`export default (vim) => {
+  vim.keymap.set("n", "zq", null);
+  vim.keymap.set("n", "zq", vim.prompt.quote());
+};`);
+      const resolved = resolveVimOptions(undefined, undefined, await loadVimJsConfig(f.path));
+      expect(resolved.options.keymap?.actions.accepted).toEqual([
+        {
+          actionId: "prompt.transform.quote",
+          key: "zq",
+          args: { action: "quote" },
+          modes: ["normal"],
+        },
+      ]);
     } finally {
       f.cleanup();
     }
@@ -562,6 +590,9 @@ export default ${asyncExport ? "async " : ""}(vim) => {
           retained.g.mapleader = " ";
         }).toThrow("config session closed");
         expect(() => retained.keymap.set("n", "zq", "q")).toThrow("config session closed");
+        expect(() => Object.defineProperty(retained.g, "mapleader", { value: " " })).toThrow(
+          "config session closed",
+        );
         expect(operations(loaded)).toEqual([{ kind: "leaf", path: "leader", value: "," }]);
       } finally {
         Reflect.deleteProperty(globalThis, retainedKey);


### PR DESCRIPTION
## Summary

Adds trusted JavaScript config evaluated as an all-or-nothing transaction, preventing failed config from partially changing active Vim settings.

## Changes

- Stage presets, mappings, remaps, and scoped unmaps until evaluation succeeds.
- Preserve declaration order and remove inherited mappings for selected mode/scope unmaps.
- Invalidate retained config APIs after evaluation.
- Add release note and durable solution documentation.

## Testing

- [x] `bun test` passes (771 tests)
- [x] `bun run check-types` passes
- [x] `bun run lint` passes
- [x] Manually tested in Pi

## Related Issues

Closes #36