### PR TITLE
feat: compile immutable scoped config plans

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -2,7 +2,7 @@
 
 ## What's new
 
-- Added trusted JavaScript configuration via `~/.pi/agent/pi-vimmode.config.js`. Configure presets, leader, prompt actions, insert actions, replay mappings, and scoped unmaps with a small `vim` API. Configuration writes are staged atomically, so failed config files leave existing settings unchanged.
+- Added trusted JavaScript configuration via `~/.pi/agent/pi-vimmode.config.js`. Configure presets, leader, prompt actions, insert actions, replay mappings, and scoped unmaps with a small `vim` API. Configuration writes are staged atomically, then defaults, global JSON, JavaScript, and project JSON compile into one immutable scoped plan before activation. Failed config files leave existing settings unchanged.
 
 ```js
 export default (vim) => {

--- a/openspec/changes/ship-pi-vimmode-0-9-0/tasks.md
+++ b/openspec/changes/ship-pi-vimmode-0-9-0/tasks.md
@@ -7,7 +7,7 @@
 ## 2. Trusted Configuration Core
 
 - [ ] 2.1 Implement [#36](https://github.com/pekochan069/pi-vimmode/issues/36): stage trusted JavaScript config as closed source-ordered transaction with frozen reads, field-local warnings, fatal results, exact late-write failure, and legacy API parity. **Blocked by:** #35.
-- [ ] 2.2 Implement [#37](https://github.com/pekochan069/pi-vimmode/issues/37): compile defaults, global JSON, JavaScript operations, and project JSON into one immutable scoped plan with final leader and project authority. **Blocked by:** #35 and #36.
+- [x] 2.2 Implement [#37](https://github.com/pekochan069/pi-vimmode/issues/37): compile defaults, global JSON, JavaScript operations, and project JSON into one immutable scoped plan with final leader and project authority. **Blocked by:** #35 and #36.
 
 ## 3. Public Config Behavior and Reload
 

--- a/openspec/changes/ship-pi-vimmode-0-9-0/tasks.md
+++ b/openspec/changes/ship-pi-vimmode-0-9-0/tasks.md
@@ -6,7 +6,7 @@
 
 ## 2. Trusted Configuration Core
 
-- [ ] 2.1 Implement [#36](https://github.com/pekochan069/pi-vimmode/issues/36): stage trusted JavaScript config as closed source-ordered transaction with frozen reads, field-local warnings, fatal results, exact late-write failure, and legacy API parity. **Blocked by:** #35.
+- [x] 2.1 Implement [#36](https://github.com/pekochan069/pi-vimmode/issues/36): stage trusted JavaScript config as closed source-ordered transaction with frozen reads, field-local warnings, fatal results, exact late-write failure, and legacy API parity. **Blocked by:** #35.
 - [x] 2.2 Implement [#37](https://github.com/pekochan069/pi-vimmode/issues/37): compile defaults, global JSON, JavaScript operations, and project JSON into one immutable scoped plan with final leader and project authority. **Blocked by:** #35 and #36.
 
 ## 3. Public Config Behavior and Reload

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -461,11 +461,10 @@ function exactBinding(
   mode?: VimActionBindingMode,
 ): Binding | undefined {
   const compiled = compiledKeymapFor(keymap);
-  const binding = compiled.exactBindings.get(sequence);
-  if (binding) return binding;
-  return compiled.actionBindings
+  const action = compiled.actionBindings
     .get(sequence)
-    ?.find((action) => actionBindingMatchesMode(action, mode));
+    ?.find((binding) => actionBindingMatchesMode(binding, mode));
+  return action ?? compiled.exactBindings.get(sequence);
 }
 
 function hasLongerPrefix(

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -27,6 +27,7 @@ import {
   KEYMAP_OPERATOR_DESCRIPTORS,
 } from "./keymap-descriptors.ts";
 import { grammarEntriesForKeymap } from "./keymap-grammar.ts";
+import { isAtomicMappingSequence } from "./mapping-scopes.ts";
 
 const LEGACY_VIM_OPERATORS = new Set<string>(
   Object.keys(deriveLegacyKeyToAction(KEYMAP_OPERATOR_DESCRIPTORS)),
@@ -263,6 +264,7 @@ function lineCommandFor(operator: VimOperator): NormalCommand {
 }
 
 function addLongerPrefixes(prefixes: Set<string>, sequence: string): void {
+  if (isAtomicMappingSequence(sequence)) return;
   for (let index = 1; index < sequence.length; index += 1) prefixes.add(sequence.slice(0, index));
 }
 
@@ -275,6 +277,7 @@ function addActionBinding(bindings: Map<string, ActionBinding[]>, binding: Actio
 }
 
 function addActionPrefixes(prefixes: Map<string, ActionBinding[]>, binding: ActionBinding): void {
+  if (isAtomicMappingSequence(binding.sequence)) return;
   for (let index = 1; index < binding.sequence.length; index += 1) {
     const prefix = binding.sequence.slice(0, index);
     prefixes.set(prefix, [...(prefixes.get(prefix) ?? []), binding]);
@@ -307,11 +310,6 @@ function compiledKeymapFor(keymap: ResolvedVimKeymap): CompiledKeymap {
   const compiled = compileKeymap(keymap);
   COMPILED_KEYMAPS.set(keymap, compiled);
   return compiled;
-}
-
-function isAtomicKeySequence(sequence: string): boolean {
-  // Arrow-key aliases arrive as complete terminal escape sequences, never character-by-character.
-  return sequence === "left" || sequence === "down" || sequence === "up" || sequence === "right";
 }
 
 function compileKeymap(keymap: ResolvedVimKeymap): CompiledKeymap {
@@ -358,10 +356,8 @@ function compileKeymap(keymap: ResolvedVimKeymap): CompiledKeymap {
         kind: "motion",
         motion: entry.id,
       });
-      if (!isAtomicKeySequence(entry.sequence)) {
-        addLongerPrefixes(longerPrefixes, entry.sequence);
-        addLongerPrefixes(motionLongerPrefixes, entry.sequence);
-      }
+      addLongerPrefixes(longerPrefixes, entry.sequence);
+      addLongerPrefixes(motionLongerPrefixes, entry.sequence);
     } else if (entry.family === "command") {
       setFirstBinding(exactBindings, {
         sequence: entry.sequence,

--- a/src/config-metadata.ts
+++ b/src/config-metadata.ts
@@ -11,18 +11,10 @@ import {
   KEYMAP_TEXT_OBJECT_KIND_DESCRIPTORS,
   KEYMAP_TEXT_OBJECT_TARGET_DESCRIPTORS,
 } from "./keymap-descriptors.ts";
+import { mappingScopesForKeymapEntry, type VimMappingScope } from "./mapping-scopes.ts";
 import { PROMPT_TRANSFORM_ACTIONS } from "./prompt-transform-actions.ts";
 
-export const VIM_MAPPING_SCOPES = [
-  "normal",
-  "visual",
-  "visualLine",
-  "visualBlock",
-  "insert",
-  "operatorPending",
-] as const;
-
-export type VimMappingScope = (typeof VIM_MAPPING_SCOPES)[number];
+export { VIM_MAPPING_SCOPES, type VimMappingScope } from "./mapping-scopes.ts";
 
 type ActionSource = "keymap-descriptor" | "prompt-transform-registry" | "diagnostic-registry";
 
@@ -34,41 +26,28 @@ export type VimActionMetadata = {
   bindable: boolean;
 };
 
-const VISUAL_SCOPES = ["visual", "visualLine", "visualBlock"] as const;
-const NORMAL_AND_VISUAL_SCOPES = ["normal", ...VISUAL_SCOPES] as const;
 function descriptorMetadata(
   family: string,
   descriptors: Record<string, { defaults: readonly string[] }>,
-  scopes: (action: string) => readonly VimMappingScope[],
 ): VimActionMetadata[] {
   return Object.entries(descriptors).map(([action, descriptor]) => ({
     id: `${family}.${action}`,
     source: "keymap-descriptor",
     defaults: descriptor.defaults,
-    scopes: scopes(action),
+    scopes: mappingScopesForKeymapEntry(family, action),
     bindable: true,
   }));
 }
 
 export const VIM_ACTION_METADATA: readonly VimActionMetadata[] = [
-  ...descriptorMetadata("operator", KEYMAP_OPERATOR_DESCRIPTORS, () => NORMAL_AND_VISUAL_SCOPES),
-  ...descriptorMetadata("motion", KEYMAP_MOTION_DESCRIPTORS, (action) =>
-    action === "halfPageDown" || action === "halfPageUp"
-      ? NORMAL_AND_VISUAL_SCOPES
-      : [...NORMAL_AND_VISUAL_SCOPES, "operatorPending"],
-  ),
-  ...descriptorMetadata("command", KEYMAP_COMMAND_DESCRIPTORS, () => ["normal"]),
-  ...descriptorMetadata("macro", KEYMAP_MACRO_DESCRIPTORS, () => ["normal"]),
-  ...descriptorMetadata("mark", KEYMAP_MARK_DESCRIPTORS, (action) =>
-    action === "set" ? NORMAL_AND_VISUAL_SCOPES : [...NORMAL_AND_VISUAL_SCOPES, "operatorPending"],
-  ),
-  ...descriptorMetadata("insert", KEYMAP_INSERT_DESCRIPTORS, () => ["insert"]),
-  ...descriptorMetadata("textObject.kind", KEYMAP_TEXT_OBJECT_KIND_DESCRIPTORS, () => [
-    "operatorPending",
-  ]),
-  ...descriptorMetadata("textObject.target", KEYMAP_TEXT_OBJECT_TARGET_DESCRIPTORS, () => [
-    "operatorPending",
-  ]),
+  ...descriptorMetadata("operator", KEYMAP_OPERATOR_DESCRIPTORS),
+  ...descriptorMetadata("motion", KEYMAP_MOTION_DESCRIPTORS),
+  ...descriptorMetadata("command", KEYMAP_COMMAND_DESCRIPTORS),
+  ...descriptorMetadata("macro", KEYMAP_MACRO_DESCRIPTORS),
+  ...descriptorMetadata("mark", KEYMAP_MARK_DESCRIPTORS),
+  ...descriptorMetadata("insert", KEYMAP_INSERT_DESCRIPTORS),
+  ...descriptorMetadata("textObject.kind", KEYMAP_TEXT_OBJECT_KIND_DESCRIPTORS),
+  ...descriptorMetadata("textObject.target", KEYMAP_TEXT_OBJECT_TARGET_DESCRIPTORS),
   ...PROMPT_TRANSFORM_ACTIONS.map(({ id, modes }) => ({
     id,
     source: "prompt-transform-registry" as const,

--- a/src/config-metadata.ts
+++ b/src/config-metadata.ts
@@ -11,7 +11,11 @@ import {
   KEYMAP_TEXT_OBJECT_KIND_DESCRIPTORS,
   KEYMAP_TEXT_OBJECT_TARGET_DESCRIPTORS,
 } from "./keymap-descriptors.ts";
-import { mappingScopesForKeymapEntry, type VimMappingScope } from "./mapping-scopes.ts";
+import {
+  mappingScopesForKeymapEntry,
+  type VimMappingFamily,
+  type VimMappingScope,
+} from "./mapping-scopes.ts";
 import { PROMPT_TRANSFORM_ACTIONS } from "./prompt-transform-actions.ts";
 
 export { VIM_MAPPING_SCOPES, type VimMappingScope } from "./mapping-scopes.ts";
@@ -27,7 +31,7 @@ export type VimActionMetadata = {
 };
 
 function descriptorMetadata(
-  family: string,
+  family: VimMappingFamily,
   descriptors: Record<string, { defaults: readonly string[] }>,
 ): VimActionMetadata[] {
   return Object.entries(descriptors).map(([action, descriptor]) => ({

--- a/src/config.ts
+++ b/src/config.ts
@@ -61,7 +61,16 @@ import {
   KEYMAP_TEXT_OBJECT_KIND_DESCRIPTORS,
   KEYMAP_TEXT_OBJECT_TARGET_DESCRIPTORS,
 } from "./keymap-descriptors.ts";
-import { grammarBindingsForKeymap, grammarConflictForActionKey } from "./keymap-grammar.ts";
+import {
+  grammarBindingsForKeymap,
+  grammarConflictForActionKey,
+  grammarEntriesForKeymap,
+} from "./keymap-grammar.ts";
+import {
+  mappingScopesForKeymapEntry,
+  VIM_MAPPING_SCOPES,
+  type VimMappingScope,
+} from "./mapping-scopes.ts";
 import {
   PROMPT_TRANSFORM_ACTIONS as PROMPT_TRANSFORM_ACTION_REGISTRY,
   bindablePromptTransformActionIds,
@@ -354,9 +363,32 @@ type PartialPromptTransformOptions = {
 
 type PartialUiOptions = VimUiEditorOptions;
 
+export type VimPlanBinding =
+  | { readonly kind: "keymap"; readonly id: string }
+  | { readonly kind: "escape"; readonly id: "escape" }
+  | { readonly kind: "insert"; readonly id: string }
+  | {
+      readonly kind: "action";
+      readonly id: BindablePromptTransformActionId;
+      readonly args: ResolvedVimActionBinding["args"];
+    }
+  | { readonly kind: "remap"; readonly id: "remap"; readonly inputs: readonly string[] };
+
+export type VimScopeLookup = {
+  readonly exact: Readonly<Record<string, VimPlanBinding>>;
+  readonly prefixes: Readonly<Record<string, readonly string[]>>;
+};
+
+export type VimConfigPlan = {
+  readonly options: ResolvedVimEditorOptions;
+  readonly diagnostics: { readonly warnings: readonly string[] };
+  readonly scopes: Readonly<Record<VimMappingScope, VimScopeLookup>>;
+};
+
 export type VimConfigLoadResult = {
+  plan: VimConfigPlan;
   options: ResolvedVimEditorOptions;
-  warnings: string[];
+  warnings: readonly string[];
 };
 
 export type VimConfigPaths = {
@@ -1759,6 +1791,45 @@ function keymapOverlayFromLayers(layers: readonly PartialKeymapOptions[]): Parti
   return overlay;
 }
 
+function projectExactMappings(
+  keymap: PartialKeymapOptions,
+): Array<{ key: string; modes: readonly VimMode[] }> {
+  const mappings: Array<{ key: string; modes: readonly VimMode[] }> = [];
+  const addRecord = (
+    record: Partial<Record<string, readonly string[]>> | undefined,
+    modes: readonly VimMode[],
+  ) => {
+    for (const bindings of Object.values(record ?? {})) {
+      for (const key of bindings ?? []) mappings.push({ key, modes });
+    }
+  };
+
+  addRecord(keymap.operators, ACTION_BINDING_MODES);
+  addRecord(keymap.motions, ACTION_BINDING_MODES);
+  addRecord(keymap.commands, ["normal"]);
+  addRecord(keymap.macros, ["normal"]);
+  addRecord(keymap.marks, ACTION_BINDING_MODES);
+  addRecord(keymap.insert, ["insert"]);
+  for (const bindings of Object.values(keymap.actions ?? {})) {
+    for (const binding of bindings ?? []) {
+      mappings.push({ key: binding.key, modes: binding.modes ?? ACTION_BINDING_MODES });
+    }
+  }
+  for (const remap of keymap.remaps?.accepted ?? []) {
+    mappings.push({ key: remap.key, modes: remap.modes ?? ACTION_BINDING_MODES });
+  }
+  return mappings;
+}
+
+function applyProjectExactPrecedence(
+  lowerLayers: readonly PartialKeymapOptions[],
+  project: PartialKeymapOptions,
+): void {
+  for (const mapping of projectExactMappings(project)) {
+    for (const layer of lowerLayers) removeJsMappings(layer, mapping.key, mapping.modes);
+  }
+}
+
 type ExpandedLeaderSequence = { sequence?: string; usesLeader: boolean };
 type LeaderExpansionContext = {
   leader: string | undefined;
@@ -2119,6 +2190,24 @@ function resolveActionBindings(
     if (reason) conflicts.set(binding, { rejected: true, reason });
   }
 
+  const acceptedPrefixBindings: ResolvedVimActionBinding[] = [];
+  for (const binding of candidates) {
+    if (conflicts.get(binding)?.rejected) continue;
+    const prior = acceptedPrefixBindings.find(
+      (candidate) =>
+        actionModesOverlap(binding.modes, candidate.modes) &&
+        hasStrictPrefixConflict(binding.key, candidate.key),
+    );
+    if (prior) {
+      conflicts.set(binding, {
+        rejected: true,
+        reason: `strict-prefix conflict with ${prior.actionId}.${prior.key}`,
+      });
+    } else {
+      acceptedPrefixBindings.push(binding);
+    }
+  }
+
   const accepted: ResolvedVimActionBinding[] = [];
   for (const binding of candidates) {
     const conflict = conflicts.get(binding);
@@ -2348,12 +2437,14 @@ function partialFromJsOperations(operations: readonly VimJsConfigOperation[]): V
     }
     const mapping = operation.mapping;
     if (mapping.kind === "insert") {
+      removeJsMappings(keymap as PartialKeymapOptions, mapping.key, ["insert"]);
       restoreJsUnmaps(keymap as PartialKeymapOptions, mapping.key, ["insert"]);
       const insert = (keymap.insert ??= {});
       insert[mapping.action] = [...(insert[mapping.action] ?? []), mapping.key];
       continue;
     }
     if (mapping.kind === "action") {
+      removeJsMappings(keymap as PartialKeymapOptions, mapping.key, mapping.modes);
       restoreJsUnmaps(keymap as PartialKeymapOptions, mapping.key, mapping.modes);
       const actions = (keymap.actions ??= {});
       actions[mapping.actionId] = [
@@ -2362,6 +2453,7 @@ function partialFromJsOperations(operations: readonly VimJsConfigOperation[]): V
       ];
       continue;
     }
+    removeJsMappings(keymap as PartialKeymapOptions, mapping.key, mapping.modes);
     restoreJsUnmaps(keymap as PartialKeymapOptions, mapping.key, mapping.modes);
     const remaps = (keymap.remaps ??= { accepted: [] });
     remaps.accepted = [
@@ -2381,6 +2473,124 @@ function compileJsConfig(jsConfig: Parameters<typeof resolveVimOptions>[2]): {
     source: compiled ?? jsConfig?.partial,
     unmaps: (compiled?.keymap as PartialKeymapOptions | undefined)?.unmaps,
   };
+}
+
+function deepFreeze<T>(value: T): T {
+  if (!value || typeof value !== "object" || Object.isFrozen(value)) return value;
+  for (const child of Object.values(value)) deepFreeze(child);
+  return Object.freeze(value);
+}
+
+function isAtomicMapping(sequence: string): boolean {
+  return sequence.includes("+") || ["left", "down", "up", "right"].includes(sequence);
+}
+
+function hasStrictPrefixConflict(left: string, right: string): boolean {
+  return (
+    left !== right &&
+    !isAtomicMapping(left) &&
+    !isAtomicMapping(right) &&
+    (left.startsWith(right) || right.startsWith(left))
+  );
+}
+
+export function createVimConfigPlan(
+  options: ResolvedVimEditorOptions,
+  warnings: readonly string[],
+): VimConfigPlan {
+  const candidates = Object.fromEntries(
+    VIM_MAPPING_SCOPES.map((scope) => [
+      scope,
+      [] as Array<{ sequence: string; binding: VimPlanBinding }>,
+    ]),
+  ) as Record<VimMappingScope, Array<{ sequence: string; binding: VimPlanBinding }>>;
+  const keymap = options.keymap ?? DEFAULT_VIM_KEYMAP;
+  const add = (scopes: readonly VimMappingScope[], sequence: string, binding: VimPlanBinding) => {
+    for (const scope of scopes) candidates[scope].push({ sequence, binding });
+  };
+
+  for (const entry of grammarEntriesForKeymap(keymap)) {
+    add(mappingScopesForKeymapEntry(entry.family, entry.id), entry.sequence, {
+      kind: "keymap",
+      id: `${entry.family}.${entry.id}`,
+    });
+  }
+  for (const sequence of keymap.escape) {
+    add(["insert", "visual", "visualLine", "visualBlock", "operatorPending"], sequence, {
+      kind: "escape",
+      id: "escape",
+    });
+  }
+  for (const [action, sequences] of Object.entries(keymap.insert)) {
+    for (const sequence of sequences) add(["insert"], sequence, { kind: "insert", id: action });
+  }
+  for (const binding of keymap.actions.accepted) {
+    add(binding.modes ?? ACTION_BINDING_MODES, binding.key, {
+      kind: "action",
+      id: binding.actionId,
+      args: binding.args,
+    });
+  }
+  for (const remap of keymap.remaps.accepted) {
+    add(remap.modes ?? ACTION_BINDING_MODES, remap.key, {
+      kind: "remap",
+      id: "remap",
+      inputs: remap.inputs,
+    });
+  }
+
+  const compileWarnings = [...warnings];
+  const scopes = Object.fromEntries(
+    VIM_MAPPING_SCOPES.map((scope) => {
+      const exact = Object.create(null) as Record<string, VimPlanBinding>;
+      for (const candidate of candidates[scope]) {
+        const strictPrefix = Object.keys(exact).find((sequence) =>
+          hasStrictPrefixConflict(sequence, candidate.sequence),
+        );
+        if (strictPrefix) {
+          const warning = `resolved settings: rejected ${candidate.binding.id}.${candidate.sequence} in ${scope}: strict-prefix conflict with ${exact[strictPrefix]!.id}.${strictPrefix}`;
+          if (!compileWarnings.includes(warning)) compileWarnings.push(warning);
+          continue;
+        }
+        exact[candidate.sequence] = candidate.binding;
+      }
+
+      const prefixes = Object.create(null) as Record<string, string[]>;
+      for (const sequence of Object.keys(exact)) {
+        if (isAtomicMapping(sequence)) continue;
+        for (let index = 1; index < sequence.length; index += 1) {
+          const prefix = sequence.slice(0, index);
+          (prefixes[prefix] ??= []).push(sequence);
+        }
+      }
+      return [scope, { exact, prefixes }];
+    }),
+  ) as unknown as Record<VimMappingScope, VimScopeLookup>;
+
+  const frozenOptions = deepFreeze(options);
+  return deepFreeze({
+    options: frozenOptions,
+    diagnostics: { warnings: compileWarnings },
+    scopes,
+  });
+}
+
+function applyProjectLayer(
+  options: ResolvedVimEditorOptions,
+  keymapLayers: PartialKeymapOptions[],
+  project: PartialVimOptions,
+): void {
+  if (project.preset) {
+    const preset = presetOptions(project.preset);
+    mergePartialOptions(options, preset);
+    if (preset.keymap) {
+      applyProjectExactPrecedence(keymapLayers, preset.keymap);
+      keymapLayers.push(preset.keymap);
+    }
+  }
+  if (project.keymap) applyProjectExactPrecedence(keymapLayers, project.keymap);
+  mergePartialOptions(options, project);
+  if (project.keymap) keymapLayers.push(project.keymap);
 }
 
 export function resolveVimOptions(
@@ -2434,13 +2644,7 @@ export function resolveVimOptions(
 
   const projectPiVimMode = isRecord(projectSettings) ? projectSettings.piVimMode : undefined;
   const parsedProject = parsePiVimMode(projectPiVimMode, "project settings");
-  if (parsedProject.partial.preset) {
-    const preset = presetOptions(parsedProject.partial.preset);
-    mergePartialOptions(options, preset);
-    if (preset.keymap) keymapLayers.push(preset.keymap);
-  }
-  mergePartialOptions(options, parsedProject.partial);
-  if (parsedProject.partial.keymap) keymapLayers.push(parsedProject.partial.keymap);
+  applyProjectLayer(options, keymapLayers, parsedProject.partial);
   let keymapResolution: ReturnType<typeof resolveKeymapFromLayers> | undefined;
   if (keymapLayers.length > 0) {
     keymapResolution = resolveKeymapFromLayers(keymapLayers, options.leader);
@@ -2476,7 +2680,8 @@ export function resolveVimOptions(
   warnings.push(...keymapWarnings, ...actionBindings.warnings);
   warnings.push(...detectKeymapConflicts(keymap));
 
-  return { options, warnings };
+  const plan = createVimConfigPlan(options, warnings);
+  return { plan, options: plan.options, warnings: plan.diagnostics.warnings };
 }
 
 function readJsonFile(
@@ -2516,10 +2721,9 @@ export async function loadVimOptions(paths: VimConfigPaths = {}): Promise<VimCon
   const jsRead = await loadVimJsConfig(jsConfigPath, { leader: globalSeed.leader });
   const resolved = resolveVimOptions(globalRead.settings, projectRead.settings, jsRead);
 
-  return {
-    options: resolved.options,
-    warnings: [...globalRead.warnings, ...projectRead.warnings, ...resolved.warnings],
-  };
+  const warnings = [...globalRead.warnings, ...projectRead.warnings, ...resolved.warnings];
+  const plan = createVimConfigPlan(resolved.options, warnings);
+  return { plan, options: plan.options, warnings: plan.diagnostics.warnings };
 }
 
 export function keymapForOptions(options: ResolvedVimEditorOptions): ResolvedVimKeymap {

--- a/src/config.ts
+++ b/src/config.ts
@@ -389,6 +389,7 @@ export type VimConfigLoadResult = {
   plan: VimConfigPlan;
   options: ResolvedVimEditorOptions;
   warnings: readonly string[];
+  fatal?: boolean;
 };
 
 export type VimConfigPaths = {
@@ -1791,10 +1792,8 @@ function keymapOverlayFromLayers(layers: readonly PartialKeymapOptions[]): Parti
   return overlay;
 }
 
-function projectExactMappings(
-  keymap: PartialKeymapOptions,
-): Array<{ key: string; modes: readonly VimMode[] }> {
-  const mappings: Array<{ key: string; modes: readonly VimMode[] }> = [];
+function projectExactMappings(keymap: PartialKeymapOptions): ProjectExactMapping[] {
+  const mappings: ProjectExactMapping[] = [];
   const addRecord = (
     record: Partial<Record<string, readonly string[]>> | undefined,
     modes: readonly VimMode[],
@@ -2118,14 +2117,18 @@ function mergeUi(target: ResolvedVimUi, partial: PartialUiOptions): void {
   if (partial.workbench) target.workbench = { ...target.workbench, ...partial.workbench };
 }
 
-type ActionBindingConflict = { rejected: boolean; reason?: string };
+type ProjectExactMapping = { key: string; modes: readonly VimMode[] };
 
-function actionModesOverlap(
-  left: readonly VimActionBindingMode[] | undefined,
-  right: readonly VimActionBindingMode[] | undefined,
+function actionBindingModes(binding: ResolvedVimActionBinding): readonly VimActionBindingMode[] {
+  return binding.modes ?? ACTION_BINDING_MODES;
+}
+
+function projectClaimsExactMapping(
+  mappings: readonly ProjectExactMapping[],
+  key: string,
+  mode: VimActionBindingMode,
 ): boolean {
-  if (!left || !right) return true;
-  return left.some((mode) => right.includes(mode));
+  return mappings.some((mapping) => mapping.key === key && mapping.modes.includes(mode));
 }
 
 function disabledActionReason(
@@ -2141,83 +2144,111 @@ function disabledActionReason(
   return undefined;
 }
 
+function rejectedActionWarning(
+  binding: ResolvedVimActionBinding,
+  mode: VimActionBindingMode,
+  reason: string,
+): string {
+  return `resolved settings: rejected piVimMode.keymap.actions.${binding.actionId}.${binding.key} in ${mode}: ${reason}`;
+}
+
 function resolveActionBindings(
   keymap: ResolvedVimKeymap,
   promptTransforms: ResolvedVimPromptTransforms,
+  projectExactMappings: readonly ProjectExactMapping[] = [],
 ): { accepted: ResolvedVimActionBinding[]; warnings: string[] } {
   const warnings: string[] = [];
   const candidates: ResolvedVimActionBinding[] = [];
   const seenSameAction = new Set<string>();
   for (const binding of keymap.actions.accepted) {
-    const modes = [...(binding.modes ?? [])].sort().join(",");
+    const modes = [...actionBindingModes(binding)].sort().join(",");
     const dedupeKey = `${binding.actionId}\0${binding.key}\0${modes}\0${JSON.stringify(binding.args ?? {})}`;
     if (seenSameAction.has(dedupeKey)) continue;
     seenSameAction.add(dedupeKey);
     candidates.push(binding);
   }
 
-  const conflicts = new Map<ResolvedVimActionBinding, ActionBindingConflict>();
-  const byKey = new Map<string, ResolvedVimActionBinding[]>();
-  for (const binding of candidates) {
-    byKey.set(binding.key, [...(byKey.get(binding.key) ?? []), binding]);
-  }
+  const rejected = new Map<ResolvedVimActionBinding, Map<VimActionBindingMode, string>>();
+  const reject = (
+    binding: ResolvedVimActionBinding,
+    mode: VimActionBindingMode,
+    reason: string,
+  ) => {
+    const reasons = rejected.get(binding) ?? new Map<VimActionBindingMode, string>();
+    reasons.set(mode, reason);
+    rejected.set(binding, reasons);
+  };
+  const isRejected = (binding: ResolvedVimActionBinding, mode: VimActionBindingMode) =>
+    rejected.get(binding)?.has(mode) ?? false;
 
   for (const binding of candidates) {
     const reason = disabledActionReason(binding.actionId, promptTransforms);
-    if (reason) conflicts.set(binding, { rejected: true, reason });
+    if (reason) for (const mode of actionBindingModes(binding)) reject(binding, mode, reason);
   }
-  for (const [key, bindings] of byKey) {
-    const conflicting = bindings.filter((binding, index) =>
-      bindings.some(
-        (other, otherIndex) =>
-          otherIndex !== index &&
-          binding.actionId !== other.actionId &&
-          actionModesOverlap(binding.modes, other.modes),
-      ),
-    );
-    if (conflicting.length === 0) continue;
-    const ids = [...new Set(bindings.map((binding) => binding.actionId))].sort();
-    warnings.push(`resolved settings: duplicate action key ${key} for ${ids.join(" and ")}`);
-    for (const binding of bindings) {
-      conflicts.set(binding, { rejected: true, reason: `duplicate action key ${key}` });
+
+  for (const mode of ACTION_BINDING_MODES) {
+    const byKey = new Map<string, ResolvedVimActionBinding[]>();
+    for (const binding of candidates) {
+      if (!actionBindingModes(binding).includes(mode)) continue;
+      byKey.set(binding.key, [...(byKey.get(binding.key) ?? []), binding]);
+    }
+    for (const [key, bindings] of byKey) {
+      const ids = [...new Set(bindings.map((binding) => binding.actionId))].sort();
+      if (ids.length < 2) continue;
+      warnings.push(
+        `resolved settings: duplicate action key ${key} in ${mode} for ${ids.join(" and ")}`,
+      );
+      for (const binding of bindings) reject(binding, mode, `duplicate action key ${key}`);
     }
   }
 
-  const grammarBindings = grammarBindingsForKeymap(keymap);
+  const grammarEntries = grammarEntriesForKeymap(keymap);
   for (const binding of candidates) {
-    if (conflicts.get(binding)?.rejected) continue;
-    const reason = grammarConflictForActionKey(binding.key, grammarBindings);
-    if (reason) conflicts.set(binding, { rejected: true, reason });
+    for (const mode of actionBindingModes(binding)) {
+      if (isRejected(binding, mode)) continue;
+      const scopedGrammar = grammarEntries.filter((entry) =>
+        mappingScopesForKeymapEntry(entry.family, entry.id).includes(mode),
+      );
+      const exact = scopedGrammar.find((entry) => entry.sequence === binding.key);
+      if (exact && !projectClaimsExactMapping(projectExactMappings, binding.key, mode)) {
+        reject(binding, mode, `conflicts with ${exact.label}`);
+        continue;
+      }
+      const prefix = scopedGrammar.find((entry) =>
+        hasStrictPrefixConflict(entry.sequence, binding.key),
+      );
+      if (prefix) reject(binding, mode, `prefix-shadow conflict with ${prefix.label}`);
+    }
   }
 
-  const acceptedPrefixBindings: ResolvedVimActionBinding[] = [];
-  for (const binding of candidates) {
-    if (conflicts.get(binding)?.rejected) continue;
-    const prior = acceptedPrefixBindings.find(
-      (candidate) =>
-        actionModesOverlap(binding.modes, candidate.modes) &&
-        hasStrictPrefixConflict(binding.key, candidate.key),
-    );
-    if (prior) {
-      conflicts.set(binding, {
-        rejected: true,
-        reason: `strict-prefix conflict with ${prior.actionId}.${prior.key}`,
-      });
-    } else {
-      acceptedPrefixBindings.push(binding);
+  for (const mode of ACTION_BINDING_MODES) {
+    const acceptedInScope: ResolvedVimActionBinding[] = [];
+    for (const binding of candidates) {
+      if (!actionBindingModes(binding).includes(mode) || isRejected(binding, mode)) continue;
+      const prior = strictPrefixConflict(
+        acceptedInScope,
+        binding.key,
+        (candidate) => candidate.key,
+      );
+      if (prior) {
+        reject(binding, mode, `strict-prefix conflict with ${prior.actionId}.${prior.key}`);
+      } else {
+        acceptedInScope.push(binding);
+      }
     }
   }
 
   const accepted: ResolvedVimActionBinding[] = [];
   for (const binding of candidates) {
-    const conflict = conflicts.get(binding);
-    if (conflict?.rejected) {
-      warnings.push(
-        `resolved settings: rejected piVimMode.keymap.actions.${binding.actionId}.${binding.key}: ${conflict.reason}`,
-      );
-      continue;
+    const modes = actionBindingModes(binding);
+    const acceptedModes = modes.filter((mode) => !isRejected(binding, mode));
+    for (const [mode, reason] of rejected.get(binding) ?? []) {
+      warnings.push(rejectedActionWarning(binding, mode, reason));
     }
-    accepted.push(binding);
+    if (acceptedModes.length === 0) continue;
+    accepted.push(
+      acceptedModes.length === modes.length ? binding : { ...binding, modes: acceptedModes },
+    );
   }
   return { accepted, warnings };
 }
@@ -2494,6 +2525,14 @@ function hasStrictPrefixConflict(left: string, right: string): boolean {
   );
 }
 
+function strictPrefixConflict<T>(
+  accepted: readonly T[],
+  sequence: string,
+  getSequence: (candidate: T) => string,
+): T | undefined {
+  return accepted.find((candidate) => hasStrictPrefixConflict(getSequence(candidate), sequence));
+}
+
 export function createVimConfigPlan(
   options: ResolvedVimEditorOptions,
   warnings: readonly string[],
@@ -2544,8 +2583,10 @@ export function createVimConfigPlan(
     VIM_MAPPING_SCOPES.map((scope) => {
       const exact = Object.create(null) as Record<string, VimPlanBinding>;
       for (const candidate of candidates[scope]) {
-        const strictPrefix = Object.keys(exact).find((sequence) =>
-          hasStrictPrefixConflict(sequence, candidate.sequence),
+        const strictPrefix = strictPrefixConflict(
+          Object.keys(exact),
+          candidate.sequence,
+          (sequence) => sequence,
         );
         if (strictPrefix) {
           const warning = `resolved settings: rejected ${candidate.binding.id}.${candidate.sequence} in ${scope}: strict-prefix conflict with ${exact[strictPrefix]!.id}.${strictPrefix}`;
@@ -2579,18 +2620,24 @@ function applyProjectLayer(
   options: ResolvedVimEditorOptions,
   keymapLayers: PartialKeymapOptions[],
   project: PartialVimOptions,
-): void {
+): PartialKeymapOptions[] {
+  const projectLayers: PartialKeymapOptions[] = [];
   if (project.preset) {
     const preset = presetOptions(project.preset);
     mergePartialOptions(options, preset);
     if (preset.keymap) {
       applyProjectExactPrecedence(keymapLayers, preset.keymap);
       keymapLayers.push(preset.keymap);
+      projectLayers.push(preset.keymap);
     }
   }
   if (project.keymap) applyProjectExactPrecedence(keymapLayers, project.keymap);
   mergePartialOptions(options, project);
-  if (project.keymap) keymapLayers.push(project.keymap);
+  if (project.keymap) {
+    keymapLayers.push(project.keymap);
+    projectLayers.push(project.keymap);
+  }
+  return projectLayers;
 }
 
 export function resolveVimOptions(
@@ -2644,7 +2691,7 @@ export function resolveVimOptions(
 
   const projectPiVimMode = isRecord(projectSettings) ? projectSettings.piVimMode : undefined;
   const parsedProject = parsePiVimMode(projectPiVimMode, "project settings");
-  applyProjectLayer(options, keymapLayers, parsedProject.partial);
+  const projectKeymapLayers = applyProjectLayer(options, keymapLayers, parsedProject.partial);
   let keymapResolution: ReturnType<typeof resolveKeymapFromLayers> | undefined;
   if (keymapLayers.length > 0) {
     keymapResolution = resolveKeymapFromLayers(keymapLayers, options.leader);
@@ -2653,11 +2700,13 @@ export function resolveVimOptions(
   }
   warnings.push(...parsedProject.warnings);
 
+  const projectMappings = projectKeymapLayers.flatMap(projectExactMappings);
   let keymap = options.keymap ?? DEFAULT_VIM_KEYMAP;
   let keymapWarnings = rejectShowKeybindingsConflicts(keymap);
   let actionBindings = resolveActionBindings(
     keymap,
     options.promptTransforms ?? DEFAULT_VIM_PROMPT_TRANSFORMS,
+    projectMappings,
   );
   const acceptedLeaderAction = actionBindings.accepted.some((binding) =>
     keymapResolution?.leaderActionBindings.has(binding),
@@ -2674,6 +2723,7 @@ export function resolveVimOptions(
     actionBindings = resolveActionBindings(
       keymap,
       options.promptTransforms ?? DEFAULT_VIM_PROMPT_TRANSFORMS,
+      projectMappings,
     );
   }
   if (options.keymap) options.keymap.actions = { accepted: actionBindings.accepted };
@@ -2681,7 +2731,12 @@ export function resolveVimOptions(
   warnings.push(...detectKeymapConflicts(keymap));
 
   const plan = createVimConfigPlan(options, warnings);
-  return { plan, options: plan.options, warnings: plan.diagnostics.warnings };
+  return {
+    plan,
+    options: plan.options,
+    warnings: plan.diagnostics.warnings,
+    fatal: jsConfig?.kind === "fatal",
+  };
 }
 
 function readJsonFile(
@@ -2723,7 +2778,12 @@ export async function loadVimOptions(paths: VimConfigPaths = {}): Promise<VimCon
 
   const warnings = [...globalRead.warnings, ...projectRead.warnings, ...resolved.warnings];
   const plan = createVimConfigPlan(resolved.options, warnings);
-  return { plan, options: plan.options, warnings: plan.diagnostics.warnings };
+  return {
+    plan,
+    options: plan.options,
+    warnings: plan.diagnostics.warnings,
+    fatal: resolved.fatal,
+  };
 }
 
 export function keymapForOptions(options: ResolvedVimEditorOptions): ResolvedVimKeymap {

--- a/src/config.ts
+++ b/src/config.ts
@@ -2558,7 +2558,10 @@ function deepFreeze<T>(value: T): T {
 }
 
 function isAtomicMapping(sequence: string): boolean {
-  return sequence.includes("+") || ["left", "down", "up", "right"].includes(sequence);
+  return (
+    /^(?:ctrl|alt|shift|super)\+/.test(sequence) ||
+    ["left", "down", "up", "right"].includes(sequence)
+  );
 }
 
 function hasStrictPrefixConflict(left: string, right: string): boolean {

--- a/src/config.ts
+++ b/src/config.ts
@@ -1792,17 +1792,25 @@ function keymapOverlayFromLayers(layers: readonly PartialKeymapOptions[]): Parti
   return overlay;
 }
 
-function projectExactMappings(keymap: PartialKeymapOptions): ProjectExactMapping[] {
+function projectExactMappings(
+  keymap: PartialKeymapOptions,
+  leader?: string | null,
+): ProjectExactMapping[] {
   const mappings: ProjectExactMapping[] = [];
+  const add = (key: string, modes: readonly VimMode[]) => {
+    const finalKey = leader === undefined ? key : resolvedLeaderKey(key, leader ?? undefined);
+    if (finalKey) mappings.push({ key: finalKey, modes });
+  };
   const addRecord = (
     record: Partial<Record<string, readonly string[]>> | undefined,
     modes: readonly VimMode[],
   ) => {
     for (const bindings of Object.values(record ?? {})) {
-      for (const key of bindings ?? []) mappings.push({ key, modes });
+      for (const key of bindings ?? []) add(key, modes);
     }
   };
 
+  for (const key of keymap.escape ?? []) add(key, ["visual", "visualLine", "visualBlock"]);
   addRecord(keymap.operators, ACTION_BINDING_MODES);
   addRecord(keymap.motions, ACTION_BINDING_MODES);
   addRecord(keymap.commands, ["normal"]);
@@ -1811,11 +1819,11 @@ function projectExactMappings(keymap: PartialKeymapOptions): ProjectExactMapping
   addRecord(keymap.insert, ["insert"]);
   for (const bindings of Object.values(keymap.actions ?? {})) {
     for (const binding of bindings ?? []) {
-      mappings.push({ key: binding.key, modes: binding.modes ?? ACTION_BINDING_MODES });
+      add(binding.key, binding.modes ?? ACTION_BINDING_MODES);
     }
   }
   for (const remap of keymap.remaps?.accepted ?? []) {
-    mappings.push({ key: remap.key, modes: remap.modes ?? ACTION_BINDING_MODES });
+    add(remap.key, remap.modes ?? ACTION_BINDING_MODES);
   }
   return mappings;
 }
@@ -1823,9 +1831,12 @@ function projectExactMappings(keymap: PartialKeymapOptions): ProjectExactMapping
 function applyProjectExactPrecedence(
   lowerLayers: readonly PartialKeymapOptions[],
   project: PartialKeymapOptions,
+  leader: string | undefined,
 ): void {
-  for (const mapping of projectExactMappings(project)) {
-    for (const layer of lowerLayers) removeJsMappings(layer, mapping.key, mapping.modes);
+  for (const mapping of projectExactMappings(project, leader ?? null)) {
+    for (const layer of lowerLayers) {
+      removeJsMappings(layer, mapping.key, mapping.modes, leader ?? null);
+    }
   }
 }
 
@@ -1866,6 +1877,14 @@ function expandLeaderSequence(
     sequence: context.expand ? sequence.replace(LEADER_TOKEN_PATTERN, context.leader) : sequence,
     usesLeader: true,
   };
+}
+
+function resolvedLeaderKey(sequence: string, leader: string | undefined): string | undefined {
+  return expandLeaderSequence(sequence, "project mapping", {
+    leader,
+    warnings: [],
+    expand: true,
+  }).sequence;
 }
 
 function expandBindingArray(
@@ -2152,23 +2171,51 @@ function rejectedActionWarning(
   return `resolved settings: rejected piVimMode.keymap.actions.${binding.actionId}.${binding.key} in ${mode}: ${reason}`;
 }
 
+type RejectedActionBindings = Map<ResolvedVimActionBinding, Map<VimActionBindingMode, string>>;
+
+function uniqueActionBindings(
+  bindings: readonly ResolvedVimActionBinding[],
+): ResolvedVimActionBinding[] {
+  const candidates: ResolvedVimActionBinding[] = [];
+  const seen = new Set<string>();
+  for (const binding of bindings) {
+    const modes = [...actionBindingModes(binding)].sort().join(",");
+    const key = `${binding.actionId}\0${binding.key}\0${modes}\0${JSON.stringify(binding.args ?? {})}`;
+    if (seen.has(key)) continue;
+    seen.add(key);
+    candidates.push(binding);
+  }
+  return candidates;
+}
+
+function collectAcceptedActionBindings(
+  candidates: readonly ResolvedVimActionBinding[],
+  rejected: RejectedActionBindings,
+  warnings: string[],
+): ResolvedVimActionBinding[] {
+  const accepted: ResolvedVimActionBinding[] = [];
+  for (const binding of candidates) {
+    const modes = actionBindingModes(binding);
+    const acceptedModes = modes.filter((mode) => !rejected.get(binding)?.has(mode));
+    for (const [mode, reason] of rejected.get(binding) ?? []) {
+      warnings.push(rejectedActionWarning(binding, mode, reason));
+    }
+    if (acceptedModes.length === 0) continue;
+    accepted.push(
+      acceptedModes.length === modes.length ? binding : { ...binding, modes: acceptedModes },
+    );
+  }
+  return accepted;
+}
+
 function resolveActionBindings(
   keymap: ResolvedVimKeymap,
   promptTransforms: ResolvedVimPromptTransforms,
   projectExactMappings: readonly ProjectExactMapping[] = [],
 ): { accepted: ResolvedVimActionBinding[]; warnings: string[] } {
   const warnings: string[] = [];
-  const candidates: ResolvedVimActionBinding[] = [];
-  const seenSameAction = new Set<string>();
-  for (const binding of keymap.actions.accepted) {
-    const modes = [...actionBindingModes(binding)].sort().join(",");
-    const dedupeKey = `${binding.actionId}\0${binding.key}\0${modes}\0${JSON.stringify(binding.args ?? {})}`;
-    if (seenSameAction.has(dedupeKey)) continue;
-    seenSameAction.add(dedupeKey);
-    candidates.push(binding);
-  }
-
-  const rejected = new Map<ResolvedVimActionBinding, Map<VimActionBindingMode, string>>();
+  const candidates = uniqueActionBindings(keymap.actions.accepted);
+  const rejected: RejectedActionBindings = new Map();
   const reject = (
     binding: ResolvedVimActionBinding,
     mode: VimActionBindingMode,
@@ -2238,19 +2285,10 @@ function resolveActionBindings(
     }
   }
 
-  const accepted: ResolvedVimActionBinding[] = [];
-  for (const binding of candidates) {
-    const modes = actionBindingModes(binding);
-    const acceptedModes = modes.filter((mode) => !isRejected(binding, mode));
-    for (const [mode, reason] of rejected.get(binding) ?? []) {
-      warnings.push(rejectedActionWarning(binding, mode, reason));
-    }
-    if (acceptedModes.length === 0) continue;
-    accepted.push(
-      acceptedModes.length === modes.length ? binding : { ...binding, modes: acceptedModes },
-    );
-  }
-  return { accepted, warnings };
+  return {
+    accepted: collectAcceptedActionBindings(candidates, rejected, warnings),
+    warnings,
+  };
 }
 
 function rejectShowKeybindingsConflicts(keymap: ResolvedVimKeymap): string[] {
@@ -2409,18 +2447,23 @@ function removeJsMappings(
   keymap: PartialKeymapOptions,
   key: string,
   modes: readonly VimMode[],
+  leader?: string | null,
 ): void {
+  const matchesKey = (candidate: string) =>
+    leader === undefined
+      ? candidate === key
+      : resolvedLeaderKey(candidate, leader ?? undefined) === key;
   const removesMode = (mode: VimMode) => modes.includes(mode);
   if (keymap.insert && removesMode("insert")) {
     for (const action of Object.keys(keymap.insert) as Array<keyof ResolvedVimInsertKeymap>) {
-      keymap.insert[action] = keymap.insert[action]?.filter((binding) => binding !== key);
+      keymap.insert[action] = keymap.insert[action]?.filter((binding) => !matchesKey(binding));
     }
   }
   if (keymap.actions) {
     for (const [actionId, bindings] of Object.entries(keymap.actions)) {
       keymap.actions[actionId as BindablePromptTransformActionId] = (bindings ?? []).flatMap(
         (binding) => {
-          if (binding.key !== key) return [binding];
+          if (!matchesKey(binding.key)) return [binding];
           const remainingModes = remainingScopedModes(binding.modes, modes);
           return remainingModes.length ? [{ ...binding, modes: remainingModes }] : [];
         },
@@ -2429,7 +2472,7 @@ function removeJsMappings(
   }
   if (keymap.remaps) {
     keymap.remaps.accepted = keymap.remaps.accepted.flatMap((mapping) => {
-      if (mapping.key !== key) return [mapping];
+      if (!matchesKey(mapping.key)) return [mapping];
       const remainingModes = remainingScopedModes(mapping.modes, modes);
       return remainingModes.length ? [{ ...mapping, modes: remainingModes }] : [];
     });
@@ -2625,19 +2668,61 @@ function applyProjectLayer(
   if (project.preset) {
     const preset = presetOptions(project.preset);
     mergePartialOptions(options, preset);
-    if (preset.keymap) {
-      applyProjectExactPrecedence(keymapLayers, preset.keymap);
-      keymapLayers.push(preset.keymap);
-      projectLayers.push(preset.keymap);
-    }
+    if (preset.keymap) projectLayers.push(preset.keymap);
   }
-  if (project.keymap) applyProjectExactPrecedence(keymapLayers, project.keymap);
   mergePartialOptions(options, project);
-  if (project.keymap) {
-    keymapLayers.push(project.keymap);
-    projectLayers.push(project.keymap);
+  if (project.keymap) projectLayers.push(project.keymap);
+  for (const layer of projectLayers) {
+    applyProjectExactPrecedence(keymapLayers, layer, options.leader);
+    keymapLayers.push(layer);
   }
   return projectLayers;
+}
+
+function compileResolvedKeymap(
+  options: ResolvedVimEditorOptions,
+  keymapLayers: PartialKeymapOptions[],
+  projectKeymapLayers: readonly PartialKeymapOptions[],
+  warnings: string[],
+): VimConfigPlan {
+  const keymapResolution =
+    keymapLayers.length > 0 ? resolveKeymapFromLayers(keymapLayers, options.leader) : undefined;
+  if (keymapResolution) {
+    options.keymap = keymapResolution.keymap;
+    warnings.push(...keymapResolution.warnings);
+  }
+
+  const projectMappings = projectKeymapLayers.flatMap((layer) =>
+    projectExactMappings(layer, options.leader ?? null),
+  );
+  let keymap = options.keymap ?? DEFAULT_VIM_KEYMAP;
+  let keymapWarnings = rejectShowKeybindingsConflicts(keymap);
+  let actionBindings = resolveActionBindings(
+    keymap,
+    options.promptTransforms ?? DEFAULT_VIM_PROMPT_TRANSFORMS,
+    projectMappings,
+  );
+  const acceptedLeaderAction = actionBindings.accepted.some((binding) =>
+    keymapResolution?.leaderActionBindings.has(binding),
+  );
+  if (
+    keymapResolution &&
+    keymap.leader &&
+    !keymapResolution.usesNonActionLeader &&
+    !acceptedLeaderAction
+  ) {
+    keymap = resolveKeymapFromLayers(keymapLayers, options.leader, false).keymap;
+    options.keymap = keymap;
+    keymapWarnings = rejectShowKeybindingsConflicts(keymap);
+    actionBindings = resolveActionBindings(
+      keymap,
+      options.promptTransforms ?? DEFAULT_VIM_PROMPT_TRANSFORMS,
+      projectMappings,
+    );
+  }
+  if (options.keymap) options.keymap.actions = { accepted: actionBindings.accepted };
+  warnings.push(...keymapWarnings, ...actionBindings.warnings, ...detectKeymapConflicts(keymap));
+  return createVimConfigPlan(options, warnings);
 }
 
 export function resolveVimOptions(
@@ -2692,45 +2777,9 @@ export function resolveVimOptions(
   const projectPiVimMode = isRecord(projectSettings) ? projectSettings.piVimMode : undefined;
   const parsedProject = parsePiVimMode(projectPiVimMode, "project settings");
   const projectKeymapLayers = applyProjectLayer(options, keymapLayers, parsedProject.partial);
-  let keymapResolution: ReturnType<typeof resolveKeymapFromLayers> | undefined;
-  if (keymapLayers.length > 0) {
-    keymapResolution = resolveKeymapFromLayers(keymapLayers, options.leader);
-    options.keymap = keymapResolution.keymap;
-    warnings.push(...keymapResolution.warnings);
-  }
   warnings.push(...parsedProject.warnings);
 
-  const projectMappings = projectKeymapLayers.flatMap(projectExactMappings);
-  let keymap = options.keymap ?? DEFAULT_VIM_KEYMAP;
-  let keymapWarnings = rejectShowKeybindingsConflicts(keymap);
-  let actionBindings = resolveActionBindings(
-    keymap,
-    options.promptTransforms ?? DEFAULT_VIM_PROMPT_TRANSFORMS,
-    projectMappings,
-  );
-  const acceptedLeaderAction = actionBindings.accepted.some((binding) =>
-    keymapResolution?.leaderActionBindings.has(binding),
-  );
-  if (
-    keymapResolution &&
-    keymap.leader &&
-    !keymapResolution.usesNonActionLeader &&
-    !acceptedLeaderAction
-  ) {
-    keymap = resolveKeymapFromLayers(keymapLayers, options.leader, false).keymap;
-    options.keymap = keymap;
-    keymapWarnings = rejectShowKeybindingsConflicts(keymap);
-    actionBindings = resolveActionBindings(
-      keymap,
-      options.promptTransforms ?? DEFAULT_VIM_PROMPT_TRANSFORMS,
-      projectMappings,
-    );
-  }
-  if (options.keymap) options.keymap.actions = { accepted: actionBindings.accepted };
-  warnings.push(...keymapWarnings, ...actionBindings.warnings);
-  warnings.push(...detectKeymapConflicts(keymap));
-
-  const plan = createVimConfigPlan(options, warnings);
+  const plan = compileResolvedKeymap(options, keymapLayers, projectKeymapLayers, warnings);
   return {
     plan,
     options: plan.options,

--- a/src/config.ts
+++ b/src/config.ts
@@ -67,7 +67,9 @@ import {
   grammarEntriesForKeymap,
 } from "./keymap-grammar.ts";
 import {
+  isAtomicMappingSequence,
   mappingScopesForKeymapEntry,
+  mappingSequencesOverlap,
   VIM_MAPPING_SCOPES,
   type VimMappingScope,
 } from "./mapping-scopes.ts";
@@ -621,26 +623,8 @@ function parseStringArray(
   return parsed.length > 0 ? parsed : undefined;
 }
 
-const NON_PRINTABLE_KEY_NAMES = new Set([
-  "enter",
-  "tab",
-  "escape",
-  "backspace",
-  "delete",
-  "home",
-  "end",
-  "pageup",
-  "pagedown",
-  "insert",
-  "up",
-  "down",
-  "left",
-  "right",
-]);
-
 function isPrintableTextSequence(sequence: string): boolean {
-  if (sequence.includes("+")) return false;
-  if (NON_PRINTABLE_KEY_NAMES.has(sequence)) return false;
+  if (isAtomicMappingSequence(sequence)) return false;
   return [...sequence].every((char) => char.charCodeAt(0) >= 32);
 }
 
@@ -1632,12 +1616,7 @@ function removeTopLevelKeymapSequences(target: ResolvedVimKeymap, sequences: Set
     const next = {} as Record<K, string[]>;
     for (const action of Object.keys(record) as K[]) {
       next[action] = record[action].filter(
-        (binding) =>
-          ![...sequences].some((sequence) => {
-            if (binding === sequence) return true;
-            if (binding.includes("+") || sequence.includes("+")) return false;
-            return binding.startsWith(sequence) || sequence.startsWith(binding);
-          }),
+        (binding) => ![...sequences].some((sequence) => mappingSequencesOverlap(binding, sequence)),
       );
     }
     return next;
@@ -1650,12 +1629,7 @@ function removeTopLevelKeymapSequences(target: ResolvedVimKeymap, sequences: Set
   target.marks = remove(target.marks);
   target.remaps = {
     accepted: target.remaps.accepted.filter(
-      (remap) =>
-        ![...sequences].some((sequence) => {
-          if (remap.key === sequence) return true;
-          if (remap.key.includes("+") || sequence.includes("+")) return false;
-          return remap.key.startsWith(sequence) || sequence.startsWith(remap.key);
-        }),
+      (remap) => ![...sequences].some((sequence) => mappingSequencesOverlap(remap.key, sequence)),
     ),
   };
 }
@@ -1747,12 +1721,7 @@ function removePartialRemaps(target: PartialKeymapOptions, sequences: Set<string
   if (!target.remaps || sequences.size === 0) return;
   target.remaps = {
     accepted: target.remaps.accepted.filter(
-      (remap) =>
-        ![...sequences].some((sequence) => {
-          if (remap.key === sequence) return true;
-          if (remap.key.includes("+") || sequence.includes("+")) return false;
-          return remap.key.startsWith(sequence) || sequence.startsWith(remap.key);
-        }),
+      (remap) => ![...sequences].some((sequence) => mappingSequencesOverlap(remap.key, sequence)),
     ),
   };
 }
@@ -2370,17 +2339,13 @@ function detectKeymapConflicts(keymap: ResolvedVimKeymap): string[] {
     for (const second of bindings) {
       if (first === second) continue;
       if (second.sequence.length <= first.sequence.length) continue;
-      if (second.sequence.includes("+")) continue;
-      if (!second.sequence.startsWith(first.sequence)) continue;
-      // Arrow-key aliases are atomic terminal sequences, never typed character-by-character.
-      // Suppress shadow warnings when the longer binding is an atomic alias.
       if (
-        second.sequence === "left" ||
-        second.sequence === "down" ||
-        second.sequence === "up" ||
-        second.sequence === "right"
-      )
+        isAtomicMappingSequence(first.sequence) ||
+        isAtomicMappingSequence(second.sequence) ||
+        !second.sequence.startsWith(first.sequence)
+      ) {
         continue;
+      }
       warnings.push(
         `resolved settings: piVimMode.keymap binding ${first.sequence} for ${first.label} is shadowed by longer binding ${second.sequence} for ${second.label}`,
       );
@@ -2558,7 +2523,7 @@ function deepFreeze<T>(value: T): T {
 }
 
 function isAtomicMapping(sequence: string): boolean {
-  return /^(?:ctrl|alt|shift|super)\+/.test(sequence) || NON_PRINTABLE_KEY_NAMES.has(sequence);
+  return isAtomicMappingSequence(sequence);
 }
 
 function hasStrictPrefixConflict(left: string, right: string): boolean {

--- a/src/config.ts
+++ b/src/config.ts
@@ -1810,7 +1810,9 @@ function projectExactMappings(
     }
   };
 
-  for (const key of keymap.escape ?? []) add(key, ["visual", "visualLine", "visualBlock"]);
+  for (const key of keymap.escape ?? []) {
+    add(key, ["insert", "visual", "visualLine", "visualBlock"]);
+  }
   addRecord(keymap.operators, ACTION_BINDING_MODES);
   addRecord(keymap.motions, ACTION_BINDING_MODES);
   addRecord(keymap.commands, ["normal"]);
@@ -2576,19 +2578,84 @@ function strictPrefixConflict<T>(
   return accepted.find((candidate) => hasStrictPrefixConflict(getSequence(candidate), sequence));
 }
 
+type ResolvedVimRemap = ResolvedVimKeymap["remaps"]["accepted"][number];
+type ScopedPlanSource = ResolvedVimActionBinding | ResolvedVimRemap;
+type VimPlanCandidate = {
+  sequence: string;
+  binding: VimPlanBinding;
+  source?: ScopedPlanSource;
+};
+
+function retainAcceptedScopes<T extends ScopedPlanSource>(
+  bindings: readonly T[],
+  acceptedScopes: ReadonlyMap<ScopedPlanSource, ReadonlySet<VimMappingScope>>,
+): T[] {
+  return bindings.flatMap((binding) => {
+    const requestedModes = binding.modes ?? ACTION_BINDING_MODES;
+    const acceptedModes = requestedModes.filter((mode) => acceptedScopes.get(binding)?.has(mode));
+    if (acceptedModes.length === 0) return [];
+    return acceptedModes.length === requestedModes.length
+      ? [binding]
+      : [{ ...binding, modes: acceptedModes }];
+  });
+}
+
+function compilePlanScope(
+  scope: VimMappingScope,
+  candidates: readonly VimPlanCandidate[],
+  warnings: string[],
+  acceptedScopes: Map<ScopedPlanSource, Set<VimMappingScope>>,
+): VimScopeLookup {
+  const exact = Object.create(null) as Record<string, VimPlanBinding>;
+  const exactCandidates = Object.create(null) as Record<string, VimPlanCandidate>;
+  for (const candidate of candidates) {
+    const strictPrefix = strictPrefixConflict(
+      Object.keys(exact),
+      candidate.sequence,
+      (sequence) => sequence,
+    );
+    if (strictPrefix) {
+      const warning = `resolved settings: rejected ${candidate.binding.id}.${candidate.sequence} in ${scope}: strict-prefix conflict with ${exact[strictPrefix]!.id}.${strictPrefix}`;
+      if (!warnings.includes(warning)) warnings.push(warning);
+      continue;
+    }
+    exact[candidate.sequence] = candidate.binding;
+    exactCandidates[candidate.sequence] = candidate;
+  }
+  for (const candidate of Object.values(exactCandidates)) {
+    if (!candidate.source) continue;
+    const accepted = acceptedScopes.get(candidate.source) ?? new Set<VimMappingScope>();
+    accepted.add(scope);
+    acceptedScopes.set(candidate.source, accepted);
+  }
+
+  const prefixes = Object.create(null) as Record<string, string[]>;
+  for (const sequence of Object.keys(exact)) {
+    if (isAtomicMapping(sequence)) continue;
+    for (let index = 1; index < sequence.length; index += 1) {
+      const prefix = sequence.slice(0, index);
+      (prefixes[prefix] ??= []).push(sequence);
+    }
+  }
+  return { exact, prefixes };
+}
+
 export function createVimConfigPlan(
   options: ResolvedVimEditorOptions,
   warnings: readonly string[],
 ): VimConfigPlan {
+  const planOptions = cloneResolvedVimOptions(options);
   const candidates = Object.fromEntries(
-    VIM_MAPPING_SCOPES.map((scope) => [
-      scope,
-      [] as Array<{ sequence: string; binding: VimPlanBinding }>,
-    ]),
-  ) as Record<VimMappingScope, Array<{ sequence: string; binding: VimPlanBinding }>>;
-  const keymap = options.keymap ?? DEFAULT_VIM_KEYMAP;
-  const add = (scopes: readonly VimMappingScope[], sequence: string, binding: VimPlanBinding) => {
-    for (const scope of scopes) candidates[scope].push({ sequence, binding });
+    VIM_MAPPING_SCOPES.map((scope) => [scope, [] as VimPlanCandidate[]]),
+  ) as Record<VimMappingScope, VimPlanCandidate[]>;
+  const keymap = planOptions.keymap ?? DEFAULT_VIM_KEYMAP;
+  const add = (
+    scopes: readonly VimMappingScope[],
+    sequence: string,
+    binding: VimPlanBinding,
+    source?: ScopedPlanSource,
+  ) => {
+    for (const scope of scopes) candidates[scope].push({ sequence, binding, source });
   };
 
   for (const entry of grammarEntriesForKeymap(keymap)) {
@@ -2607,53 +2674,43 @@ export function createVimConfigPlan(
     for (const sequence of sequences) add(["insert"], sequence, { kind: "insert", id: action });
   }
   for (const binding of keymap.actions.accepted) {
-    add(binding.modes ?? ACTION_BINDING_MODES, binding.key, {
-      kind: "action",
-      id: binding.actionId,
-      args: binding.args,
-    });
+    add(
+      binding.modes ?? ACTION_BINDING_MODES,
+      binding.key,
+      { kind: "action", id: binding.actionId, args: binding.args },
+      binding,
+    );
   }
   for (const remap of keymap.remaps.accepted) {
-    add(remap.modes ?? ACTION_BINDING_MODES, remap.key, {
-      kind: "remap",
-      id: "remap",
-      inputs: remap.inputs,
-    });
+    add(
+      remap.modes ?? ACTION_BINDING_MODES,
+      remap.key,
+      { kind: "remap", id: "remap", inputs: remap.inputs },
+      remap,
+    );
   }
 
   const compileWarnings = [...warnings];
+  const acceptedScopes = new Map<ScopedPlanSource, Set<VimMappingScope>>();
   const scopes = Object.fromEntries(
-    VIM_MAPPING_SCOPES.map((scope) => {
-      const exact = Object.create(null) as Record<string, VimPlanBinding>;
-      for (const candidate of candidates[scope]) {
-        const strictPrefix = strictPrefixConflict(
-          Object.keys(exact),
-          candidate.sequence,
-          (sequence) => sequence,
-        );
-        if (strictPrefix) {
-          const warning = `resolved settings: rejected ${candidate.binding.id}.${candidate.sequence} in ${scope}: strict-prefix conflict with ${exact[strictPrefix]!.id}.${strictPrefix}`;
-          if (!compileWarnings.includes(warning)) compileWarnings.push(warning);
-          continue;
-        }
-        exact[candidate.sequence] = candidate.binding;
-      }
+    VIM_MAPPING_SCOPES.map((scope) => [
+      scope,
+      compilePlanScope(scope, candidates[scope], compileWarnings, acceptedScopes),
+    ]),
+  ) as Record<VimMappingScope, VimScopeLookup>;
 
-      const prefixes = Object.create(null) as Record<string, string[]>;
-      for (const sequence of Object.keys(exact)) {
-        if (isAtomicMapping(sequence)) continue;
-        for (let index = 1; index < sequence.length; index += 1) {
-          const prefix = sequence.slice(0, index);
-          (prefixes[prefix] ??= []).push(sequence);
-        }
-      }
-      return [scope, { exact, prefixes }];
-    }),
-  ) as unknown as Record<VimMappingScope, VimScopeLookup>;
-
-  const frozenOptions = deepFreeze(options);
+  if (planOptions.keymap) {
+    planOptions.keymap.actions.accepted = retainAcceptedScopes(
+      planOptions.keymap.actions.accepted,
+      acceptedScopes,
+    );
+    planOptions.keymap.remaps.accepted = retainAcceptedScopes(
+      planOptions.keymap.remaps.accepted,
+      acceptedScopes,
+    );
+  }
   return deepFreeze({
-    options: frozenOptions,
+    options: planOptions,
     diagnostics: { warnings: compileWarnings },
     scopes,
   });

--- a/src/config.ts
+++ b/src/config.ts
@@ -2558,10 +2558,7 @@ function deepFreeze<T>(value: T): T {
 }
 
 function isAtomicMapping(sequence: string): boolean {
-  return (
-    /^(?:ctrl|alt|shift|super)\+/.test(sequence) ||
-    ["left", "down", "up", "right"].includes(sequence)
-  );
+  return /^(?:ctrl|alt|shift|super)\+/.test(sequence) || NON_PRINTABLE_KEY_NAMES.has(sequence);
 }
 
 function hasStrictPrefixConflict(left: string, right: string): boolean {

--- a/src/lifecycle.ts
+++ b/src/lifecycle.ts
@@ -77,11 +77,13 @@ function createConfigState(dependencies: VimLifecycleDependencies): ConfigState 
       if (loaded instanceof Promise) {
         return loaded.then(
           (result) => {
-            if (generation === refreshGeneration) apply(ctx, result);
+            if (generation !== refreshGeneration) return false;
+            apply(ctx, result);
             return true;
           },
           (error) => {
-            if (generation === refreshGeneration) applyFailure(ctx, error);
+            if (generation !== refreshGeneration) return false;
+            applyFailure(ctx, error);
             return true;
           },
         );
@@ -144,7 +146,8 @@ function installEditor(
   }
   const refreshed = state.config.refresh(ctx);
   if (refreshed instanceof Promise) {
-    return refreshed.then(() => {
+    return refreshed.then((applied) => {
+      if (!applied) return;
       if (state.enabled) finishInstall(state, ctx, force);
       else ctx.ui.setStatus("pi-vimmode", "vim off");
     });

--- a/src/lifecycle.ts
+++ b/src/lifecycle.ts
@@ -21,7 +21,7 @@ type VimEditorFactory = (
 export type VimShutdownCallback = () => void;
 
 type EditorComponentFactory = ReturnType<ExtensionContext["ui"]["getEditorComponent"]>;
-type TrackedEditor = Pick<VimEditor, "resetTerminalCursorStyle" | "setAgentBusy">;
+type TrackedEditor = Pick<VimEditor, "reloadConfig" | "resetTerminalCursorStyle" | "setAgentBusy">;
 type CreateEditor = (
   tui: ConstructorParameters<typeof VimEditor>[0],
   theme: ConstructorParameters<typeof VimEditor>[1],
@@ -131,6 +131,12 @@ function finishInstall(state: EditorState, ctx: ExtensionContext, force = false)
   state.hasInstalledFactory = true;
 }
 
+function reloadKnownEditors(state: EditorState): void {
+  for (const editor of state.editors) {
+    editor.reloadConfig(state.config.options(), state.config.diagnostics());
+  }
+}
+
 function installEditor(
   state: EditorState,
   ctx: ExtensionContext,
@@ -140,11 +146,13 @@ function installEditor(
     ctx.ui.setStatus("pi-vimmode", "vim off");
     return;
   }
+  const finish = () => {
+    reloadKnownEditors(state);
+    finishInstall(state, ctx, force);
+  };
   const refreshed = state.config.refresh(ctx);
-  if (refreshed instanceof Promise) {
-    return refreshed.then(() => finishInstall(state, ctx, force));
-  }
-  finishInstall(state, ctx, force);
+  if (refreshed instanceof Promise) return refreshed.then(finish);
+  finish();
 }
 
 function resetKnownEditors(state: EditorState): void {
@@ -215,6 +223,7 @@ function registerVimCommand(pi: ExtensionAPI, state: EditorState): void {
       }
       if (action === "reload") {
         await state.config.refresh(ctx);
+        reloadKnownEditors(state);
         if (state.enabled) finishInstall(state, ctx);
         ctx.ui.notify(
           `pi-vimmode ${state.enabled ? "reloaded" : "config reloaded (disabled)"}`,

--- a/src/lifecycle.ts
+++ b/src/lifecycle.ts
@@ -3,6 +3,7 @@ import { type ExtensionAPI, type ExtensionContext } from "@earendil-works/pi-cod
 import type { ResolvedVimEditorOptions, VimDiagnostics } from "./types.ts";
 
 import {
+  createVimConfigPlan,
   DEFAULT_VIM_OPTIONS,
   loadVimOptions,
   type VimConfigLoadResult,
@@ -45,8 +46,9 @@ export function registerVimLifecycle(
   pi: ExtensionAPI,
   dependencies: VimLifecycleDependencies = {},
 ) {
-  let currentOptions = dependencies.defaultOptions ?? DEFAULT_VIM_OPTIONS;
-  let currentDiagnostics: VimDiagnostics = { warnings: [] };
+  let currentPlan = createVimConfigPlan(dependencies.defaultOptions ?? DEFAULT_VIM_OPTIONS, []);
+  let currentOptions = currentPlan.options;
+  let currentDiagnostics: VimDiagnostics = currentPlan.diagnostics;
   let currentShutdown: (() => void) | undefined;
   let enabled = true;
   let agentBusy = false;
@@ -70,9 +72,10 @@ export function registerVimLifecycle(
   };
 
   const applyLoadedOptions = (ctx: ExtensionContext, loaded: VimConfigLoadResult) => {
-    currentOptions = loaded.options;
-    currentDiagnostics = { warnings: [...loaded.warnings] };
-    ctx.ui.setStatus("pi-vimmode", loaded.warnings.length > 0 ? "vim ⚠" : "vim");
+    currentPlan = loaded.plan;
+    currentOptions = currentPlan.options;
+    currentDiagnostics = currentPlan.diagnostics;
+    ctx.ui.setStatus("pi-vimmode", currentDiagnostics.warnings.length > 0 ? "vim ⚠" : "vim");
   };
 
   const refreshOptions = (ctx: ExtensionContext): boolean | Promise<boolean> => {
@@ -88,9 +91,11 @@ export function registerVimLifecycle(
       return true;
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);
+      const warnings = [`global JS config: failed to load (${message})`];
       applyLoadedOptions(ctx, {
+        plan: createVimConfigPlan(currentOptions, warnings),
         options: currentOptions,
-        warnings: [`global JS config: failed to load (${message})`],
+        warnings,
       });
       return true;
     }

--- a/src/lifecycle.ts
+++ b/src/lifecycle.ts
@@ -222,7 +222,7 @@ function registerVimCommand(pi: ExtensionAPI, state: EditorState): void {
         return;
       }
       if (action === "reload") {
-        await state.config.refresh(ctx);
+        if (!(await state.config.refresh(ctx))) return;
         if (state.enabled) finishInstall(state, ctx);
         ctx.ui.notify(
           `pi-vimmode ${state.enabled ? "reloaded" : "config reloaded (disabled)"}`,

--- a/src/lifecycle.ts
+++ b/src/lifecycle.ts
@@ -21,9 +21,7 @@ type VimEditorFactory = (
 export type VimShutdownCallback = () => void;
 
 type EditorComponentFactory = ReturnType<ExtensionContext["ui"]["getEditorComponent"]>;
-
 type TrackedEditor = Pick<VimEditor, "resetTerminalCursorStyle" | "setAgentBusy">;
-
 type CreateEditor = (
   tui: ConstructorParameters<typeof VimEditor>[0],
   theme: ConstructorParameters<typeof VimEditor>[1],
@@ -32,192 +30,232 @@ type CreateEditor = (
   diagnostics: VimDiagnostics,
   vimOptions?: { onShutdown?: () => void },
 ) => TrackedEditor;
-
 type Schedule = (callback: () => void) => void;
 
 export type VimLifecycleDependencies = {
   defaultOptions?: ResolvedVimEditorOptions;
-  loadOptions?: (paths: VimConfigPaths) => VimConfigLoadResult;
+  loadOptions?: (paths: VimConfigPaths) => VimConfigLoadResult | Promise<VimConfigLoadResult>;
   createEditor?: CreateEditor;
   schedule?: Schedule;
 };
 
-export function registerVimLifecycle(
-  pi: ExtensionAPI,
-  dependencies: VimLifecycleDependencies = {},
-) {
+type ConfigState = {
+  options: () => ResolvedVimEditorOptions;
+  diagnostics: () => VimDiagnostics;
+  refresh: (ctx: ExtensionContext) => boolean | Promise<boolean>;
+};
+
+function createConfigState(dependencies: VimLifecycleDependencies): ConfigState {
   let currentPlan = createVimConfigPlan(dependencies.defaultOptions ?? DEFAULT_VIM_OPTIONS, []);
-  let currentOptions = currentPlan.options;
   let currentDiagnostics: VimDiagnostics = currentPlan.diagnostics;
-  let currentShutdown: (() => void) | undefined;
-  let enabled = true;
-  let agentBusy = false;
-  let previousEditorFactory: EditorComponentFactory;
-  let hasInstalledFactory = false;
-  const editors = new Set<TrackedEditor>();
+  let hasCommittedLoad = false;
   const loadOptions = dependencies.loadOptions ?? loadVimOptions;
-  const createEditor =
-    dependencies.createEditor ??
-    ((tui, theme, keybindings, options, diagnostics, vimOptions) =>
-      new VimEditor(tui, theme, keybindings, options, diagnostics, vimOptions));
-  const schedule = dependencies.schedule ?? ((callback) => setTimeout(callback, 0));
 
-  const editorFactory: VimEditorFactory = (tui, theme, keybindings) => {
-    const editor = createEditor(tui, theme, keybindings, currentOptions, currentDiagnostics, {
-      onShutdown: currentShutdown,
-    });
-    editors.add(editor);
-    if (agentBusy) editor.setAgentBusy(true);
-    return editor as VimEditor;
-  };
-
-  const applyLoadedOptions = (ctx: ExtensionContext, loaded: VimConfigLoadResult) => {
-    currentPlan = loaded.plan;
-    currentOptions = currentPlan.options;
-    currentDiagnostics = currentPlan.diagnostics;
+  const apply = (ctx: ExtensionContext, loaded: VimConfigLoadResult) => {
+    if (!loaded.fatal || !hasCommittedLoad) {
+      currentPlan = loaded.plan;
+      hasCommittedLoad = true;
+    }
+    currentDiagnostics = loaded.fatal ? loaded.plan.diagnostics : currentPlan.diagnostics;
     ctx.ui.setStatus("pi-vimmode", currentDiagnostics.warnings.length > 0 ? "vim ⚠" : "vim");
   };
-
-  const refreshOptions = (ctx: ExtensionContext): boolean | Promise<boolean> => {
+  const applyFailure = (ctx: ExtensionContext, error: unknown) => {
+    const message = error instanceof Error ? error.message : String(error);
+    const warnings = [`global JS config: failed to load (${message})`];
+    apply(ctx, {
+      plan: createVimConfigPlan(currentPlan.options, warnings),
+      options: currentPlan.options,
+      warnings,
+      fatal: true,
+    });
+  };
+  const refresh = (ctx: ExtensionContext): boolean | Promise<boolean> => {
     try {
       const loaded = loadOptions({ cwd: ctx.cwd });
       if (loaded instanceof Promise) {
-        return loaded.then((result) => {
-          applyLoadedOptions(ctx, result);
-          return true;
-        });
+        return loaded.then(
+          (result) => {
+            apply(ctx, result);
+            return true;
+          },
+          (error) => {
+            applyFailure(ctx, error);
+            return true;
+          },
+        );
       }
-      applyLoadedOptions(ctx, loaded);
-      return true;
+      apply(ctx, loaded);
     } catch (error) {
-      const message = error instanceof Error ? error.message : String(error);
-      const warnings = [`global JS config: failed to load (${message})`];
-      applyLoadedOptions(ctx, {
-        plan: createVimConfigPlan(currentOptions, warnings),
-        options: currentOptions,
-        warnings,
-      });
-      return true;
+      applyFailure(ctx, error);
     }
+    return true;
   };
 
-  const finishInstall = (ctx: ExtensionContext, force = false) => {
-    currentShutdown = () => ctx.shutdown();
-    const current = ctx.ui.getEditorComponent();
-    if (current === editorFactory) {
-      hasInstalledFactory = true;
-      return;
-    }
-
-    // Preserve a foreign factory that took ownership after Vim installed.
-    if (
-      !force &&
-      hasInstalledFactory &&
-      current !== undefined &&
-      current !== previousEditorFactory
-    ) {
-      return;
-    }
-
-    previousEditorFactory = current;
-    ctx.ui.setEditorComponent(editorFactory);
-    hasInstalledFactory = true;
+  return {
+    options: () => currentPlan.options,
+    diagnostics: () => currentDiagnostics,
+    refresh,
   };
+}
 
-  const installEditor = (ctx: ExtensionContext, force = false): void | Promise<void> => {
-    if (!enabled) {
-      ctx.ui.setStatus("pi-vimmode", "vim off");
-      return;
-    }
-    const refreshed = refreshOptions(ctx);
-    if (refreshed instanceof Promise) return refreshed.then(() => finishInstall(ctx, force));
-    finishInstall(ctx, force);
-  };
+type EditorState = {
+  config: ConfigState;
+  createEditor: CreateEditor;
+  schedule: Schedule;
+  editors: Set<TrackedEditor>;
+  editorFactory: VimEditorFactory;
+  currentShutdown?: () => void;
+  enabled: boolean;
+  agentBusy: boolean;
+  previousEditorFactory?: EditorComponentFactory;
+  hasInstalledFactory: boolean;
+};
 
-  const installEditorSoon = (ctx: ExtensionContext) => {
-    void installEditor(ctx);
-    schedule(() => {
-      try {
-        void installEditor(ctx);
-      } catch {
-        // Context can go stale during reload/session switch. Next session_start will reinstall.
-      }
-    });
-  };
+function finishInstall(state: EditorState, ctx: ExtensionContext, force = false): void {
+  state.currentShutdown = () => ctx.shutdown();
+  const current = ctx.ui.getEditorComponent();
+  if (current === state.editorFactory) {
+    state.hasInstalledFactory = true;
+    return;
+  }
+  if (
+    !force &&
+    state.hasInstalledFactory &&
+    current !== undefined &&
+    current !== state.previousEditorFactory
+  ) {
+    return;
+  }
+  state.previousEditorFactory = current;
+  ctx.ui.setEditorComponent(state.editorFactory);
+  state.hasInstalledFactory = true;
+}
 
-  const setKnownEditorsAgentBusy = (active: boolean) => {
-    agentBusy = active;
-    for (const editor of editors) editor.setAgentBusy(active);
-  };
-
-  const resetKnownEditors = () => {
-    for (const editor of editors) editor.resetTerminalCursorStyle();
-    editors.clear();
-  };
-
-  const disableEditor = (ctx: ExtensionContext) => {
-    enabled = false;
-    agentBusy = false;
-    resetKnownEditors();
-    const current = ctx.ui.getEditorComponent();
-    if (current === editorFactory) {
-      ctx.ui.setEditorComponent(previousEditorFactory);
-      hasInstalledFactory = false;
-    }
+function installEditor(
+  state: EditorState,
+  ctx: ExtensionContext,
+  force = false,
+): void | Promise<void> {
+  if (!state.enabled) {
     ctx.ui.setStatus("pi-vimmode", "vim off");
-  };
+    return;
+  }
+  const refreshed = state.config.refresh(ctx);
+  if (refreshed instanceof Promise) {
+    return refreshed.then(() => finishInstall(state, ctx, force));
+  }
+  finishInstall(state, ctx, force);
+}
 
-  const enableEditor = (ctx: ExtensionContext): void | Promise<void> => {
-    enabled = true;
-    return installEditor(ctx, true);
-  };
+function resetKnownEditors(state: EditorState): void {
+  for (const editor of state.editors) editor.resetTerminalCursorStyle();
+  state.editors.clear();
+}
 
+function createEditorState(dependencies: VimLifecycleDependencies): EditorState {
+  const state: EditorState = {
+    config: createConfigState(dependencies),
+    createEditor:
+      dependencies.createEditor ??
+      ((tui, theme, keybindings, options, diagnostics, vimOptions) =>
+        new VimEditor(tui, theme, keybindings, options, diagnostics, vimOptions)),
+    schedule: dependencies.schedule ?? ((callback) => setTimeout(callback, 0)),
+    editors: new Set<TrackedEditor>(),
+    editorFactory: undefined as unknown as VimEditorFactory,
+    enabled: true,
+    agentBusy: false,
+    hasInstalledFactory: false,
+  };
+  state.editorFactory = (tui, theme, keybindings) => {
+    const editor = state.createEditor(
+      tui,
+      theme,
+      keybindings,
+      state.config.options(),
+      state.config.diagnostics(),
+      { onShutdown: state.currentShutdown },
+    );
+    state.editors.add(editor);
+    if (state.agentBusy) editor.setAgentBusy(true);
+    return editor as VimEditor;
+  };
+  return state;
+}
+
+function installEditorSoon(state: EditorState, ctx: ExtensionContext): void {
+  void installEditor(state, ctx);
+  state.schedule(() => {
+    try {
+      void installEditor(state, ctx);
+    } catch {
+      // Context can go stale during reload/session switch. Next session_start will reinstall.
+    }
+  });
+}
+
+function disableEditor(state: EditorState, ctx: ExtensionContext): void {
+  state.enabled = false;
+  state.agentBusy = false;
+  resetKnownEditors(state);
+  if (ctx.ui.getEditorComponent() === state.editorFactory) {
+    ctx.ui.setEditorComponent(state.previousEditorFactory);
+    state.hasInstalledFactory = false;
+  }
+  ctx.ui.setStatus("pi-vimmode", "vim off");
+}
+
+function registerVimCommand(pi: ExtensionAPI, state: EditorState): void {
   pi.registerCommand("vimmode", {
     description: "Toggle pi-vimmode editor on/off",
     handler: async (args, ctx) => {
       const action = args.trim().toLowerCase() || "toggle";
       if (action === "status") {
-        ctx.ui.notify(`pi-vimmode ${enabled ? "enabled" : "disabled"}`, "info");
+        ctx.ui.notify(`pi-vimmode ${state.enabled ? "enabled" : "disabled"}`, "info");
         return;
       }
       if (action === "reload") {
-        const refreshed = refreshOptions(ctx);
-        if (refreshed instanceof Promise) await refreshed;
-        if (enabled) finishInstall(ctx);
-        ctx.ui.notify(`pi-vimmode ${enabled ? "reloaded" : "config reloaded (disabled)"}`, "info");
+        await state.config.refresh(ctx);
+        if (state.enabled) finishInstall(state, ctx);
+        ctx.ui.notify(
+          `pi-vimmode ${state.enabled ? "reloaded" : "config reloaded (disabled)"}`,
+          "info",
+        );
         return;
       }
       if (action !== "toggle" && action !== "on" && action !== "off") {
         ctx.ui.notify("Usage: /vimmode [on|off|toggle|status|reload]", "warning");
         return;
       }
-
-      if (action === "on" || (action === "toggle" && !enabled)) await enableEditor(ctx);
-      else disableEditor(ctx);
-
-      ctx.ui.notify(`pi-vimmode ${enabled ? "enabled" : "disabled"}`, "info");
+      if (action === "on" || (action === "toggle" && !state.enabled)) {
+        state.enabled = true;
+        await installEditor(state, ctx, true);
+      } else {
+        disableEditor(state, ctx);
+      }
+      ctx.ui.notify(`pi-vimmode ${state.enabled ? "enabled" : "disabled"}`, "info");
     },
   });
+}
 
-  pi.on("session_start", (_event, ctx) => {
-    installEditorSoon(ctx);
-  });
-
-  pi.on("resources_discover", (_event, ctx) => {
-    installEditorSoon(ctx);
-  });
-
+export function registerVimLifecycle(
+  pi: ExtensionAPI,
+  dependencies: VimLifecycleDependencies = {},
+): void {
+  const state = createEditorState(dependencies);
+  registerVimCommand(pi, state);
+  pi.on("session_start", (_event, ctx) => installEditorSoon(state, ctx));
+  pi.on("resources_discover", (_event, ctx) => installEditorSoon(state, ctx));
   pi.on("agent_start", () => {
-    setKnownEditorsAgentBusy(true);
+    state.agentBusy = true;
+    for (const editor of state.editors) editor.setAgentBusy(true);
   });
-
   pi.on("agent_end", (_event, ctx) => {
-    setKnownEditorsAgentBusy(false);
-    void installEditor(ctx);
+    state.agentBusy = false;
+    for (const editor of state.editors) editor.setAgentBusy(false);
+    void installEditor(state, ctx);
   });
-
   pi.on("session_shutdown", () => {
-    agentBusy = false;
-    resetKnownEditors();
+    state.agentBusy = false;
+    resetKnownEditors(state);
   });
 }

--- a/src/lifecycle.ts
+++ b/src/lifecycle.ts
@@ -56,13 +56,16 @@ function createConfigState(
   const loadOptions = dependencies.loadOptions ?? loadVimOptions;
 
   const apply = (ctx: ExtensionContext, loaded: VimConfigLoadResult) => {
+    const previousConfig = JSON.stringify([currentPlan.options, currentDiagnostics]);
     const committed = !loaded.fatal || !hasCommittedLoad;
     if (committed) {
       currentPlan = loaded.plan;
       hasCommittedLoad = true;
     }
     currentDiagnostics = loaded.fatal ? loaded.plan.diagnostics : currentPlan.diagnostics;
-    if (committed) onCommit(currentPlan.options, currentDiagnostics);
+    const configChanged =
+      JSON.stringify([currentPlan.options, currentDiagnostics]) !== previousConfig;
+    if (committed && configChanged) onCommit(currentPlan.options, currentDiagnostics);
     ctx.ui.setStatus("pi-vimmode", currentDiagnostics.warnings.length > 0 ? "vim ⚠" : "vim");
   };
   const applyFailure = (ctx: ExtensionContext, error: unknown) => {
@@ -200,11 +203,15 @@ function createEditorState(dependencies: VimLifecycleDependencies): EditorState 
   return state;
 }
 
+function ignoreStaleInstall(install: void | Promise<void>): void {
+  if (install instanceof Promise) void install.catch(() => {});
+}
+
 function installEditorSoon(state: EditorState, ctx: ExtensionContext): void {
-  void installEditor(state, ctx);
+  ignoreStaleInstall(installEditor(state, ctx));
   state.schedule(() => {
     try {
-      void installEditor(state, ctx);
+      ignoreStaleInstall(installEditor(state, ctx));
     } catch {
       // Context can go stale during reload/session switch. Next session_start will reinstall.
     }

--- a/src/lifecycle.ts
+++ b/src/lifecycle.ts
@@ -203,15 +203,23 @@ function createEditorState(dependencies: VimLifecycleDependencies): EditorState 
   return state;
 }
 
-function ignoreStaleInstall(install: void | Promise<void>): void {
-  if (install instanceof Promise) void install.catch(() => {});
+function observeInstall(install: void | Promise<void>, ctx: ExtensionContext): void {
+  if (!(install instanceof Promise)) return;
+  void install.catch((error: unknown) => {
+    try {
+      const message = error instanceof Error ? error.message : String(error);
+      ctx.ui.notify(`pi-vimmode install failed: ${message}`, "error");
+    } catch {
+      // Context went stale while reporting the original failure.
+    }
+  });
 }
 
 function installEditorSoon(state: EditorState, ctx: ExtensionContext): void {
-  ignoreStaleInstall(installEditor(state, ctx));
+  observeInstall(installEditor(state, ctx), ctx);
   state.schedule(() => {
     try {
-      ignoreStaleInstall(installEditor(state, ctx));
+      observeInstall(installEditor(state, ctx), ctx);
     } catch {
       // Context can go stale during reload/session switch. Next session_start will reinstall.
     }

--- a/src/lifecycle.ts
+++ b/src/lifecycle.ts
@@ -21,7 +21,7 @@ type VimEditorFactory = (
 export type VimShutdownCallback = () => void;
 
 type EditorComponentFactory = ReturnType<ExtensionContext["ui"]["getEditorComponent"]>;
-type TrackedEditor = Pick<VimEditor, "reloadConfig" | "resetTerminalCursorStyle" | "setAgentBusy">;
+type TrackedEditor = Pick<VimEditor, "resetTerminalCursorStyle" | "setAgentBusy">;
 type CreateEditor = (
   tui: ConstructorParameters<typeof VimEditor>[0],
   theme: ConstructorParameters<typeof VimEditor>[1],
@@ -131,12 +131,6 @@ function finishInstall(state: EditorState, ctx: ExtensionContext, force = false)
   state.hasInstalledFactory = true;
 }
 
-function reloadKnownEditors(state: EditorState): void {
-  for (const editor of state.editors) {
-    editor.reloadConfig(state.config.options(), state.config.diagnostics());
-  }
-}
-
 function installEditor(
   state: EditorState,
   ctx: ExtensionContext,
@@ -146,13 +140,11 @@ function installEditor(
     ctx.ui.setStatus("pi-vimmode", "vim off");
     return;
   }
-  const finish = () => {
-    reloadKnownEditors(state);
-    finishInstall(state, ctx, force);
-  };
   const refreshed = state.config.refresh(ctx);
-  if (refreshed instanceof Promise) return refreshed.then(finish);
-  finish();
+  if (refreshed instanceof Promise) {
+    return refreshed.then(() => finishInstall(state, ctx, force));
+  }
+  finishInstall(state, ctx, force);
 }
 
 function resetKnownEditors(state: EditorState): void {
@@ -223,7 +215,6 @@ function registerVimCommand(pi: ExtensionAPI, state: EditorState): void {
       }
       if (action === "reload") {
         await state.config.refresh(ctx);
-        reloadKnownEditors(state);
         if (state.enabled) finishInstall(state, ctx);
         ctx.ui.notify(
           `pi-vimmode ${state.enabled ? "reloaded" : "config reloaded (disabled)"}`,

--- a/src/lifecycle.ts
+++ b/src/lifecycle.ts
@@ -21,7 +21,7 @@ type VimEditorFactory = (
 export type VimShutdownCallback = () => void;
 
 type EditorComponentFactory = ReturnType<ExtensionContext["ui"]["getEditorComponent"]>;
-type TrackedEditor = Pick<VimEditor, "resetTerminalCursorStyle" | "setAgentBusy">;
+type TrackedEditor = Pick<VimEditor, "reconfigure" | "resetTerminalCursorStyle" | "setAgentBusy">;
 type CreateEditor = (
   tui: ConstructorParameters<typeof VimEditor>[0],
   theme: ConstructorParameters<typeof VimEditor>[1],
@@ -45,7 +45,10 @@ type ConfigState = {
   refresh: (ctx: ExtensionContext) => boolean | Promise<boolean>;
 };
 
-function createConfigState(dependencies: VimLifecycleDependencies): ConfigState {
+function createConfigState(
+  dependencies: VimLifecycleDependencies,
+  onCommit: (options: ResolvedVimEditorOptions, diagnostics: VimDiagnostics) => void,
+): ConfigState {
   let currentPlan = createVimConfigPlan(dependencies.defaultOptions ?? DEFAULT_VIM_OPTIONS, []);
   let currentDiagnostics: VimDiagnostics = currentPlan.diagnostics;
   let hasCommittedLoad = false;
@@ -53,11 +56,13 @@ function createConfigState(dependencies: VimLifecycleDependencies): ConfigState 
   const loadOptions = dependencies.loadOptions ?? loadVimOptions;
 
   const apply = (ctx: ExtensionContext, loaded: VimConfigLoadResult) => {
-    if (!loaded.fatal || !hasCommittedLoad) {
+    const committed = !loaded.fatal || !hasCommittedLoad;
+    if (committed) {
       currentPlan = loaded.plan;
       hasCommittedLoad = true;
     }
     currentDiagnostics = loaded.fatal ? loaded.plan.diagnostics : currentPlan.diagnostics;
+    if (committed) onCommit(currentPlan.options, currentDiagnostics);
     ctx.ui.setStatus("pi-vimmode", currentDiagnostics.warnings.length > 0 ? "vim ⚠" : "vim");
   };
   const applyFailure = (ctx: ExtensionContext, error: unknown) => {
@@ -161,8 +166,13 @@ function resetKnownEditors(state: EditorState): void {
 }
 
 function createEditorState(dependencies: VimLifecycleDependencies): EditorState {
-  const state: EditorState = {
-    config: createConfigState(dependencies),
+  let state: EditorState;
+  const config = createConfigState(dependencies, (options, diagnostics) => {
+    if (!state?.enabled) return;
+    for (const editor of state.editors) editor.reconfigure(options, diagnostics);
+  });
+  state = {
+    config,
     createEditor:
       dependencies.createEditor ??
       ((tui, theme, keybindings, options, diagnostics, vimOptions) =>

--- a/src/lifecycle.ts
+++ b/src/lifecycle.ts
@@ -285,7 +285,7 @@ export function registerVimLifecycle(
   pi.on("agent_end", (_event, ctx) => {
     state.agentBusy = false;
     for (const editor of state.editors) editor.setAgentBusy(false);
-    void installEditor(state, ctx);
+    observeInstall(installEditor(state, ctx), ctx);
   });
   pi.on("session_shutdown", () => {
     state.agentBusy = false;

--- a/src/lifecycle.ts
+++ b/src/lifecycle.ts
@@ -49,6 +49,7 @@ function createConfigState(dependencies: VimLifecycleDependencies): ConfigState 
   let currentPlan = createVimConfigPlan(dependencies.defaultOptions ?? DEFAULT_VIM_OPTIONS, []);
   let currentDiagnostics: VimDiagnostics = currentPlan.diagnostics;
   let hasCommittedLoad = false;
+  let refreshGeneration = 0;
   const loadOptions = dependencies.loadOptions ?? loadVimOptions;
 
   const apply = (ctx: ExtensionContext, loaded: VimConfigLoadResult) => {
@@ -70,16 +71,17 @@ function createConfigState(dependencies: VimLifecycleDependencies): ConfigState 
     });
   };
   const refresh = (ctx: ExtensionContext): boolean | Promise<boolean> => {
+    const generation = ++refreshGeneration;
     try {
       const loaded = loadOptions({ cwd: ctx.cwd });
       if (loaded instanceof Promise) {
         return loaded.then(
           (result) => {
-            apply(ctx, result);
+            if (generation === refreshGeneration) apply(ctx, result);
             return true;
           },
           (error) => {
-            applyFailure(ctx, error);
+            if (generation === refreshGeneration) applyFailure(ctx, error);
             return true;
           },
         );
@@ -142,7 +144,10 @@ function installEditor(
   }
   const refreshed = state.config.refresh(ctx);
   if (refreshed instanceof Promise) {
-    return refreshed.then(() => finishInstall(state, ctx, force));
+    return refreshed.then(() => {
+      if (state.enabled) finishInstall(state, ctx, force);
+      else ctx.ui.setStatus("pi-vimmode", "vim off");
+    });
   }
   finishInstall(state, ctx, force);
 }

--- a/src/mapping-scopes.ts
+++ b/src/mapping-scopes.ts
@@ -1,0 +1,33 @@
+export const VIM_MAPPING_SCOPES = [
+  "normal",
+  "visual",
+  "visualLine",
+  "visualBlock",
+  "insert",
+  "operatorPending",
+] as const;
+
+export type VimMappingScope = (typeof VIM_MAPPING_SCOPES)[number];
+
+const VISUAL_SCOPES = ["visual", "visualLine", "visualBlock"] as const;
+const NORMAL_AND_VISUAL_SCOPES = ["normal", ...VISUAL_SCOPES] as const;
+
+export function mappingScopesForKeymapEntry(
+  family: string,
+  action: string,
+): readonly VimMappingScope[] {
+  if (family === "motion") {
+    return action === "halfPageDown" || action === "halfPageUp"
+      ? NORMAL_AND_VISUAL_SCOPES
+      : [...NORMAL_AND_VISUAL_SCOPES, "operatorPending"];
+  }
+  if (family === "operator") return NORMAL_AND_VISUAL_SCOPES;
+  if (family === "command" || family === "macro") return ["normal"];
+  if (family === "mark") {
+    return action === "set"
+      ? NORMAL_AND_VISUAL_SCOPES
+      : [...NORMAL_AND_VISUAL_SCOPES, "operatorPending"];
+  }
+  if (family === "insert") return ["insert"];
+  return ["operatorPending"];
+}

--- a/src/mapping-scopes.ts
+++ b/src/mapping-scopes.ts
@@ -8,12 +8,23 @@ export const VIM_MAPPING_SCOPES = [
 ] as const;
 
 export type VimMappingScope = (typeof VIM_MAPPING_SCOPES)[number];
+export type VimMappingFamily =
+  | "operator"
+  | "motion"
+  | "command"
+  | "macro"
+  | "mark"
+  | "insert"
+  | "textObjectKind"
+  | "textObjectTarget"
+  | "textObject.kind"
+  | "textObject.target";
 
 const VISUAL_SCOPES = ["visual", "visualLine", "visualBlock"] as const;
 const NORMAL_AND_VISUAL_SCOPES = ["normal", ...VISUAL_SCOPES] as const;
 
 export function mappingScopesForKeymapEntry(
-  family: string,
+  family: VimMappingFamily,
   action: string,
 ): readonly VimMappingScope[] {
   if (family === "motion") {
@@ -29,5 +40,13 @@ export function mappingScopesForKeymapEntry(
       : [...NORMAL_AND_VISUAL_SCOPES, "operatorPending"];
   }
   if (family === "insert") return ["insert"];
-  return ["operatorPending"];
+  if (
+    family === "textObjectKind" ||
+    family === "textObjectTarget" ||
+    family === "textObject.kind" ||
+    family === "textObject.target"
+  ) {
+    return ["operatorPending"];
+  }
+  return family satisfies never;
 }

--- a/src/mapping-scopes.ts
+++ b/src/mapping-scopes.ts
@@ -20,6 +20,37 @@ export type VimMappingFamily =
   | "textObject.kind"
   | "textObject.target";
 
+const NAMED_TERMINAL_KEYS = new Set([
+  "enter",
+  "tab",
+  "escape",
+  "backspace",
+  "delete",
+  "home",
+  "end",
+  "pageup",
+  "pagedown",
+  "insert",
+  "up",
+  "down",
+  "left",
+  "right",
+]);
+
+export function isAtomicMappingSequence(sequence: string): boolean {
+  return (
+    /^(?:ctrl|alt|shift|super)\+/.test(sequence) ||
+    NAMED_TERMINAL_KEYS.has(sequence) ||
+    /^f\d+$/.test(sequence)
+  );
+}
+
+export function mappingSequencesOverlap(left: string, right: string): boolean {
+  if (left === right) return true;
+  if (isAtomicMappingSequence(left) || isAtomicMappingSequence(right)) return false;
+  return left.startsWith(right) || right.startsWith(left);
+}
+
 const VISUAL_SCOPES = ["visual", "visualLine", "visualBlock"] as const;
 const NORMAL_AND_VISUAL_SCOPES = ["normal", ...VISUAL_SCOPES] as const;
 

--- a/src/modal/engine.ts
+++ b/src/modal/engine.ts
@@ -399,8 +399,14 @@ function remapUpdate(
   key: string,
 ): ModalUpdate | undefined {
   const sequence = `${state.pending ?? ""}${key}`;
-  const remaps = keymapForOptions(options).remaps.accepted.filter(
-    (remap) => !remap.modes || remap.modes.includes(mode),
+  const keymap = keymapForOptions(options);
+  const actionKeys = new Set(
+    keymap.actions.accepted
+      .filter((action) => !action.modes || action.modes.includes(mode))
+      .map((action) => action.key),
+  );
+  const remaps = keymap.remaps.accepted.filter(
+    (remap) => (!remap.modes || remap.modes.includes(mode)) && !actionKeys.has(remap.key),
   );
   const exact = remaps.find((remap) => remap.key === sequence);
   if (exact) {

--- a/src/modal/state.ts
+++ b/src/modal/state.ts
@@ -18,8 +18,10 @@ export function resetTransientState(state: ModalState, mode: VimMode): ModalStat
   if (state.marks) nextState.marks = state.marks;
   if (state.lastCharSearch) nextState.lastCharSearch = state.lastCharSearch;
   if (state.lastSearch) nextState.lastSearch = state.lastSearch;
+  if (state.searchHistory) nextState.searchHistory = state.searchHistory;
   if (state.searchHighlight) nextState.searchHighlight = state.searchHighlight;
   if (state.messageHistory) nextState.messageHistory = state.messageHistory;
+  if (state.exHistory) nextState.exHistory = state.exHistory;
   if (state.lastExSubstitution) nextState.lastExSubstitution = state.lastExSubstitution;
   if (state.lastRepeatableChange) nextState.lastRepeatableChange = state.lastRepeatableChange;
   if (state.lastVisualSelection) nextState.lastVisualSelection = state.lastVisualSelection;

--- a/src/vim-editor.ts
+++ b/src/vim-editor.ts
@@ -221,8 +221,8 @@ export type VimEditorOptions = {
 
 export class VimEditor extends CustomEditor {
   private modalState: ModalState;
-  private options: ResolvedVimEditorOptions;
-  private diagnostics: VimDiagnostics;
+  private readonly options: ResolvedVimEditorOptions;
+  private readonly diagnostics: VimDiagnostics;
   private readonly overlayTheme: EditorTheme;
   private readonly redoStack: RedoSnapshot[] = [];
   private readonly originalHardwareCursorVisible: boolean | undefined;
@@ -249,13 +249,6 @@ export class VimEditor extends CustomEditor {
     this.modalState = createModalState(this.options.startMode);
     this.originalHardwareCursorVisible = this.getHardwareCursorVisibility();
     this.applyTerminalCursorStyle(cursorStyleForMode(this.options, this.modalState.mode));
-  }
-
-  reloadConfig(options: ResolvedVimEditorOptions, diagnostics: VimDiagnostics): void {
-    this.options = cloneOptions(options);
-    this.diagnostics = { warnings: [...diagnostics.warnings] };
-    this.applyTerminalCursorStyle(cursorStyleForMode(this.options, this.modalState.mode));
-    this.invalidate();
   }
 
   getVimMode(): VimMode {

--- a/src/vim-editor.ts
+++ b/src/vim-editor.ts
@@ -53,7 +53,7 @@ import {
   modalPendingDisplay,
 } from "./modal/engine.ts";
 import { appendMessageHistory } from "./modal/inspect.ts";
-import { createModalState } from "./modal/state.ts";
+import { createModalState, resetTransientState } from "./modal/state.ts";
 import { modalStatus } from "./modal/view.ts";
 import {
   cursorShapeEscape,
@@ -215,14 +215,20 @@ function sameRedoSnapshot(a: RedoSnapshot, b: RedoSnapshot): boolean {
   return a.text === b.text && a.cursor.line === b.cursor.line && a.cursor.col === b.cursor.col;
 }
 
+function clampToText(text: string, position: Position): Position {
+  const lines = text.split("\n");
+  const line = Math.max(0, Math.min(position.line, lines.length - 1));
+  return { line, col: Math.max(0, Math.min(position.col, lines[line]!.length)) };
+}
+
 export type VimEditorOptions = {
   onShutdown?: () => void;
 };
 
 export class VimEditor extends CustomEditor {
   private modalState: ModalState;
-  private readonly options: ResolvedVimEditorOptions;
-  private readonly diagnostics: VimDiagnostics;
+  private options: ResolvedVimEditorOptions;
+  private diagnostics: VimDiagnostics;
   private readonly overlayTheme: EditorTheme;
   private readonly redoStack: RedoSnapshot[] = [];
   private readonly originalHardwareCursorVisible: boolean | undefined;
@@ -277,6 +283,31 @@ export class VimEditor extends CustomEditor {
 
   getCurrentCursorStyle(): CursorStyle {
     return cursorStyleForMode(this.options, this.modalState.mode);
+  }
+
+  reconfigure(options: ResolvedVimEditorOptions, diagnostics: VimDiagnostics): void {
+    this.options = cloneOptions(options);
+    this.diagnostics = { warnings: [...diagnostics.warnings] };
+    const { recordingSlot: _recordingSlot, ...reset } = resetTransientState(
+      this.modalState,
+      this.modalState.mode,
+    );
+    const text = this.getText();
+    if (this.modalState.visualAnchor && this.modalState.mode.startsWith("visual")) {
+      reset.visualAnchor = clampToText(text, this.modalState.visualAnchor);
+    }
+    if (reset.lastVisualSelection) {
+      reset.lastVisualSelection = {
+        ...reset.lastVisualSelection,
+        anchor: clampToText(text, reset.lastVisualSelection.anchor),
+        cursor: clampToText(text, reset.lastVisualSelection.cursor),
+      };
+    }
+    this.modalState = reset;
+    this.helpOverlay?.hide();
+    this.helpOverlay = undefined;
+    this.applyTerminalCursorStyle(this.getCurrentCursorStyle());
+    this.invalidate();
   }
 
   setAgentBusy(active: boolean): void {

--- a/src/vim-editor.ts
+++ b/src/vim-editor.ts
@@ -221,8 +221,8 @@ export type VimEditorOptions = {
 
 export class VimEditor extends CustomEditor {
   private modalState: ModalState;
-  private readonly options: ResolvedVimEditorOptions;
-  private readonly diagnostics: VimDiagnostics;
+  private options: ResolvedVimEditorOptions;
+  private diagnostics: VimDiagnostics;
   private readonly overlayTheme: EditorTheme;
   private readonly redoStack: RedoSnapshot[] = [];
   private readonly originalHardwareCursorVisible: boolean | undefined;
@@ -249,6 +249,13 @@ export class VimEditor extends CustomEditor {
     this.modalState = createModalState(this.options.startMode);
     this.originalHardwareCursorVisible = this.getHardwareCursorVisibility();
     this.applyTerminalCursorStyle(cursorStyleForMode(this.options, this.modalState.mode));
+  }
+
+  reloadConfig(options: ResolvedVimEditorOptions, diagnostics: VimDiagnostics): void {
+    this.options = cloneOptions(options);
+    this.diagnostics = { warnings: [...diagnostics.warnings] };
+    this.applyTerminalCursorStyle(cursorStyleForMode(this.options, this.modalState.mode));
+    this.invalidate();
   }
 
   getVimMode(): VimMode {

--- a/test/commands.test.ts
+++ b/test/commands.test.ts
@@ -367,6 +367,26 @@ describe("normal command parser", () => {
     });
   });
 
+  test("named terminal command mappings stay atomic at runtime", () => {
+    const keymap = resolveVimOptions({
+      piVimMode: { keymap: { commands: { undo: ["<Home>", "<F1>"] } } },
+    }).options.keymap!;
+
+    expect(resolveNormalCommand("h", undefined, keymap)).toEqual({
+      type: "motion",
+      motion: "left",
+    });
+    expect(resolveNormalCommand("f", undefined, keymap)).toMatchObject({ type: "pending" });
+    expect(resolveNormalCommand("home", undefined, keymap)).toMatchObject({
+      type: "command",
+      command: "undo",
+    });
+    expect(resolveNormalCommand("f1", undefined, keymap)).toMatchObject({
+      type: "command",
+      command: "undo",
+    });
+  });
+
   test("resolves configured semantic operators, motions, and commands", () => {
     const keymap = {
       ...DEFAULT_VIM_KEYMAP,

--- a/test/config-js.test.ts
+++ b/test/config-js.test.ts
@@ -352,6 +352,60 @@ export default (vim) => {
     expect(result.plan.scopes.normal.exact.zq?.id).toBe("prompt.transform.reflow");
   });
 
+  test("project leader actions override lower JS remaps after final expansion", () => {
+    const result = resolveVimOptions(
+      undefined,
+      {
+        piVimMode: {
+          leader: ",",
+          keymap: {
+            actions: { "prompt.transform.quote": [{ key: "<leader>u", modes: ["normal"] }] },
+          },
+        },
+      },
+      {
+        kind: "success",
+        warnings: [],
+        operations: [
+          {
+            kind: "map",
+            mapping: { kind: "remap", key: ",u", inputs: ["l"], modes: ["normal"] },
+          },
+        ],
+      },
+    );
+
+    expect(result.options.keymap?.remaps.accepted).toEqual([]);
+    expect(result.plan.scopes.normal.exact[",u"]?.id).toBe("prompt.transform.quote");
+  });
+
+  test("project escape mappings override lower JS remaps in visual scopes", () => {
+    const result = resolveVimOptions(
+      undefined,
+      { piVimMode: { keymap: { escape: ["<D-j>"] } } },
+      {
+        kind: "success",
+        warnings: [],
+        operations: [
+          {
+            kind: "map",
+            mapping: {
+              kind: "remap",
+              key: "super+j",
+              inputs: ["l"],
+              modes: ["visual", "visualLine", "visualBlock"],
+            },
+          },
+        ],
+      },
+    );
+
+    expect(result.options.keymap?.remaps.accepted).toEqual([]);
+    for (const scope of ["visual", "visualLine", "visualBlock"] as const) {
+      expect(result.plan.scopes[scope].exact["super+j"]?.kind).toBe("escape");
+    }
+  });
+
   test("invalid remap modes are dropped", () => {
     const result = resolveVimOptions(undefined, undefined, {
       appendKeymap: true,

--- a/test/config-js.test.ts
+++ b/test/config-js.test.ts
@@ -259,6 +259,40 @@ export default (vim) => {
     expect(result.plan.scopes.normal.exact.zq?.id).toBe("prompt.transform.quote");
   });
 
+  test("later JS remap replaces lower action in only claimed scopes", () => {
+    const result = resolveVimOptions(
+      {
+        piVimMode: {
+          keymap: {
+            actions: {
+              "prompt.transform.quote": [{ key: "zq", modes: ["normal", "visual"] }],
+            },
+          },
+        },
+      },
+      undefined,
+      {
+        kind: "success",
+        warnings: [],
+        operations: [
+          {
+            kind: "map",
+            mapping: { kind: "remap", key: "zq", inputs: ["l"], modes: ["normal"] },
+          },
+        ],
+      },
+    );
+
+    expect(result.plan.scopes.normal.exact.zq?.kind).toBe("remap");
+    expect(result.plan.scopes.visual.exact.zq?.kind).toBe("action");
+    expect(result.options.keymap?.actions.accepted).toEqual([
+      expect.objectContaining({ actionId: "prompt.transform.quote", modes: ["visual"] }),
+    ]);
+    expect(result.options.keymap?.remaps.accepted).toEqual([
+      { key: "zq", inputs: ["l"], modes: ["normal"] },
+    ]);
+  });
+
   test("action bindings on same key survive in disjoint modes", () => {
     const result = resolveVimOptions(undefined, undefined, {
       appendKeymap: true,
@@ -300,7 +334,12 @@ export default (vim) => {
         operations: [
           {
             kind: "map",
-            mapping: { kind: "remap", key: "zab", inputs: ["l"], modes: ["normal"] },
+            mapping: {
+              kind: "remap",
+              key: "zab",
+              inputs: ["l"],
+              modes: ["normal", "visual"],
+            },
           },
         ],
       },
@@ -308,6 +347,10 @@ export default (vim) => {
 
     expect(result.plan.scopes.normal.exact.za?.id).toBe("command.undo");
     expect(result.plan.scopes.normal.exact.zab).toBeUndefined();
+    expect(result.plan.scopes.visual.exact.zab?.kind).toBe("remap");
+    expect(result.options.keymap?.remaps.accepted).toEqual([
+      { key: "zab", inputs: ["l"], modes: ["visual"] },
+    ]);
     expect(result.warnings).toEqual([
       expect.stringContaining("remap.zab in normal: strict-prefix conflict with command.undo.za"),
     ]);
@@ -379,7 +422,7 @@ export default (vim) => {
     expect(result.plan.scopes.normal.exact[",u"]?.id).toBe("prompt.transform.quote");
   });
 
-  test("project escape mappings override lower JS remaps in visual scopes", () => {
+  test("project escape mappings override lower JS mappings in escape scopes", () => {
     const result = resolveVimOptions(
       undefined,
       { piVimMode: { keymap: { escape: ["<D-j>"] } } },
@@ -396,12 +439,17 @@ export default (vim) => {
               modes: ["visual", "visualLine", "visualBlock"],
             },
           },
+          {
+            kind: "map",
+            mapping: { kind: "insert", action: "openLineBelow", key: "super+j" },
+          },
         ],
       },
     );
 
     expect(result.options.keymap?.remaps.accepted).toEqual([]);
-    for (const scope of ["visual", "visualLine", "visualBlock"] as const) {
+    expect(result.options.keymap?.insert.openLineBelow).not.toContain("super+j");
+    for (const scope of ["insert", "visual", "visualLine", "visualBlock"] as const) {
       expect(result.plan.scopes[scope].exact["super+j"]?.kind).toBe("escape");
     }
   });

--- a/test/config-js.test.ts
+++ b/test/config-js.test.ts
@@ -235,6 +235,30 @@ export default (vim) => {
     expect(result.options.keymap?.commands.insertBefore).toEqual(["z"]);
   });
 
+  test("project exact action replaces inherited JS remap", () => {
+    const result = resolveVimOptions(
+      undefined,
+      {
+        piVimMode: {
+          keymap: { actions: { "prompt.transform.quote": [{ key: "zq", modes: ["normal"] }] } },
+        },
+      },
+      {
+        kind: "success",
+        warnings: [],
+        operations: [
+          {
+            kind: "map",
+            mapping: { kind: "remap", key: "zq", inputs: ["l"], modes: ["normal"] },
+          },
+        ],
+      },
+    );
+
+    expect(result.options.keymap?.remaps.accepted).toEqual([]);
+    expect(result.plan.scopes.normal.exact.zq?.id).toBe("prompt.transform.quote");
+  });
+
   test("action bindings on same key survive in disjoint modes", () => {
     const result = resolveVimOptions(undefined, undefined, {
       appendKeymap: true,
@@ -264,6 +288,68 @@ export default (vim) => {
         modes: ["visual"],
       },
     ]);
+  });
+
+  test("plan preflights remap strict-prefix conflicts in concrete scope", () => {
+    const result = resolveVimOptions(
+      { piVimMode: { keymap: { commands: { undo: ["za"] } } } },
+      undefined,
+      {
+        kind: "success",
+        warnings: [],
+        operations: [
+          {
+            kind: "map",
+            mapping: { kind: "remap", key: "zab", inputs: ["l"], modes: ["normal"] },
+          },
+        ],
+      },
+    );
+
+    expect(result.plan.scopes.normal.exact.za?.id).toBe("command.undo");
+    expect(result.plan.scopes.normal.exact.zab).toBeUndefined();
+    expect(result.warnings).toEqual([
+      expect.stringContaining("remap.zab in normal: strict-prefix conflict with command.undo.za"),
+    ]);
+  });
+
+  test("latest same-scope JS exact mapping wins", () => {
+    const result = resolveVimOptions(undefined, undefined, {
+      kind: "success",
+      warnings: [],
+      operations: [
+        {
+          kind: "map",
+          mapping: {
+            kind: "action",
+            actionId: "prompt.transform.quote",
+            key: "zq",
+            modes: ["normal"],
+          },
+        },
+        {
+          kind: "map",
+          mapping: {
+            kind: "action",
+            actionId: "prompt.transform.reflow",
+            key: "zq",
+            args: {},
+            modes: ["normal"],
+          },
+        },
+      ],
+    });
+
+    expect(result.warnings).toEqual([]);
+    expect(result.options.keymap?.actions.accepted).toEqual([
+      {
+        actionId: "prompt.transform.reflow",
+        key: "zq",
+        args: { action: "reflow" },
+        modes: ["normal"],
+      },
+    ]);
+    expect(result.plan.scopes.normal.exact.zq?.id).toBe("prompt.transform.reflow");
   });
 
   test("invalid remap modes are dropped", () => {

--- a/test/config-js.test.ts
+++ b/test/config-js.test.ts
@@ -356,6 +356,30 @@ export default (vim) => {
     ]);
   });
 
+  test("printable plus sequences participate in strict-prefix preflight", () => {
+    const result = resolveVimOptions(
+      { piVimMode: { keymap: { commands: { undo: ["g+"] } } } },
+      undefined,
+      {
+        kind: "success",
+        warnings: [],
+        operations: [
+          {
+            kind: "map",
+            mapping: { kind: "remap", key: "g+x", inputs: ["l"], modes: ["normal"] },
+          },
+        ],
+      },
+    );
+
+    expect(result.plan.scopes.normal.exact["g+"]?.id).toBe("command.undo");
+    expect(result.plan.scopes.normal.exact["g+x"]).toBeUndefined();
+    expect(result.plan.scopes.normal.prefixes["g+"]).toBeUndefined();
+    expect(result.warnings).toEqual([
+      expect.stringContaining("remap.g+x in normal: strict-prefix conflict with command.undo.g+"),
+    ]);
+  });
+
   test("latest same-scope JS exact mapping wins", () => {
     const result = resolveVimOptions(undefined, undefined, {
       kind: "success",

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -101,6 +101,15 @@ describe("vim config parsing", () => {
     ).toThrow();
   });
 
+  test("named terminal keys compile atomically without character prefixes", () => {
+    const result = resolveVimOptions({
+      piVimMode: { keymap: { commands: { undo: ["<Home>"] } } },
+    });
+
+    expect(result.plan.scopes.normal.exact.home?.id).toBe("command.undo");
+    expect(result.plan.scopes.normal.prefixes.h).toBeUndefined();
+  });
+
   test("immutable plan does not share configured nested fields", () => {
     const settings = {
       piVimMode: {
@@ -119,6 +128,12 @@ describe("vim config parsing", () => {
     expect(settings.piVimMode.promptTransforms.commands.quote).toEqual(["qte"]);
     expect(settings.piVimMode.ui.status.items).toEqual(["mode", "selection"]);
     expect(settings.piVimMode.ui.mode.labels.normal).toBe("COMMAND");
+    expect(options.keymap?.motions.wordForward).not.toBe(
+      settings.piVimMode.keymap.motions.wordForward,
+    );
+    expect(options.ui?.status.items).not.toBe(settings.piVimMode.ui.status.items);
+    expect(Object.isFrozen(settings.piVimMode.keymap.motions.wordForward)).toBe(false);
+    expect(Object.isFrozen(settings.piVimMode.ui.status.items)).toBe(false);
     expect(options.keymap?.motions.left).toEqual(["h", "left"]);
     expect(DEFAULT_VIM_OPTIONS.keymap?.motions.left).toEqual(["h", "left"]);
   });

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -77,26 +77,29 @@ describe("vim config parsing", () => {
     expect(options.ui?.status.position).toBe("left");
   });
 
-  test("resolved defaults do not share mutable nested config fields", () => {
-    const options = resolveVimOptions(undefined).options;
+  test("compiles resolved options and scoped lookups into one immutable plan", () => {
+    const result = resolveVimOptions({
+      piVimMode: {
+        keymap: { motions: { wordForward: ["zw"] } },
+        promptTransforms: { commands: { quote: ["qte"] } },
+      },
+    });
 
-    (options.keymap!.motions.wordForward as unknown as string[]).push("custom-word");
-    (options.promptTransforms!.commands.quote as unknown as string[]).push("custom-quote");
-    (options.ui!.status.items as unknown as string[]).push("mode");
-    if (options.ui) options.ui.mode.labels.normal = "COMMAND";
-
-    expect(DEFAULT_VIM_OPTIONS.keymap?.motions.wordForward).toEqual(["w"]);
-    expect(DEFAULT_VIM_OPTIONS.promptTransforms?.commands.quote).toEqual(["quote"]);
-    expect(DEFAULT_VIM_OPTIONS.ui?.status.items).toEqual([
-      "mode",
-      "pendingOperator",
-      "selection",
-      "cursorPosition",
-    ]);
-    expect(DEFAULT_VIM_OPTIONS.ui?.mode.labels.normal).toBe("NORMAL");
+    expect(result.plan.options).toBe(result.options);
+    expect(Object.isFrozen(result.plan)).toBe(true);
+    expect(Object.isFrozen(result.plan.options)).toBe(true);
+    expect(Object.isFrozen(result.plan.options.keymap?.motions.wordForward)).toBe(true);
+    expect(Object.isFrozen(result.plan.scopes)).toBe(true);
+    expect(result.plan.scopes.normal.exact.zw?.id).toBe("motion.wordForward");
+    expect(result.plan.scopes.normal.prefixes.z).toEqual(["zw"]);
+    expect(result.plan.scopes.operatorPending.exact.zw?.id).toBe("motion.wordForward");
+    expect(result.plan.scopes.insert.exact.zw).toBeUndefined();
+    expect(() =>
+      (result.plan.options.keymap!.motions.wordForward as unknown as string[]).push("custom-word"),
+    ).toThrow();
   });
 
-  test("resolved configured options do not share mutable nested config fields", () => {
+  test("immutable plan does not share configured nested fields", () => {
     const settings = {
       piVimMode: {
         keymap: { motions: { wordForward: ["q"] }, commands: { openLineBelow: ["n"] } },
@@ -108,12 +111,6 @@ describe("vim config parsing", () => {
       },
     };
     const options = resolveVimOptions(settings).options;
-
-    (options.keymap!.motions.wordForward as unknown as string[]).push("custom-word");
-    (options.keymap!.commands.openLineBelow as unknown as string[]).push("custom-open");
-    (options.promptTransforms!.commands.quote as unknown as string[]).push("custom-quote");
-    (options.ui!.status.items as unknown as string[]).push("cursorPosition");
-    if (options.ui) options.ui.mode.labels.normal = "NORMAL-MUTATED";
 
     expect(settings.piVimMode.keymap.motions.wordForward).toEqual(["q"]);
     expect(settings.piVimMode.keymap.commands.openLineBelow).toEqual(["n"]);
@@ -709,13 +706,13 @@ describe("vim config parsing", () => {
       );
     });
 
-    test("insert bindings survive cloning without sharing arrays with defaults", () => {
+    test("insert bindings compile as immutable arrays without sharing defaults", () => {
       const result = resolveVimOptions({
         piVimMode: {
           keymap: { insert: { openLineBelow: ["ctrl+j"] } },
         },
       });
-      (result.options.keymap!.insert.openLineBelow as unknown as string[]).push("ctrl+k");
+      expect(Object.isFrozen(result.options.keymap!.insert.openLineBelow)).toBe(true);
       expect(DEFAULT_VIM_OPTIONS.keymap?.insert.openLineBelow).toEqual([]);
     });
 
@@ -1629,6 +1626,40 @@ describe("vim config parsing", () => {
     expect(result.warnings).not.toEqual(
       expect.arrayContaining([expect.stringContaining("protected key ctrl+p")]),
     );
+  });
+
+  test("rejects later strict-prefix action overlap per scope", () => {
+    const result = resolveVimOptions({
+      piVimMode: {
+        keymap: {
+          actions: {
+            "prompt.transform.quote": [{ key: "za", modes: ["normal"] }],
+            "prompt.transform.reflow": [
+              { key: "zab", modes: ["normal"] },
+              { key: "zab", modes: ["visual"] },
+            ],
+          },
+        },
+      },
+    });
+
+    expect(result.options.keymap?.actions.accepted).toEqual([
+      {
+        key: "za",
+        actionId: "prompt.transform.quote",
+        args: { action: "quote" },
+        modes: ["normal"],
+      },
+      {
+        key: "zab",
+        actionId: "prompt.transform.reflow",
+        args: { action: "reflow" },
+        modes: ["visual"],
+      },
+    ]);
+    expect(result.warnings).toEqual([
+      expect.stringContaining("strict-prefix conflict with prompt.transform.quote.za"),
+    ]);
   });
 
   test("rejects action conflicts but allows shared non-executable prefixes", () => {

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -103,11 +103,13 @@ describe("vim config parsing", () => {
 
   test("named terminal keys compile atomically without character prefixes", () => {
     const result = resolveVimOptions({
-      piVimMode: { keymap: { commands: { undo: ["<Home>"] } } },
+      piVimMode: { keymap: { commands: { undo: ["<Home>", "<F1>"] } } },
     });
 
     expect(result.plan.scopes.normal.exact.home?.id).toBe("command.undo");
+    expect(result.plan.scopes.normal.exact.f1?.id).toBe("command.undo");
     expect(result.plan.scopes.normal.prefixes.h).toBeUndefined();
+    expect(result.plan.scopes.normal.prefixes.f).toBeUndefined();
   });
 
   test("immutable plan does not share configured nested fields", () => {

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -1520,6 +1520,34 @@ describe("vim config parsing", () => {
     }
   });
 
+  test("project exact actions override inherited grammar in only claimed scopes", () => {
+    const result = resolveVimOptions(undefined, {
+      piVimMode: {
+        keymap: {
+          actions: {
+            "prompt.transform.quote": [{ key: "u", modes: ["normal"] }],
+          },
+        },
+      },
+    });
+
+    expect(result.options.keymap?.actions.accepted).toEqual([
+      {
+        key: "u",
+        actionId: "prompt.transform.quote",
+        args: { action: "quote" },
+        modes: ["normal"],
+      },
+    ]);
+    expect(result.plan.scopes.normal.exact.u).toEqual({
+      kind: "action",
+      id: "prompt.transform.quote",
+      args: { action: "quote" },
+    });
+    expect(result.plan.scopes.visual.exact.u).toBeUndefined();
+    expect(result.warnings.join("\n")).not.toContain("conflicts with commands.undo");
+  });
+
   test("project action bindings replace global bindings and empty arrays unbind", () => {
     const replaced = resolveVimOptions(
       { piVimMode: { keymap: { actions: { "prompt.transform.reflow": ["gq"] } } } },
@@ -1660,6 +1688,28 @@ describe("vim config parsing", () => {
     expect(result.warnings).toEqual([
       expect.stringContaining("strict-prefix conflict with prompt.transform.quote.za"),
     ]);
+  });
+
+  test("keeps non-conflicting scopes from one multi-scope action binding", () => {
+    const result = resolveVimOptions({
+      piVimMode: {
+        keymap: {
+          actions: {
+            "prompt.transform.quote": [{ key: "za", modes: ["normal"] }],
+            "prompt.transform.reflow": [{ key: "zab", modes: ["normal", "visual"] }],
+          },
+        },
+      },
+    });
+
+    expect(result.options.keymap?.actions.accepted).toContainEqual({
+      key: "zab",
+      actionId: "prompt.transform.reflow",
+      args: { action: "reflow" },
+      modes: ["visual"],
+    });
+    expect(result.plan.scopes.visual.exact.zab?.id).toBe("prompt.transform.reflow");
+    expect(result.plan.scopes.normal.exact.zab).toBeUndefined();
   });
 
   test("rejects action conflicts but allows shared non-executable prefixes", () => {

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -80,7 +80,7 @@ describe("vim config parsing", () => {
   test("compiles resolved options and scoped lookups into one immutable plan", () => {
     const result = resolveVimOptions({
       piVimMode: {
-        keymap: { motions: { wordForward: ["zw"] } },
+        keymap: { escape: ["<C-j>"], motions: { wordForward: ["zw"] } },
         promptTransforms: { commands: { quote: ["qte"] } },
       },
     });
@@ -93,6 +93,8 @@ describe("vim config parsing", () => {
     expect(result.plan.scopes.normal.exact.zw?.id).toBe("motion.wordForward");
     expect(result.plan.scopes.normal.prefixes.z).toEqual(["zw"]);
     expect(result.plan.scopes.operatorPending.exact.zw?.id).toBe("motion.wordForward");
+    expect(result.plan.scopes.operatorPending.exact["ctrl+j"]?.kind).toBe("escape");
+    expect(result.plan.scopes.normal.prefixes.ctrl).toBeUndefined();
     expect(result.plan.scopes.insert.exact.zw).toBeUndefined();
     expect(() =>
       (result.plan.options.keymap!.motions.wordForward as unknown as string[]).push("custom-word"),
@@ -386,7 +388,11 @@ describe("vim config parsing", () => {
   test("merges status position across global, JS, and project fields", () => {
     const result = resolveVimOptions(
       { piVimMode: { ui: { status: { position: "right" } } } },
-      { piVimMode: { ui: { mode: { narrowLabels: { normal: "P" } } } } },
+      {
+        piVimMode: {
+          ui: { status: { position: "right" }, mode: { narrowLabels: { normal: "P" } } },
+        },
+      },
       {
         partial: {
           ui: { status: { position: "left" }, mode: { labels: { normal: "JS" } } },
@@ -395,7 +401,7 @@ describe("vim config parsing", () => {
     );
 
     expect(result.warnings).toEqual([]);
-    expect(result.options.ui?.status.position).toBe("left");
+    expect(result.options.ui?.status.position).toBe("right");
     expect(result.options.ui?.mode.labels.normal).toBe("JS");
     expect(result.options.ui?.mode.narrowLabels.normal).toBe("P");
   });

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -1548,6 +1548,31 @@ describe("vim config parsing", () => {
     expect(result.warnings.join("\n")).not.toContain("conflicts with commands.undo");
   });
 
+  test("project leader actions override inherited grammar after final leader expansion", () => {
+    const result = resolveVimOptions(
+      { piVimMode: { keymap: { commands: { undo: [",u"] } } } },
+      {
+        piVimMode: {
+          leader: ",",
+          keymap: {
+            actions: { "prompt.transform.quote": [{ key: "<leader>u", modes: ["normal"] }] },
+          },
+        },
+      },
+    );
+
+    expect(result.options.keymap?.actions.accepted).toEqual([
+      {
+        key: ",u",
+        actionId: "prompt.transform.quote",
+        args: { action: "quote" },
+        modes: ["normal"],
+      },
+    ]);
+    expect(result.plan.scopes.normal.exact[",u"]?.id).toBe("prompt.transform.quote");
+    expect(result.warnings.join("\n")).not.toContain("conflicts with commands.undo");
+  });
+
   test("project action bindings replace global bindings and empty arrays unbind", () => {
     const replaced = resolveVimOptions(
       { piVimMode: { keymap: { actions: { "prompt.transform.reflow": ["gq"] } } } },

--- a/test/lifecycle.test.ts
+++ b/test/lifecycle.test.ts
@@ -563,6 +563,19 @@ describe("vim extension lifecycle", () => {
     expect(createdEditors.map((editor) => editor.options.startMode)).toEqual(["insert", "normal"]);
   });
 
+  test("vimmode reload stays disabled after refreshing options", async () => {
+    const { hooks, commands, loadCalls } = createLifecycleHarness();
+    const ctx = createContext("/repo");
+
+    hooks.get("session_start")?.({}, ctx);
+    await commands.get("vimmode")?.handler("off", ctx);
+    await commands.get("vimmode")?.handler("reload", ctx);
+
+    expect(loadCalls).toEqual([{ cwd: "/repo" }, { cwd: "/repo" }]);
+    expect(ctx.ui.component).toBeUndefined();
+    expect(ctx.ui.notifications.at(-1)).toEqual(["pi-vimmode config reloaded (disabled)", "info"]);
+  });
+
   test("stale vimmode reload cannot reinstall an older context", async () => {
     const { hooks, commands, deferredLoads, resolveDeferred, shutdownCallbacks } =
       createLifecycleHarness();

--- a/test/lifecycle.test.ts
+++ b/test/lifecycle.test.ts
@@ -563,6 +563,31 @@ describe("vim extension lifecycle", () => {
     expect(createdEditors.map((editor) => editor.options.startMode)).toEqual(["insert", "normal"]);
   });
 
+  test("stale vimmode reload cannot reinstall an older context", async () => {
+    const { hooks, commands, deferredLoads, resolveDeferred, shutdownCallbacks } =
+      createLifecycleHarness();
+    const older = createContext("/older");
+    const newer = createContext("/newer");
+
+    hooks.get("session_start")?.({}, older);
+    deferredLoads.add(1);
+    const reload = commands.get("vimmode")?.handler("reload", older);
+    hooks.get("agent_end")?.({}, newer);
+    resolveDeferred.get(1)?.({
+      plan: createVimConfigPlan(DEFAULT_VIM_OPTIONS, []),
+      options: DEFAULT_VIM_OPTIONS,
+      warnings: [],
+      fatal: false,
+    });
+    await reload;
+
+    newer.ui.component?.({}, {}, {});
+    shutdownCallbacks[0]?.();
+    expect(older.shutdownCalls).toBe(0);
+    expect(newer.shutdownCalls).toBe(1);
+    expect(older.ui.notifications).toEqual([]);
+  });
+
   test("vimmode command toggles editor off and on", async () => {
     const { hooks, commands, createdEditors } = createLifecycleHarness();
     const ctx = createContext("/repo");

--- a/test/lifecycle.test.ts
+++ b/test/lifecycle.test.ts
@@ -45,7 +45,9 @@ type FakeEditor = {
   options: ResolvedVimEditorOptions;
   diagnostics: VimDiagnostics;
   busyCalls: boolean[];
+  reconfigureCalls: Array<[ResolvedVimEditorOptions, VimDiagnostics]>;
   resetCount: number;
+  reconfigure: (options: ResolvedVimEditorOptions, diagnostics: VimDiagnostics) => void;
   resetTerminalCursorStyle: () => void;
   setAgentBusy: (active: boolean) => void;
 };
@@ -138,7 +140,13 @@ function createLifecycleHarness(
         options: editorOptions,
         diagnostics,
         busyCalls: [],
+        reconfigureCalls: [],
         resetCount: 0,
+        reconfigure: (options, nextDiagnostics) => {
+          editor.options = options;
+          editor.diagnostics = nextDiagnostics;
+          editor.reconfigureCalls.push([options, nextDiagnostics]);
+        },
         resetTerminalCursorStyle: () => {
           editor.resetCount += 1;
         },
@@ -338,7 +346,7 @@ describe("vim extension lifecycle", () => {
     expect(ctx.ui.setCalls[0]).toBe(ctx.ui.setCalls[1]);
   });
 
-  test("settings refresh updates status and new editor options", () => {
+  test("settings refresh reconfigures active editors and updates new editor options", () => {
     const { hooks, warnings, createdEditors, loadCalls } = createLifecycleHarness();
     warnings.push([], ["bad config"]);
     const ctx = createContext("/repo");
@@ -354,11 +362,12 @@ describe("vim extension lifecycle", () => {
       ["pi-vimmode", "vim"],
       ["pi-vimmode", "vim ⚠"],
     ]);
-    expect(createdEditors.map((editor) => editor.options.startMode)).toEqual(["insert", "normal"]);
+    expect(createdEditors.map((editor) => editor.options.startMode)).toEqual(["normal", "normal"]);
     expect(createdEditors.map((editor) => editor.diagnostics.warnings)).toEqual([
-      [],
+      ["bad config"],
       ["bad config"],
     ]);
+    expect(createdEditors[0]!.reconfigureCalls).toHaveLength(1);
   });
 
   test("fatal first load commits its usable JSON-backed plan", () => {
@@ -495,6 +504,7 @@ describe("vim extension lifecycle", () => {
       [],
       ["fatal JS config"],
     ]);
+    expect(createdEditors[0]!.reconfigureCalls).toHaveLength(0);
     expect(ctx.ui.statuses.at(-1)).toEqual(["pi-vimmode", "vim ⚠"]);
   });
 
@@ -560,7 +570,7 @@ describe("vim extension lifecycle", () => {
     expect(loadCalls).toEqual([{ cwd: "/repo" }, { cwd: "/repo" }]);
     expect(ctx.ui.component).toBe(factory);
     expect(ctx.ui.notifications.at(-1)).toEqual(["pi-vimmode reloaded", "info"]);
-    expect(createdEditors.map((editor) => editor.options.startMode)).toEqual(["insert", "normal"]);
+    expect(createdEditors.map((editor) => editor.options.startMode)).toEqual(["normal", "normal"]);
   });
 
   test("vimmode reload stays disabled after refreshing options", async () => {

--- a/test/lifecycle.test.ts
+++ b/test/lifecycle.test.ts
@@ -520,7 +520,7 @@ describe("vim extension lifecycle", () => {
     expect(createdEditors[0]!.reconfigureCalls).toHaveLength(0);
   });
 
-  test("delayed async reinstall catches stale context rejection", async () => {
+  test("delayed async reinstall reports current-context failures", async () => {
     const normal = { ...DEFAULT_VIM_OPTIONS, startMode: "normal" as const };
     const { hooks, scheduled, deferredLoads, resolveDeferred } = createLifecycleHarness([
       normal,
@@ -543,6 +543,10 @@ describe("vim extension lifecycle", () => {
     await new Promise((resolve) => setTimeout(resolve, 0));
 
     expect(ctx.ui.component).toBeDefined();
+    expect(ctx.ui.notifications).toContainEqual([
+      "pi-vimmode install failed: stale context",
+      "error",
+    ]);
   });
 
   test("delayed reinstall refreshes settings and catches stale context failures", () => {

--- a/test/lifecycle.test.ts
+++ b/test/lifecycle.test.ts
@@ -42,7 +42,6 @@ type FakeEditor = {
   diagnostics: VimDiagnostics;
   busyCalls: boolean[];
   resetCount: number;
-  reloadConfig: (options: ResolvedVimEditorOptions, diagnostics: VimDiagnostics) => void;
   resetTerminalCursorStyle: () => void;
   setAgentBusy: (active: boolean) => void;
 };
@@ -126,10 +125,6 @@ function createLifecycleHarness(
         diagnostics,
         busyCalls: [],
         resetCount: 0,
-        reloadConfig: (options, diagnostics) => {
-          editor.options = options;
-          editor.diagnostics = diagnostics;
-        },
         resetTerminalCursorStyle: () => {
           editor.resetCount += 1;
         },
@@ -341,9 +336,9 @@ describe("vim extension lifecycle", () => {
       ["pi-vimmode", "vim"],
       ["pi-vimmode", "vim ⚠"],
     ]);
-    expect(createdEditors.map((editor) => editor.options.startMode)).toEqual(["normal", "normal"]);
+    expect(createdEditors.map((editor) => editor.options.startMode)).toEqual(["insert", "normal"]);
     expect(createdEditors.map((editor) => editor.diagnostics.warnings)).toEqual([
-      ["bad config"],
+      [],
       ["bad config"],
     ]);
   });
@@ -362,7 +357,7 @@ describe("vim extension lifecycle", () => {
 
     expect(createdEditors.map((editor) => editor.options.startMode)).toEqual(["insert", "insert"]);
     expect(createdEditors.map((editor) => editor.diagnostics.warnings)).toEqual([
-      ["fatal JS config"],
+      [],
       ["fatal JS config"],
     ]);
     expect(ctx.ui.statuses.at(-1)).toEqual(["pi-vimmode", "vim ⚠"]);
@@ -430,7 +425,7 @@ describe("vim extension lifecycle", () => {
     expect(loadCalls).toEqual([{ cwd: "/repo" }, { cwd: "/repo" }]);
     expect(ctx.ui.component).toBe(factory);
     expect(ctx.ui.notifications.at(-1)).toEqual(["pi-vimmode reloaded", "info"]);
-    expect(createdEditors.map((editor) => editor.options.startMode)).toEqual(["normal", "normal"]);
+    expect(createdEditors.map((editor) => editor.options.startMode)).toEqual(["insert", "normal"]);
   });
 
   test("vimmode command toggles editor off and on", async () => {

--- a/test/lifecycle.test.ts
+++ b/test/lifecycle.test.ts
@@ -508,6 +508,43 @@ describe("vim extension lifecycle", () => {
     expect(ctx.ui.statuses.at(-1)).toEqual(["pi-vimmode", "vim ⚠"]);
   });
 
+  test("unchanged delayed refresh does not reset active editor state", () => {
+    const normal = { ...DEFAULT_VIM_OPTIONS, startMode: "normal" as const };
+    const { hooks, scheduled, createdEditors } = createLifecycleHarness([normal, normal]);
+    const ctx = createContext("/repo");
+
+    hooks.get("session_start")?.({}, ctx);
+    ctx.ui.component?.({}, {}, {});
+    scheduled[0]!();
+
+    expect(createdEditors[0]!.reconfigureCalls).toHaveLength(0);
+  });
+
+  test("delayed async reinstall catches stale context rejection", async () => {
+    const normal = { ...DEFAULT_VIM_OPTIONS, startMode: "normal" as const };
+    const { hooks, scheduled, deferredLoads, resolveDeferred } = createLifecycleHarness([
+      normal,
+      normal,
+    ]);
+    const ctx = createContext("/repo");
+
+    hooks.get("session_start")?.({}, ctx);
+    deferredLoads.add(1);
+    scheduled[0]!();
+    ctx.ui.setStatus = () => {
+      throw new Error("stale context");
+    };
+    resolveDeferred.get(1)?.({
+      plan: createVimConfigPlan(normal, []),
+      options: normal,
+      warnings: [],
+      fatal: false,
+    });
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(ctx.ui.component).toBeDefined();
+  });
+
   test("delayed reinstall refreshes settings and catches stale context failures", () => {
     const { hooks, scheduled, loadCalls } = createLifecycleHarness();
     const ctx = createContext("/repo");

--- a/test/lifecycle.test.ts
+++ b/test/lifecycle.test.ts
@@ -2,7 +2,11 @@ import { describe, expect, test } from "bun:test";
 
 import type { ResolvedVimEditorOptions, VimDiagnostics } from "../src/types.ts";
 
-import { createVimConfigPlan, DEFAULT_VIM_OPTIONS } from "../src/config.ts";
+import {
+  createVimConfigPlan,
+  DEFAULT_VIM_OPTIONS,
+  type VimConfigLoadResult,
+} from "../src/config.ts";
 import { registerVimLifecycle } from "../src/lifecycle.ts";
 
 type HookName =
@@ -94,6 +98,8 @@ function createLifecycleHarness(
   const fatalLoads: boolean[] = [];
   const asyncLoads = new Set<number>();
   const rejectedLoads = new Set<number>();
+  const deferredLoads = new Set<number>();
+  const resolveDeferred = new Map<number, (result: VimConfigLoadResult) => void>();
   let loadIndex = 0;
 
   const pi = {
@@ -121,6 +127,9 @@ function createLifecycleHarness(
         warnings: warning,
         fatal,
       };
+      if (deferredLoads.has(load)) {
+        return new Promise<VimConfigLoadResult>((resolve) => resolveDeferred.set(load, resolve));
+      }
       return asyncLoads.has(load) ? Promise.resolve(result) : result;
     },
     createEditor: (_tui, _theme, _keybindings, editorOptions, diagnostics, vimOptions) => {
@@ -156,6 +165,8 @@ function createLifecycleHarness(
     fatalLoads,
     asyncLoads,
     rejectedLoads,
+    deferredLoads,
+    resolveDeferred,
   };
 }
 
@@ -389,6 +400,56 @@ describe("vim extension lifecycle", () => {
       "global JS config: failed to load (async load failed)",
     ]);
     expect(ctx.ui.statuses.at(-1)).toEqual(["pi-vimmode", "vim ⚠"]);
+  });
+
+  test("newer async refresh stays authoritative when loads resolve out of order", async () => {
+    const normal = { ...DEFAULT_VIM_OPTIONS, startMode: "normal" as const };
+    const insert = { ...DEFAULT_VIM_OPTIONS, startMode: "insert" as const };
+    const { hooks, deferredLoads, resolveDeferred, createdEditors } = createLifecycleHarness([
+      normal,
+      insert,
+    ]);
+    deferredLoads.add(0).add(1);
+    const ctx = createContext("/repo");
+
+    hooks.get("agent_end")?.({}, ctx);
+    hooks.get("agent_end")?.({}, ctx);
+    resolveDeferred.get(1)?.({
+      plan: createVimConfigPlan(insert, []),
+      options: insert,
+      warnings: [],
+      fatal: false,
+    });
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    resolveDeferred.get(0)?.({
+      plan: createVimConfigPlan(normal, []),
+      options: normal,
+      warnings: [],
+      fatal: false,
+    });
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    ctx.ui.component?.({}, {}, {});
+    expect(createdEditors[0]?.options.startMode).toBe("insert");
+  });
+
+  test("async install cannot reactivate editor after vimmode off", async () => {
+    const { hooks, commands, deferredLoads, resolveDeferred } = createLifecycleHarness();
+    deferredLoads.add(0);
+    const ctx = createContext("/repo");
+
+    hooks.get("agent_end")?.({}, ctx);
+    await commands.get("vimmode")?.handler("off", ctx);
+    resolveDeferred.get(0)?.({
+      plan: createVimConfigPlan(DEFAULT_VIM_OPTIONS, []),
+      options: DEFAULT_VIM_OPTIONS,
+      warnings: [],
+      fatal: false,
+    });
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(ctx.ui.component).toBeUndefined();
+    expect(ctx.ui.statuses.at(-1)).toEqual(["pi-vimmode", "vim off"]);
   });
 
   test("fatal reload updates diagnostics but preserves last-known-good options", () => {

--- a/test/lifecycle.test.ts
+++ b/test/lifecycle.test.ts
@@ -225,6 +225,23 @@ describe("vim extension lifecycle", () => {
     expect(loadCalls).toEqual([{ cwd: "/repo" }]);
   });
 
+  test("agent end reports async install failures", async () => {
+    const { hooks, asyncLoads } = createLifecycleHarness();
+    const ctx = createContext("/repo");
+    asyncLoads.add(0);
+    ctx.ui.setStatus = () => {
+      throw new Error("current context failed");
+    };
+
+    hooks.get("agent_end")?.({}, ctx);
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(ctx.ui.notifications).toContainEqual([
+      "pi-vimmode install failed: current context failed",
+      "error",
+    ]);
+  });
+
   test("agent start marks existing editors busy without installing", () => {
     const { hooks, createdEditors, loadCalls } = createLifecycleHarness();
     const ctx = createContext("/repo");

--- a/test/lifecycle.test.ts
+++ b/test/lifecycle.test.ts
@@ -42,6 +42,7 @@ type FakeEditor = {
   diagnostics: VimDiagnostics;
   busyCalls: boolean[];
   resetCount: number;
+  reloadConfig: (options: ResolvedVimEditorOptions, diagnostics: VimDiagnostics) => void;
   resetTerminalCursorStyle: () => void;
   setAgentBusy: (active: boolean) => void;
 };
@@ -125,6 +126,10 @@ function createLifecycleHarness(
         diagnostics,
         busyCalls: [],
         resetCount: 0,
+        reloadConfig: (options, diagnostics) => {
+          editor.options = options;
+          editor.diagnostics = diagnostics;
+        },
         resetTerminalCursorStyle: () => {
           editor.resetCount += 1;
         },
@@ -336,9 +341,9 @@ describe("vim extension lifecycle", () => {
       ["pi-vimmode", "vim"],
       ["pi-vimmode", "vim ⚠"],
     ]);
-    expect(createdEditors.map((editor) => editor.options.startMode)).toEqual(["insert", "normal"]);
+    expect(createdEditors.map((editor) => editor.options.startMode)).toEqual(["normal", "normal"]);
     expect(createdEditors.map((editor) => editor.diagnostics.warnings)).toEqual([
-      [],
+      ["bad config"],
       ["bad config"],
     ]);
   });
@@ -357,7 +362,7 @@ describe("vim extension lifecycle", () => {
 
     expect(createdEditors.map((editor) => editor.options.startMode)).toEqual(["insert", "insert"]);
     expect(createdEditors.map((editor) => editor.diagnostics.warnings)).toEqual([
-      [],
+      ["fatal JS config"],
       ["fatal JS config"],
     ]);
     expect(ctx.ui.statuses.at(-1)).toEqual(["pi-vimmode", "vim ⚠"]);
@@ -425,7 +430,7 @@ describe("vim extension lifecycle", () => {
     expect(loadCalls).toEqual([{ cwd: "/repo" }, { cwd: "/repo" }]);
     expect(ctx.ui.component).toBe(factory);
     expect(ctx.ui.notifications.at(-1)).toEqual(["pi-vimmode reloaded", "info"]);
-    expect(createdEditors.map((editor) => editor.options.startMode)).toEqual(["insert", "normal"]);
+    expect(createdEditors.map((editor) => editor.options.startMode)).toEqual(["normal", "normal"]);
   });
 
   test("vimmode command toggles editor off and on", async () => {

--- a/test/lifecycle.test.ts
+++ b/test/lifecycle.test.ts
@@ -343,6 +343,22 @@ describe("vim extension lifecycle", () => {
     ]);
   });
 
+  test("fatal first load commits its usable JSON-backed plan", () => {
+    const { hooks, fatalLoads, warnings, createdEditors } = createLifecycleHarness([
+      { ...DEFAULT_VIM_OPTIONS, startMode: "normal" },
+    ]);
+    fatalLoads.push(true);
+    warnings.push(["fatal JS config"]);
+    const ctx = createContext("/repo");
+
+    hooks.get("agent_end")?.({}, ctx);
+    ctx.ui.setCalls[0]!({}, {}, {});
+
+    expect(createdEditors[0]?.options.startMode).toBe("normal");
+    expect(createdEditors[0]?.diagnostics.warnings).toEqual(["fatal JS config"]);
+    expect(ctx.ui.statuses.at(-1)).toEqual(["pi-vimmode", "vim ⚠"]);
+  });
+
   test("fatal reload updates diagnostics but preserves last-known-good options", () => {
     const { hooks, fatalLoads, warnings, createdEditors } = createLifecycleHarness();
     fatalLoads.push(false, true);

--- a/test/lifecycle.test.ts
+++ b/test/lifecycle.test.ts
@@ -91,6 +91,7 @@ function createLifecycleHarness(
   const createdEditors: FakeEditor[] = [];
   const shutdownCallbacks: Array<(() => void) | undefined> = [];
   const warnings: string[][] = [];
+  const fatalLoads: boolean[] = [];
   let loadIndex = 0;
 
   const pi = {
@@ -105,10 +106,17 @@ function createLifecycleHarness(
   registerVimLifecycle(pi as never, {
     loadOptions: (paths) => {
       loadCalls.push(paths);
-      const option = options[Math.min(loadIndex, options.length - 1)]!;
+      const index = Math.min(loadIndex, options.length - 1);
+      const option = options[index]!;
       const warning = warnings[Math.min(loadIndex, warnings.length - 1)] ?? [];
+      const fatal = fatalLoads[loadIndex] ?? false;
       loadIndex += 1;
-      return { plan: createVimConfigPlan(option, warning), options: option, warnings: warning };
+      return {
+        plan: createVimConfigPlan(option, warning),
+        options: option,
+        warnings: warning,
+        fatal,
+      };
     },
     createEditor: (_tui, _theme, _keybindings, editorOptions, diagnostics, vimOptions) => {
       shutdownCallbacks.push(vimOptions?.onShutdown);
@@ -132,7 +140,16 @@ function createLifecycleHarness(
     },
   });
 
-  return { hooks, commands, scheduled, loadCalls, createdEditors, shutdownCallbacks, warnings };
+  return {
+    hooks,
+    commands,
+    scheduled,
+    loadCalls,
+    createdEditors,
+    shutdownCallbacks,
+    warnings,
+    fatalLoads,
+  };
 }
 
 describe("vim extension lifecycle", () => {
@@ -324,6 +341,26 @@ describe("vim extension lifecycle", () => {
       [],
       ["bad config"],
     ]);
+  });
+
+  test("fatal reload updates diagnostics but preserves last-known-good options", () => {
+    const { hooks, fatalLoads, warnings, createdEditors } = createLifecycleHarness();
+    fatalLoads.push(false, true);
+    warnings.push([], ["fatal JS config"]);
+    const ctx = createContext("/repo");
+
+    hooks.get("agent_end")?.({}, ctx);
+    const factory = ctx.ui.setCalls[0]!;
+    factory({}, {}, {});
+    hooks.get("agent_end")?.({}, ctx);
+    factory({}, {}, {});
+
+    expect(createdEditors.map((editor) => editor.options.startMode)).toEqual(["insert", "insert"]);
+    expect(createdEditors.map((editor) => editor.diagnostics.warnings)).toEqual([
+      [],
+      ["fatal JS config"],
+    ]);
+    expect(ctx.ui.statuses.at(-1)).toEqual(["pi-vimmode", "vim ⚠"]);
   });
 
   test("delayed reinstall refreshes settings and catches stale context failures", () => {

--- a/test/lifecycle.test.ts
+++ b/test/lifecycle.test.ts
@@ -433,6 +433,32 @@ describe("vim extension lifecycle", () => {
     expect(createdEditors[0]?.options.startMode).toBe("insert");
   });
 
+  test("stale async refresh cannot install into an older context", async () => {
+    const { hooks, deferredLoads, resolveDeferred, shutdownCallbacks } = createLifecycleHarness();
+    deferredLoads.add(0).add(1);
+    const older = createContext("/older");
+    const newer = createContext("/newer");
+
+    hooks.get("agent_end")?.({}, older);
+    hooks.get("agent_end")?.({}, newer);
+    const result = {
+      plan: createVimConfigPlan(DEFAULT_VIM_OPTIONS, []),
+      options: DEFAULT_VIM_OPTIONS,
+      warnings: [],
+      fatal: false,
+    };
+    resolveDeferred.get(1)?.(result);
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    resolveDeferred.get(0)?.(result);
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(older.ui.component).toBeUndefined();
+    newer.ui.component?.({}, {}, {});
+    shutdownCallbacks[0]?.();
+    expect(older.shutdownCalls).toBe(0);
+    expect(newer.shutdownCalls).toBe(1);
+  });
+
   test("async install cannot reactivate editor after vimmode off", async () => {
     const { hooks, commands, deferredLoads, resolveDeferred } = createLifecycleHarness();
     deferredLoads.add(0);

--- a/test/lifecycle.test.ts
+++ b/test/lifecycle.test.ts
@@ -92,6 +92,8 @@ function createLifecycleHarness(
   const shutdownCallbacks: Array<(() => void) | undefined> = [];
   const warnings: string[][] = [];
   const fatalLoads: boolean[] = [];
+  const asyncLoads = new Set<number>();
+  const rejectedLoads = new Set<number>();
   let loadIndex = 0;
 
   const pi = {
@@ -106,17 +108,20 @@ function createLifecycleHarness(
   registerVimLifecycle(pi as never, {
     loadOptions: (paths) => {
       loadCalls.push(paths);
-      const index = Math.min(loadIndex, options.length - 1);
+      const load = loadIndex;
+      const index = Math.min(load, options.length - 1);
       const option = options[index]!;
-      const warning = warnings[Math.min(loadIndex, warnings.length - 1)] ?? [];
-      const fatal = fatalLoads[loadIndex] ?? false;
+      const warning = warnings[Math.min(load, warnings.length - 1)] ?? [];
+      const fatal = fatalLoads[load] ?? false;
       loadIndex += 1;
-      return {
+      if (rejectedLoads.has(load)) return Promise.reject(new Error("async load failed"));
+      const result = {
         plan: createVimConfigPlan(option, warning),
         options: option,
         warnings: warning,
         fatal,
       };
+      return asyncLoads.has(load) ? Promise.resolve(result) : result;
     },
     createEditor: (_tui, _theme, _keybindings, editorOptions, diagnostics, vimOptions) => {
       shutdownCallbacks.push(vimOptions?.onShutdown);
@@ -149,6 +154,8 @@ function createLifecycleHarness(
     shutdownCallbacks,
     warnings,
     fatalLoads,
+    asyncLoads,
+    rejectedLoads,
   };
 }
 
@@ -356,6 +363,31 @@ describe("vim extension lifecycle", () => {
 
     expect(createdEditors[0]?.options.startMode).toBe("normal");
     expect(createdEditors[0]?.diagnostics.warnings).toEqual(["fatal JS config"]);
+    expect(ctx.ui.statuses.at(-1)).toEqual(["pi-vimmode", "vim ⚠"]);
+  });
+
+  test("async loads commit success and preserve it after rejection", async () => {
+    const { hooks, asyncLoads, rejectedLoads, createdEditors } = createLifecycleHarness([
+      { ...DEFAULT_VIM_OPTIONS, startMode: "normal" },
+      DEFAULT_VIM_OPTIONS,
+    ]);
+    asyncLoads.add(0);
+    rejectedLoads.add(1);
+    const ctx = createContext("/repo");
+
+    hooks.get("agent_end")?.({}, ctx);
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    const factory = ctx.ui.setCalls[0]!;
+    factory({}, {}, {});
+
+    hooks.get("agent_end")?.({}, ctx);
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    factory({}, {}, {});
+
+    expect(createdEditors.map((editor) => editor.options.startMode)).toEqual(["normal", "normal"]);
+    expect(createdEditors[1]?.diagnostics.warnings).toEqual([
+      "global JS config: failed to load (async load failed)",
+    ]);
     expect(ctx.ui.statuses.at(-1)).toEqual(["pi-vimmode", "vim ⚠"]);
   });
 

--- a/test/lifecycle.test.ts
+++ b/test/lifecycle.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, test } from "bun:test";
 
 import type { ResolvedVimEditorOptions, VimDiagnostics } from "../src/types.ts";
 
-import { DEFAULT_VIM_OPTIONS } from "../src/config.ts";
+import { createVimConfigPlan, DEFAULT_VIM_OPTIONS } from "../src/config.ts";
 import { registerVimLifecycle } from "../src/lifecycle.ts";
 
 type HookName =
@@ -108,7 +108,7 @@ function createLifecycleHarness(
       const option = options[Math.min(loadIndex, options.length - 1)]!;
       const warning = warnings[Math.min(loadIndex, warnings.length - 1)] ?? [];
       loadIndex += 1;
-      return { options: option, warnings: warning };
+      return { plan: createVimConfigPlan(option, warning), options: option, warnings: warning };
     },
     createEditor: (_tui, _theme, _keybindings, editorOptions, diagnostics, vimOptions) => {
       shutdownCallbacks.push(vimOptions?.onShutdown);

--- a/test/modal.test.ts
+++ b/test/modal.test.ts
@@ -2085,6 +2085,37 @@ describe("Ex command-line modal behavior", () => {
     expect(visual.state.pending).toBeUndefined();
   });
 
+  test("exact semantic actions win when a stale remap survives resolution", () => {
+    const actionOptions = resolveVimOptions({
+      piVimMode: {
+        leader: ",",
+        keymap: {
+          actions: {
+            "prompt.transform.quote": [{ key: "<leader>u", modes: ["normal"] }],
+          },
+        },
+      },
+    }).options;
+    const conflictingOptions: ModalOptions = {
+      ...actionOptions,
+      keymap: {
+        ...actionOptions.keymap!,
+        remaps: { accepted: [{ key: ",u", inputs: ["l"], modes: ["normal"] }] },
+      },
+    };
+
+    const result = applyModalKeys(
+      { mode: "normal" },
+      "hello",
+      p(0, 0),
+      [",", "u"],
+      conflictingOptions,
+    );
+
+    expect(result.text).toBe("> hello");
+    expect(result.effects.some((effect) => effect.type === "playMacro")).toBe(false);
+  });
+
   test("keybound prompt transform actions report no-op feedback and skip dot-repeat", () => {
     const actionOptions = resolveVimOptions({
       piVimMode: {

--- a/test/modal.test.ts
+++ b/test/modal.test.ts
@@ -2025,6 +2025,17 @@ describe("Ex command-line modal behavior", () => {
     expect(reflowed.text).toBe("alpha beta gamma\ndelta epsilon");
   });
 
+  test("project semantic action exact keys override built-in grammar", () => {
+    const options = resolveVimOptions(undefined, {
+      piVimMode: {
+        keymap: { actions: { "prompt.transform.quote": [{ key: "u", modes: ["normal"] }] } },
+      },
+    }).options;
+
+    const result = applyModalKeys({ mode: "normal" }, "hello", p(0, 0), ["u"], options);
+    expect(result.text).toBe("> hello");
+  });
+
   test("keybound prompt transform actions edit visual touched lines", () => {
     const actionOptions = resolveVimOptions({
       piVimMode: { keymap: { actions: { "prompt.transform.quote": ["g>"] } } },

--- a/test/vim-editor.test.ts
+++ b/test/vim-editor.test.ts
@@ -258,13 +258,15 @@ describe("vim editor integration", () => {
   });
 
   test("constructor clones caller-owned nested keymap options", () => {
-    const options = resolveVimOptions({
-      piVimMode: {
-        startMode: "normal",
-        leader: ",",
-        keymap: { escape: ["<D-j>"], commands: { openLineBelow: ["<leader>k"] } },
-      },
-    }).options;
+    const options = structuredClone(
+      resolveVimOptions({
+        piVimMode: {
+          startMode: "normal",
+          leader: ",",
+          keymap: { escape: ["<D-j>"], commands: { openLineBelow: ["<leader>k"] } },
+        },
+      }).options,
+    );
     const { editor } = createEditor(options);
     options.leader = ";";
     options.keymap!.leader = ";";
@@ -917,15 +919,17 @@ describe("vim editor integration", () => {
   });
 
   test("renders and clones a right-positioned status group", () => {
-    const options = resolveVimOptions({
-      piVimMode: {
-        startMode: "normal",
-        ui: {
-          status: { position: "right" },
-          mode: { labels: { normal: "COMMAND" } },
+    const options = structuredClone(
+      resolveVimOptions({
+        piVimMode: {
+          startMode: "normal",
+          ui: {
+            status: { position: "right" },
+            mode: { labels: { normal: "COMMAND" } },
+          },
         },
-      },
-    }).options;
+      }).options,
+    );
     const { editor } = createEditor(options);
     options.ui!.status.position = "left";
 

--- a/test/vim-editor.test.ts
+++ b/test/vim-editor.test.ts
@@ -296,6 +296,24 @@ describe("vim editor integration", () => {
     expect(editor.getVimMode()).toBe("normal");
   });
 
+  test("reconfigure applies new keymaps immediately while clearing pending grammar", () => {
+    const { editor } = createEditor({ ...DEFAULT_VIM_OPTIONS, startMode: "normal" });
+    const options = resolveVimOptions({
+      piVimMode: { startMode: "insert", keymap: { commands: { openLineBelow: [",k"] } } },
+    }).options;
+
+    editor.setText("one\ntwo");
+    editor.handleInput("d");
+    expect(editor.getPendingOperator()).toBe("d");
+
+    editor.reconfigure(options, { warnings: ["reloaded"] });
+    expectEditorState(editor, { text: "one\ntwo", mode: "normal", pending: undefined });
+    typeKeys(editor, ["g", "g", ",", "k"]);
+
+    expect(editor.getText()).toBe("one\n\ntwo");
+    expect(editor.getVimMode()).toBe("insert");
+  });
+
   test("plain insert text uses fast path without full snapshot", () => {
     const { editor } = createEditor();
     (editor as unknown as { getLines: () => string[] }).getLines = () => {

--- a/test/vim-editor.test.ts
+++ b/test/vim-editor.test.ts
@@ -567,34 +567,6 @@ describe("vim editor integration", () => {
     expectRenderedWidth(message, 20);
   });
 
-  test("live config reload updates bindings and diagnostics on the active editor", () => {
-    const before = resolveVimOptions({ piVimMode: { startMode: "normal" } }, undefined, {
-      kind: "success",
-      operations: [
-        {
-          kind: "map",
-          mapping: { kind: "remap", key: "zq", inputs: ["l"], modes: ["normal"] },
-        },
-      ],
-    });
-    const after = resolveVimOptions({
-      piVimMode: {
-        startMode: "normal",
-        keymap: { actions: { "prompt.transform.quote": ["zq"] } },
-      },
-    });
-    const { editor, overlays } = createEditor(before.options);
-
-    editor.reloadConfig(after.options, { warnings: ["fatal JS config"] });
-    editor.setText("hello");
-    typeKeys(editor, ["z", "q"]);
-    expect(editor.getText()).toBe("> hello");
-
-    runEx(editor, "vimdoctor");
-    const overlayText = overlays.at(-1)?.component.render(64).join("\n") ?? "";
-    expect(overlayText).toContain("fatal JS config");
-  });
-
   test("diagnostic popups and feedback info rows render width-safely", () => {
     const { editor, overlays } = createEditor(
       { ...DEFAULT_VIM_OPTIONS, startMode: "normal", feedback: { noop: "status" } },

--- a/test/vim-editor.test.ts
+++ b/test/vim-editor.test.ts
@@ -567,6 +567,34 @@ describe("vim editor integration", () => {
     expectRenderedWidth(message, 20);
   });
 
+  test("live config reload updates bindings and diagnostics on the active editor", () => {
+    const before = resolveVimOptions({ piVimMode: { startMode: "normal" } }, undefined, {
+      kind: "success",
+      operations: [
+        {
+          kind: "map",
+          mapping: { kind: "remap", key: "zq", inputs: ["l"], modes: ["normal"] },
+        },
+      ],
+    });
+    const after = resolveVimOptions({
+      piVimMode: {
+        startMode: "normal",
+        keymap: { actions: { "prompt.transform.quote": ["zq"] } },
+      },
+    });
+    const { editor, overlays } = createEditor(before.options);
+
+    editor.reloadConfig(after.options, { warnings: ["fatal JS config"] });
+    editor.setText("hello");
+    typeKeys(editor, ["z", "q"]);
+    expect(editor.getText()).toBe("> hello");
+
+    runEx(editor, "vimdoctor");
+    const overlayText = overlays.at(-1)?.component.render(64).join("\n") ?? "";
+    expect(overlayText).toContain("fatal JS config");
+  });
+
   test("diagnostic popups and feedback info rows render width-safely", () => {
     const { editor, overlays } = createEditor(
       { ...DEFAULT_VIM_OPTIONS, startMode: "normal", feedback: { noop: "status" } },


### PR DESCRIPTION
## Summary

**Immutable scoped configuration plans**
- Compile defaults, global JSON, trusted JavaScript operations, and project JSON into one deeply immutable plan.
- Resolve final leader expansion before project-authoritative exact-key and strict-prefix conflict checks.
- Keep mappings independent across normal, visual, operator-pending, insert, and escape scopes.
- Preserve unrelated inherited mappings while scoped unmaps and later same-scope mappings replace earlier entries.

**Runtime integration and reload safety**
- Prefer exact semantic actions over stale remaps at runtime.
- Reconfigure active editors after meaningful config changes while preserving prompt text and durable modal state.
- Reject stale and out-of-order async reloads, preserve last-known-good options, and keep disabled Vim mode disabled.
- Report async installation failures from scheduled and agent-end lifecycle paths.

**Tests and release tracking**
- Expand config, command, lifecycle, modal, and editor integration coverage for precedence, immutability, reload races, failure reporting, and keymap boundaries.
- Mark trusted JavaScript config prerequisite #36 complete in OpenSpec.

## Test Coverage

```text
CODE PATHS                                      USER FLOWS
├─ Configuration resolution                     ├─ Initial configuration
│  ├─ [★★★] defaults → global → JS → project    │  ├─ [★★★] immutable plan installed
│  ├─ [★★★] project scalar/exact authority      │  ├─ [★★★] scoped keys resolve correctly
│  ├─ [★★★] final leader expansion              │  └─ [★★★] conflicts produce warnings
│  ├─ [★★★] scoped conflicts and unmaps         ├─ Runtime key handling
│  ├─ [★★★] printable + and atomic named keys   │  ├─ [★★★] exact actions beat remaps
│  └─ [★★★] immutable exact/prefix lookups       │  └─ [★★★] mode ownership preserved
├─ Lifecycle refresh                            ├─ Configuration reload
│  ├─ [★★★] sync/async and generation ordering  │  ├─ [★★★] changed config applies
│  ├─ [★★★] fatal and last-known-good handling  │  ├─ [★★★] unchanged state survives
│  ├─ [★★★] scheduled and agent-end reporting   │  └─ [★★★] stale/disabled loads contained
│  ├─ [GAP] notification itself throws          └─ Live editor reconfiguration
│  └─ [GAP] non-Error rejection formatting         ├─ [★★★] keymap/pending/text/mode
│                                                    ├─ [GAP] visualAnchor clamping
│                                                    ├─ [GAP] last selection clamping
│                                                    ├─ [GAP] overlay dismissal
│                                                    └─ [GAP] durable state + diagnostics

COVERAGE: 38/44 changed behavioral paths tested (86%)
TEST FILES: 28 before → 28 after
```

Six remaining integration gaps belong to deferred active-editor reload issue #40.

## Pre-Landing Review

No issues found after testing, maintainability, security, performance, and Claude adversarial passes. Codex adversarial and structured reviews timed out after five minutes.

Known accepted deferral: full atomic multi-editor reload remains issue #40.

## Design Review

No frontend files changed. Design review skipped.

## Eval Results

No prompt-related files changed. Evals skipped.

## Scope Drift

Preparatory active-editor reload work overlaps issue #40 but does not claim its full atomic contract. User approved deferral to #40.

## Plan Completion

### Issue-scoped completion
- [x] #37 / task 2.2: immutable scoped configuration plan implemented and tested.
- [x] #35 / task 1.3: prerequisite canonical metadata and mapping scopes.
- [x] #36 / task 2.1: prerequisite trusted JavaScript transaction.

### Deferred release work
Eleven later 0.9.0 tasks remain intentionally unchecked: #33, #34, #38, #39, #40, #41, #42, #43, #44, #45, and final release validation.

Closes #37

## Verification Results

No browser verification section exists for this terminal extension. Automated checks passed.

## Test plan

- [x] `bun test`: 798 passed, 0 failed, 4,531 assertions
- [x] `bun run check-types`
- [x] `bun run lint`
- [x] `bun run format:check`
- [x] `bun run build`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
