### PR TITLE
Feature: Add vim-easymotion (go to character) capability

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,22 @@ Example keymap/UI override:
 }
 ```
 
+### EasyMotion
+
+When you trigger character search (e.g. `f`, `t`, `F`, `T`), matching characters on the current line are replaced with colored label characters. Press the label to jump to that character, which restores the original. The label color is configurable under `piVimMode.easymotion.labelColor`:
+
+```json
+{
+  "piVimMode": {
+    "easymotion": {
+      "labelColor": "\u001b[31m"
+    }
+  }
+}
+```
+
+Common ANSI color codes: `\u001b[31m` (red), `\u001b[32m` (green), `\u001b[33m` (yellow), `\u001b[34m` (blue), `\u001b[35m` (magenta), `\u001b[36m` (cyan), `\u001b[37m` (white). Default is red (`\u001b[31m`).
+
 Trusted global JS keybindings live at `~/.pi/agent/pi-vimmode.config.js` and run as local code with Pi process privileges:
 
 ```js

--- a/docs/settings.md
+++ b/docs/settings.md
@@ -672,6 +672,14 @@ These settings control search highlighting, not search motion semantics.
 | `piVimMode.search.clearOnInsert`    | `true`  | boolean              | Clears visible highlights when entering insert mode. Does not erase repeat-search state.              |
 | `piVimMode.search.maxHighlights`    | `200`   | non-negative integer | Maximum non-current match ranges rendered. `0` disables non-current ranges.                           |
 
+## EasyMotion settings
+
+These settings control the visual appearance of EasyMotion character-search labels.
+
+| Path                              | Default    | Accepted values         | Effect                                                                                        |
+| --------------------------------- | ---------- | ----------------------- | --------------------------------------------------------------------------------------------- |
+| `piVimMode.easymotion.labelColor` | `\x1b[31m` | ANSI escape code string | Color applied to EasyMotion label characters (e.g. `\x1b[31m` for red, `\x1b[32m` for green). |
+
 Search is literal by default and prompt-local. `?` starts backward search, empty `/` or `?` recalls the previous successful query, and `Up` / `Down` navigate in-memory history while a search is pending. Prefix a pending query with `\r` for bounded regex search. Vim highlight groups, offsets, and cross-prompt history are not supported. `:noh` / `:nohlsearch` clear current prompt search highlights without changing text or registers.
 
 ## Feedback settings

--- a/src/config-js.ts
+++ b/src/config-js.ts
@@ -127,6 +127,7 @@ const KNOWN_COMMANDS = new Set([
   "showKeybindings",
   "reselectVisual",
   "easymotion",
+  "easymotion.goToChar",
 ]);
 
 const INSERT_ACTIONS = new Set<VimInsertAction>([

--- a/src/config-js.ts
+++ b/src/config-js.ts
@@ -39,6 +39,12 @@ export type VimJsConfigMapOperation =
       key: string;
       inputs: readonly string[];
       modes: readonly VimActionBindingMode[];
+    }
+  | {
+      kind: "command";
+      command: string;
+      key: string;
+      modes: readonly VimActionBindingMode[];
     };
 
 export type VimJsConfigOperation =
@@ -75,6 +81,53 @@ const MODE_ALIASES: Record<string, readonly VimMode[]> = {
   visualLine: ["visualLine"],
   visualBlock: ["visualBlock"],
 };
+
+// Known command actions from KEYMAP_COMMAND_DESCRIPTORS — string RHS matching these
+// become command bindings instead of keystroke-replay remaps.
+const KNOWN_COMMANDS = new Set([
+  "insertBefore",
+  "insertAfter",
+  "insertLineStart",
+  "insertLineEnd",
+  "openLineBelow",
+  "openLineAbove",
+  "visualChar",
+  "visualLine",
+  "visualBlock",
+  "deleteChar",
+  "deleteCharBefore",
+  "deleteToLineEnd",
+  "changeToLineEnd",
+  "yankLine",
+  "joinLine",
+  "pasteAfter",
+  "pasteBefore",
+  "incrementNumber",
+  "decrementNumber",
+  "toggleCase",
+  "replaceChar",
+  "substituteChar",
+  "substituteLine",
+  "findCharForward",
+  "findCharBackward",
+  "tillCharForward",
+  "tillCharBackward",
+  "repeatCharSearch",
+  "repeatCharSearchReverse",
+  "startSearch",
+  "startSearchBackward",
+  "repeatSearch",
+  "repeatSearchReverse",
+  "searchWordForward",
+  "searchWordBackward",
+  "startExCommand",
+  "repeatChange",
+  "undo",
+  "redo",
+  "showKeybindings",
+  "reselectVisual",
+  "easymotion",
+]);
 
 const INSERT_ACTIONS = new Set<VimInsertAction>([
   "openLineBelow",
@@ -216,6 +269,15 @@ function compileMapping(session: ConfigSession, mode: unknown, lhs: unknown, rhs
     return;
   }
   if (typeof rhs === "string") {
+    // If the string matches a known command action, create a command binding
+    // instead of treating it as a keystroke-replay remap.
+    if (KNOWN_COMMANDS.has(rhs)) {
+      const actionModes = modes.filter((m) => m !== "insert") as VimActionBindingMode[];
+      if (actionModes.length > 0) {
+        session.recordMap({ kind: "command", command: rhs, key, modes: actionModes });
+      }
+      return;
+    }
     recordStringRemap(session, key, rhs, modes);
     return;
   }

--- a/src/config-metadata.ts
+++ b/src/config-metadata.ts
@@ -137,6 +137,7 @@ export const CONFIG_LEAVES: readonly ConfigLeaf[] = leaves([
   "search.clearOnInsert",
   "search.maxHighlights",
   "exCommand.autocomplete",
+  "easymotion.labelColor",
   "feedback.noop",
   "promptStructures.enabled",
   ...Object.keys(DEFAULT_VIM_OPTIONS.promptStructures!.targets).map(

--- a/src/config.ts
+++ b/src/config.ts
@@ -17,6 +17,7 @@ import type {
   ResolvedVimPromptStructures,
   ResolvedVimPromptTransforms,
   ResolvedVimSearch,
+  ResolvedVimEasymotion,
   ResolvedVimUi,
   StartupMode,
   VimActionBindingMode,
@@ -252,6 +253,10 @@ export const DEFAULT_VIM_SEARCH = Object.freeze({
   maxHighlights: 200,
 }) as unknown as ResolvedVimSearch;
 
+export const DEFAULT_VIM_EASYMOTION = Object.freeze({
+  labelColor: "\x1b[31m",
+}) as unknown as ResolvedVimEasymotion;
+
 export const DEFAULT_VIM_EX_COMMAND = Object.freeze({
   autocomplete: true,
 }) as unknown as ResolvedVimExCommand;
@@ -307,6 +312,7 @@ export const DEFAULT_VIM_OPTIONS: ResolvedVimEditorOptions = Object.freeze({
   macros: DEFAULT_VIM_MACROS,
   marks: DEFAULT_VIM_MARKS,
   search: DEFAULT_VIM_SEARCH,
+  easymotion: DEFAULT_VIM_EASYMOTION,
   exCommand: DEFAULT_VIM_EX_COMMAND,
   feedback: DEFAULT_VIM_FEEDBACK,
   promptStructures: DEFAULT_VIM_PROMPT_STRUCTURES,
@@ -323,6 +329,7 @@ type PartialVimOptions = {
   macros?: PartialMacroOptions;
   marks?: PartialMarkOptions;
   search?: PartialSearchOptions;
+  easymotion?: PartialVimEasymotionOptions;
   exCommand?: PartialExCommandOptions;
   feedback?: PartialFeedbackOptions;
   promptStructures?: PartialPromptStructureOptions;
@@ -352,6 +359,7 @@ type PartialKeymapOptions = {
 type PartialMacroOptions = Partial<ResolvedVimMacros>;
 type PartialMarkOptions = Partial<ResolvedVimMarks>;
 type PartialSearchOptions = Partial<ResolvedVimSearch>;
+type PartialVimEasymotionOptions = Partial<ResolvedVimEasymotion>;
 type PartialFeedbackOptions = Partial<VimFeedbackOptions>;
 type PartialPromptStructureOptions = {
   enabled?: boolean;
@@ -473,6 +481,12 @@ function cloneMarks(marks: ResolvedVimMarks = DEFAULT_VIM_MARKS): ResolvedVimMar
 
 function cloneSearch(search: ResolvedVimSearch = DEFAULT_VIM_SEARCH): ResolvedVimSearch {
   return { ...search };
+}
+
+function cloneEasymotion(
+  easymotion: ResolvedVimEasymotion = DEFAULT_VIM_EASYMOTION,
+): ResolvedVimEasymotion {
+  return { ...easymotion };
 }
 
 function cloneExCommand(
@@ -2052,6 +2066,15 @@ function mergeSearch(target: ResolvedVimSearch, partial: PartialSearchOptions): 
   Object.assign(target, partial);
 }
 
+function mergeEasymotion(
+  target: ResolvedVimEasymotion,
+  partial: PartialVimEasymotionOptions,
+): void {
+  if (partial.labelColor !== undefined) {
+    target.labelColor = partial.labelColor;
+  }
+}
+
 function mergeExCommand(target: ResolvedVimExCommand, partial: PartialExCommandOptions): void {
   Object.assign(target, partial);
 }
@@ -2395,6 +2418,8 @@ function mergePartialOptions(target: ResolvedVimEditorOptions, partial: PartialV
   if (partial.macros) mergeMacros(target.macros ?? cloneMacros(), partial.macros);
   if (partial.marks) mergeMarks(target.marks ?? cloneMarks(), partial.marks);
   if (partial.search) mergeSearch(target.search ?? cloneSearch(), partial.search);
+  if (partial.easymotion)
+    mergeEasymotion(target.easymotion ?? cloneEasymotion(), partial.easymotion);
   if (partial.exCommand) mergeExCommand(target.exCommand ?? cloneExCommand(), partial.exCommand);
   if (partial.feedback) mergeFeedback(target.feedback ?? cloneFeedback(), partial.feedback);
   if (partial.promptStructures) {
@@ -2499,7 +2524,10 @@ function partialFromJsOperations(operations: readonly VimJsConfigOperation[]): V
       removeJsMappings(keymap as PartialKeymapOptions, mapping.key, mapping.modes);
       restoreJsUnmaps(keymap as PartialKeymapOptions, mapping.key, mapping.modes);
       const commands = (keymap.commands ??= {}) as Partial<Record<VimCommandAction, string[]>>;
-      commands[mapping.command as VimCommandAction] = [...(commands[mapping.command as VimCommandAction] ?? []), mapping.key];
+      commands[mapping.command as VimCommandAction] = [
+        ...(commands[mapping.command as VimCommandAction] ?? []),
+        mapping.key,
+      ];
       continue;
     }
     removeJsMappings(keymap as PartialKeymapOptions, mapping.key, mapping.modes);
@@ -2647,7 +2675,8 @@ export function createVimConfigPlan(
     for (const sequence of sequences) add(["insert"], sequence, { kind: "insert", id: action });
   }
   for (const [action, sequences] of Object.entries(keymap.commands)) {
-    for (const sequence of sequences) add(["normal"], sequence, { kind: "command", id: `command.${action}` });
+    for (const sequence of sequences)
+      add(["normal"], sequence, { kind: "command", id: `command.${action}` });
   }
   for (const binding of keymap.actions.accepted) {
     add(
@@ -2882,6 +2911,10 @@ export function macrosForOptions(options: ResolvedVimEditorOptions): ResolvedVim
 
 export function marksForOptions(options: ResolvedVimEditorOptions): ResolvedVimMarks {
   return options.marks ?? DEFAULT_VIM_MARKS;
+}
+
+export function easymotionForOptions(options: ResolvedVimEditorOptions): ResolvedVimEasymotion {
+  return options.easymotion ?? DEFAULT_VIM_EASYMOTION;
 }
 
 export function searchForOptions(options: ResolvedVimEditorOptions): ResolvedVimSearch {

--- a/src/config.ts
+++ b/src/config.ts
@@ -374,6 +374,7 @@ export type VimPlanBinding =
       readonly id: BindablePromptTransformActionId;
       readonly args: ResolvedVimActionBinding["args"];
     }
+  | { readonly kind: "command"; readonly id: string }
   | { readonly kind: "remap"; readonly id: "remap"; readonly inputs: readonly string[] };
 
 export type VimScopeLookup = {
@@ -2494,6 +2495,13 @@ function partialFromJsOperations(operations: readonly VimJsConfigOperation[]): V
       ];
       continue;
     }
+    if (mapping.kind === "command") {
+      removeJsMappings(keymap as PartialKeymapOptions, mapping.key, mapping.modes);
+      restoreJsUnmaps(keymap as PartialKeymapOptions, mapping.key, mapping.modes);
+      const commands = (keymap.commands ??= {}) as Partial<Record<VimCommandAction, string[]>>;
+      commands[mapping.command as VimCommandAction] = [...(commands[mapping.command as VimCommandAction] ?? []), mapping.key];
+      continue;
+    }
     removeJsMappings(keymap as PartialKeymapOptions, mapping.key, mapping.modes);
     restoreJsUnmaps(keymap as PartialKeymapOptions, mapping.key, mapping.modes);
     const remaps = (keymap.remaps ??= { accepted: [] });
@@ -2637,6 +2645,9 @@ export function createVimConfigPlan(
   }
   for (const [action, sequences] of Object.entries(keymap.insert)) {
     for (const sequence of sequences) add(["insert"], sequence, { kind: "insert", id: action });
+  }
+  for (const [action, sequences] of Object.entries(keymap.commands)) {
+    for (const sequence of sequences) add(["normal"], sequence, { kind: "command", id: `command.${action}` });
   }
   for (const binding of keymap.actions.accepted) {
     add(

--- a/src/customization.ts
+++ b/src/customization.ts
@@ -121,6 +121,7 @@ const COMMAND_DESCRIPTIONS: Record<VimCommandAction, string> = {
   redo: "redo prompt edit",
   showKeybindings: "show keybindings popup",
   reselectVisual: "reselect last visual selection",
+  easymotion: "jump to character on current file (EasyMotion)",
 };
 
 const MOTION_DESCRIPTIONS: Record<VimMotionAction, string> = {

--- a/src/keymap-descriptors.ts
+++ b/src/keymap-descriptors.ts
@@ -146,6 +146,7 @@ export const KEYMAP_COMMAND_DESCRIPTORS = {
   redo: { defaults: ["ctrl+r"] },
   showKeybindings: { defaults: [] },
   reselectVisual: { defaults: ["gv"] },
+  easymotion: { defaults: [] },
 } as const satisfies Record<VimCommandAction, CommandDescriptor>;
 
 export function deriveActionKeys<T extends Record<string, KeymapDescriptor>>(

--- a/src/modal/engine.ts
+++ b/src/modal/engine.ts
@@ -223,21 +223,25 @@ function handleEasymotionInput(
   }
 
   if (state.pendingEasymotion?.kind === "char") {
-    const targets: { label: string; line: number; character: number }[] = [];
+    // Transition to highlight state with case-insensitive matching
+    const targets: { label: string; line: number; character: number; original: string }[] = [];
     const lines = snapshot.text.split("\n");
     const labels = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ".split("");
     let count = 0;
+    const targetChar = key.toLowerCase();
 
     for (let i = 0; i < lines.length && count < labels.length; i++) {
       const line = lines[i];
       if (line === undefined) continue;
-      let pos = line.indexOf(key);
+      // Case-insensitive matching
+      let pos = line.toLowerCase().indexOf(targetChar);
       while (pos !== -1 && count < labels.length) {
         const label = labels[count];
         if (label === undefined) break;
-        targets.push({ label, line: i, character: pos });
+        const original = line[pos] ?? key;
+        targets.push({ label, line: i, character: pos, original });
         count++;
-        pos = line.indexOf(key, pos + 1);
+        pos = line.toLowerCase().indexOf(targetChar, pos + 1);
       }
     }
 
@@ -246,16 +250,60 @@ function handleEasymotionInput(
       return invalidate(rest);
     }
 
-    return invalidate({
-      ...state,
-      pendingEasymotion: { kind: "jump", targets, char: key },
-    });
+    // Build text with address characters replacing matched characters
+    const nextLines = [...snapshot.lines];
+    for (const target of targets) {
+      const line = nextLines[target.line];
+      if (line === undefined) continue;
+      nextLines[target.line] =
+        line.slice(0, target.character) + target.label + line.slice(target.character + 1);
+    }
+    const nextText = nextLines.join("\n");
+
+    return withEffects(
+      {
+        ...state,
+        pendingEasymotion: { kind: "highlight", targets },
+      },
+      [
+        {
+          type: "edit",
+          result: { text: nextText, cursor: snapshot.cursor, changed: nextText !== snapshot.text },
+        },
+      ],
+    );
+  }
+
+  if (state.pendingEasymotion?.kind === "highlight") {
+    // Address character input: jump to target and restore that character
+    const target = state.pendingEasymotion.targets.find((t) => t.label === key);
+
+    if (target) {
+      const { pendingEasymotion: _, ...rest } = state;
+      // Restore the target's original character
+      const line = snapshot.lines[target.line] ?? "";
+      const nextLine =
+        line.slice(0, target.character) + target.original + line.slice(target.character + 1);
+      const nextLines = [...snapshot.lines];
+      nextLines[target.line] = nextLine;
+      const nextText = nextLines.join("\n");
+
+      return withEffects(rest, [
+        {
+          type: "edit",
+          result: { text: nextText, cursor: snapshot.cursor, changed: nextText !== snapshot.text },
+        },
+        { type: "restoreCursor", position: { line: target.line, col: target.character } },
+        { type: "invalidate" },
+      ]);
+    }
+    return invalidate(state);
   }
 
   if (state.pendingEasymotion?.kind === "jump") {
     const target = state.pendingEasymotion.targets.find((t: any) => t.label === key);
     const { pendingEasymotion: _, ...rest } = state;
-    
+
     if (target) {
       return withEffects(rest, [
         { type: "restoreCursor", position: { line: target.line, col: target.character } },
@@ -582,7 +630,7 @@ function handleNormalInput(
   if (pendingResult.type === "command") {
     // Intercept the configurable "easymotion" command here
     if (pendingResult.command === "easymotion") {
-        return invalidate({ ...state, pending: undefined, pendingEasymotion: { kind: "char" } });
+      return invalidate({ ...state, pending: undefined, pendingEasymotion: { kind: "char" } });
     }
     return applyCommand(state, snapshot, options, pendingResult.command, pendingResult.count);
   }
@@ -853,9 +901,9 @@ function routeModalInput(
 ): ModalUpdate {
   const routedState = state.exMessage && !state.pendingEx ? clearExMessage(state) : state;
   if (routedState.helpPopup) return handleHelpPopupInput(routedState, options, data);
-  
+
   // Easymotion routing
-  if (routedState.pendingEasymotion) 
+  if (routedState.pendingEasymotion)
     return handleEasymotionInput(routedState, snapshot, options, data);
 
   if (routedState.pendingEx)
@@ -875,8 +923,11 @@ function routeModalInput(
 
 export function modalPendingDisplay(state: ModalState): string | undefined {
   if (state.pendingEasymotion?.kind === "char") return "EasyMotion: Find Char...";
+  if (state.pendingEasymotion?.kind === "highlight") {
+    return `Jump [${state.pendingEasymotion.targets.map((t) => t.label).join("")}]: `;
+  }
   if (state.pendingEasymotion?.kind === "jump") {
-      return `Jump [${state.pendingEasymotion.targets.map((t: any) => t.label).join('')}]: `;
+    return `Jump [${state.pendingEasymotion.targets.map((t: any) => t.label).join("")}]: `;
   }
 
   return (

--- a/src/modal/engine.ts
+++ b/src/modal/engine.ts
@@ -207,6 +207,63 @@ export function canFastDelegateInsertInput(
   );
 }
 
+/**
+ * EASYNOMOTION LOGIC
+ */
+function handleEasymotionInput(
+  state: ModalState,
+  snapshot: EditorSnapshot,
+  _options: ModalOptions,
+  data: string,
+): ModalUpdate {
+  const key = keySequence(data);
+  if (!key || matchesKey(data, "escape")) {
+    const { pendingEasymotion: _, ...rest } = state;
+    return invalidate(rest);
+  }
+
+  if (state.pendingEasymotion?.kind === "char") {
+    const targets: { label: string; line: number; character: number }[] = [];
+    const lines = snapshot.text.split("\n");
+    const labels = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ".split("");
+    let count = 0;
+
+    for (let i = 0; i < lines.length && count < labels.length; i++) {
+      let pos = lines[i].indexOf(key);
+      while (pos !== -1 && count < labels.length) {
+        targets.push({ label: labels[count], line: i, character: pos });
+        count++;
+        pos = lines[i].indexOf(key, pos + 1);
+      }
+    }
+
+    if (targets.length === 0) {
+      const { pendingEasymotion: _, ...rest } = state;
+      return invalidate(rest);
+    }
+
+    return invalidate({
+      ...state,
+      pendingEasymotion: { kind: "jump", targets, char: key },
+    });
+  }
+
+  if (state.pendingEasymotion?.kind === "jump") {
+    const target = state.pendingEasymotion.targets.find((t: any) => t.label === key);
+    const { pendingEasymotion: _, ...rest } = state;
+    
+    if (target) {
+      return withEffects(rest, [
+        { type: "restoreCursor", position: { line: target.line, character: target.character } },
+        { type: "invalidate" },
+      ]);
+    }
+    return invalidate(rest);
+  }
+
+  return invalidate(state);
+}
+
 function handleInsertInput(
   state: ModalState,
   snapshot: EditorSnapshot,
@@ -518,8 +575,13 @@ function handleNormalInput(
     if (state.pendingRegister) return invalidate(clearPending(state));
     return moveUpdate(clearPending(state), pendingResult.motion, snapshot, pendingResult.count);
   }
-  if (pendingResult.type === "command")
+  if (pendingResult.type === "command") {
+    // Intercept the configurable "easymotion" command here
+    if (pendingResult.command === "easymotion") {
+        return invalidate({ ...state, pending: undefined, pendingEasymotion: { kind: "char" } });
+    }
     return applyCommand(state, snapshot, options, pendingResult.command, pendingResult.count);
+  }
   if (pendingResult.type === "action") {
     if (state.pendingRegister) return invalidate(clearPending(state));
     return applyPromptTransformAction(state, snapshot, options, pendingResult);
@@ -787,6 +849,11 @@ function routeModalInput(
 ): ModalUpdate {
   const routedState = state.exMessage && !state.pendingEx ? clearExMessage(state) : state;
   if (routedState.helpPopup) return handleHelpPopupInput(routedState, options, data);
+  
+  // Easymotion routing
+  if (routedState.pendingEasymotion) 
+    return handleEasymotionInput(routedState, snapshot, options, data);
+
   if (routedState.pendingEx)
     return handlePendingExInput(routedState, snapshot, options, data, diagnostics);
   if (routedState.pendingSearch)
@@ -803,6 +870,11 @@ function routeModalInput(
 }
 
 export function modalPendingDisplay(state: ModalState): string | undefined {
+  if (state.pendingEasymotion?.kind === "char") return "EasyMotion: Find Char...";
+  if (state.pendingEasymotion?.kind === "jump") {
+      return `Jump [${state.pendingEasymotion.targets.map((t: any) => t.label).join('')}]: `;
+  }
+
   return (
     exDisplay(state.pendingEx) ??
     pendingSearchDisplay(state.pendingSearch) ??

--- a/src/modal/engine.ts
+++ b/src/modal/engine.ts
@@ -218,7 +218,20 @@ function handleEasymotionInput(
 ): ModalUpdate {
   const key = keySequence(data);
   if (!key || matchesKey(data, "escape")) {
-    const { pendingEasymotion: _, ...rest } = state;
+    const { pendingEasymotion, ...rest } = state;
+    if (pendingEasymotion?.kind === "highlight") {
+      return withEffects(rest, [
+        {
+          type: "edit",
+          result: {
+            text: pendingEasymotion.originalText,
+            cursor: snapshot.cursor,
+            changed: true,
+          },
+        },
+        { type: "invalidate" },
+      ]);
+    }
     return invalidate(rest);
   }
 
@@ -263,7 +276,7 @@ function handleEasymotionInput(
     return withEffects(
       {
         ...state,
-        pendingEasymotion: { kind: "highlight", targets },
+        pendingEasymotion: { kind: "highlight", targets, originalText: snapshot.text },
       },
       [
         {
@@ -280,18 +293,15 @@ function handleEasymotionInput(
 
     if (target) {
       const { pendingEasymotion: _, ...rest } = state;
-      // Restore the target's original character
-      const line = snapshot.lines[target.line] ?? "";
-      const nextLine =
-        line.slice(0, target.character) + target.original + line.slice(target.character + 1);
-      const nextLines = [...snapshot.lines];
-      nextLines[target.line] = nextLine;
-      const nextText = nextLines.join("\n");
-
+      // Restore full original text then place cursor on the target
       return withEffects(rest, [
         {
           type: "edit",
-          result: { text: nextText, cursor: snapshot.cursor, changed: nextText !== snapshot.text },
+          result: {
+            text: state.pendingEasymotion.originalText,
+            cursor: snapshot.cursor,
+            changed: true,
+          },
         },
         { type: "restoreCursor", position: { line: target.line, col: target.character } },
         { type: "invalidate" },

--- a/src/modal/engine.ts
+++ b/src/modal/engine.ts
@@ -229,11 +229,15 @@ function handleEasymotionInput(
     let count = 0;
 
     for (let i = 0; i < lines.length && count < labels.length; i++) {
-      let pos = lines[i].indexOf(key);
+      const line = lines[i];
+      if (line === undefined) continue;
+      let pos = line.indexOf(key);
       while (pos !== -1 && count < labels.length) {
-        targets.push({ label: labels[count], line: i, character: pos });
+        const label = labels[count];
+        if (label === undefined) break;
+        targets.push({ label, line: i, character: pos });
         count++;
-        pos = lines[i].indexOf(key, pos + 1);
+        pos = line.indexOf(key, pos + 1);
       }
     }
 
@@ -254,7 +258,7 @@ function handleEasymotionInput(
     
     if (target) {
       return withEffects(rest, [
-        { type: "restoreCursor", position: { line: target.line, character: target.character } },
+        { type: "restoreCursor", position: { line: target.line, col: target.character } },
         { type: "invalidate" },
       ]);
     }

--- a/src/modal/normal.ts
+++ b/src/modal/normal.ts
@@ -582,6 +582,9 @@ export function applyCommand(
         { type: "invalidate" },
       ]);
     }
+    // easymotion is intercepted in handleNormalInput before reaching applyCommand
+    default:
+      return invalidate(nextState);
   }
 }
 

--- a/src/modal/types.ts
+++ b/src/modal/types.ts
@@ -191,7 +191,13 @@ export type ModalState = {
     cursor: Position;
     text: string;
   };
-  pendingEasymotion?: { kind: "char" } | { kind: "jump"; targets: { label: string; line: number; character: number }[]; char: string };
+  pendingEasymotion?:
+    | { kind: "char" }
+    | {
+        kind: "highlight";
+        targets: { label: string; line: number; character: number; original: string }[];
+      }
+    | { kind: "jump"; targets: { label: string; line: number; character: number }[]; char: string };
 };
 
 export type FastInsertDelegateContext = {

--- a/src/modal/types.ts
+++ b/src/modal/types.ts
@@ -196,6 +196,7 @@ export type ModalState = {
     | {
         kind: "highlight";
         targets: { label: string; line: number; character: number; original: string }[];
+        originalText: string;
       }
     | { kind: "jump"; targets: { label: string; line: number; character: number }[]; char: string };
 };

--- a/src/modal/types.ts
+++ b/src/modal/types.ts
@@ -191,6 +191,7 @@ export type ModalState = {
     cursor: Position;
     text: string;
   };
+  pendingEasymotion?: { kind: "char" } | { kind: "jump"; targets: { label: string; line: number; character: number }[]; char: string };
 };
 
 export type FastInsertDelegateContext = {

--- a/src/render.ts
+++ b/src/render.ts
@@ -36,6 +36,11 @@ export type SearchHighlightRenderInput = {
   maxHighlights: number;
 };
 
+export type EasymotionRenderInput = {
+  targets: { line: number; character: number }[];
+  labelColor: string;
+};
+
 export type PromptRenderInput = {
   snapshot: {
     lines: string[];
@@ -54,6 +59,7 @@ export type PromptRenderInput = {
   display?: {
     borderColor?: (text: string) => string;
   };
+  easymotion?: EasymotionRenderInput;
 };
 
 export type ActiveVisualRenderInput = {
@@ -78,6 +84,7 @@ export type ActiveVisualRenderInput = {
   display?: {
     borderColor?: (text: string) => string;
   };
+  easymotion?: EasymotionRenderInput;
 };
 
 type VisualRenderView = {
@@ -94,6 +101,8 @@ type VisualRenderView = {
   borderColor?: (text: string) => string;
   search?: SearchHighlightRenderInput;
   searchRanges: TextRange[];
+  easymotion: EasymotionRenderInput | undefined;
+  easymotionTargets: Set<string>;
 };
 
 function styleSelection(text: string): string {
@@ -280,6 +289,8 @@ function renderLayoutLine(
       )
     ) {
       output += styleSelection(cell);
+    } else if (options.easymotionTargets?.has(`${chunk.lineIndex}:${cellStart}`)) {
+      output += options.easymotion?.labelColor + cell + ANSI_RESET;
     } else {
       const searchStyle = searchRangeAt(options, chunk.lineIndex, cellStart);
       if (searchStyle === "current") output += styleCurrentSearch(cell);
@@ -364,6 +375,10 @@ function createPromptRenderView(input: PromptRenderInput): VisualRenderView {
     borderColor: input.display?.borderColor,
     search: input.search,
     searchRanges: createSearchRanges(input.snapshot.text, input.search),
+    easymotion: input.easymotion,
+    easymotionTargets: new Set(
+      (input.easymotion?.targets ?? []).map((t) => `${t.line}:${t.character}`),
+    ),
   };
 }
 
@@ -383,6 +398,10 @@ function createVisualRenderView(input: ActiveVisualRenderInput): VisualRenderVie
     borderColor: input.display?.borderColor,
     search: input.search,
     searchRanges: createSearchRanges(text, input.search),
+    easymotion: input.easymotion,
+    easymotionTargets: new Set(
+      (input.easymotion?.targets ?? []).map((t) => `${t.line}:${t.character}`),
+    ),
   };
 }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -95,7 +95,8 @@ export type VimCommandAction =
   | "undo"
   | "redo"
   | "showKeybindings"
-  | "reselectVisual";
+  | "reselectVisual"
+  | "easymotion";
 
 export type VimTextObjectKind = "inner" | "around";
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -257,6 +257,14 @@ export type VimSearchOptions = {
 
 export type ResolvedVimSearch = VimSearchOptions;
 
+export type VimEasymotionOptions = {
+  labelColor: string;
+};
+
+export type ResolvedVimEasymotion = VimEasymotionOptions;
+
+export type PartialVimEasymotionOptions = Partial<ResolvedVimEasymotion>;
+
 export type VimUiOptions = {
   status: {
     enabled: boolean;
@@ -353,6 +361,7 @@ export type VimEditorOptions = {
   macros?: Partial<ResolvedVimMacros>;
   marks?: Partial<ResolvedVimMarks>;
   search?: Partial<ResolvedVimSearch>;
+  easymotion?: PartialVimEasymotionOptions;
   feedback?: Partial<VimFeedbackOptions>;
   promptStructures?: VimPromptStructureEditorOptions;
   promptTransforms?: VimPromptTransformEditorOptions;
@@ -368,6 +377,7 @@ export type ResolvedVimEditorOptions = {
   macros?: ResolvedVimMacros;
   marks?: ResolvedVimMarks;
   search?: ResolvedVimSearch;
+  easymotion?: ResolvedVimEasymotion;
   exCommand?: ResolvedVimExCommand;
   feedback?: VimFeedbackOptions;
   promptStructures?: ResolvedVimPromptStructures;

--- a/src/vim-editor.ts
+++ b/src/vim-editor.ts
@@ -40,6 +40,7 @@ import {
   promptTransformsForOptions,
   searchForOptions,
   uiForOptions,
+  easymotionForOptions,
 } from "./config.ts";
 import { suggestExCommands } from "./ex.ts";
 import {
@@ -404,6 +405,16 @@ export class VimEditor extends CustomEditor {
       maxHighlights: search.maxHighlights,
     };
   }
+  private easymotionRenderInput() {
+    const easymotion = easymotionForOptions(this.options);
+    if (!easymotion) return undefined;
+    const pending = this.modalState.pendingEasymotion;
+    if (pending?.kind !== "highlight") return undefined;
+    return {
+      targets: pending.targets.map((t) => ({ line: t.line, character: t.character })),
+      labelColor: easymotion.labelColor,
+    };
+  }
 
   private renderEditorLines(
     width: number,
@@ -437,6 +448,7 @@ export class VimEditor extends CustomEditor {
           },
         },
         search: this.searchRenderInput(),
+        easymotion: this.easymotionRenderInput(),
         display: {
           borderColor: this.borderColor,
         },
@@ -473,6 +485,7 @@ export class VimEditor extends CustomEditor {
           },
         },
         search: this.searchRenderInput(),
+        easymotion: this.easymotionRenderInput(),
         display: {
           borderColor: this.borderColor,
         },

--- a/test/customization.test.ts
+++ b/test/customization.test.ts
@@ -27,7 +27,7 @@ describe("vim customization helpers", () => {
   });
 
   test("formats keymap entries from resolved bindings", () => {
-    expect(keymapMessage(keymap)).toBe("keymap: 90 entries; :keymap <action>");
+    expect(keymapMessage(keymap)).toBe("keymap: 91 entries; :keymap <action>");
     expect(keymapMessage(keymap, "redo")).toContain("command.redo ctrl+r");
     expect(keymapMessage(keymap, "halfPageDown")).toContain("motion.halfPageDown ctrl+d");
     expect(keymapMessage(keymap, "missing-action")).toBe("keymap: no match for missing-action");

--- a/test/keymap-descriptors.test.ts
+++ b/test/keymap-descriptors.test.ts
@@ -101,6 +101,7 @@ const expectedCommands = [
   "redo",
   "showKeybindings",
   "reselectVisual",
+  "easymotion",
 ];
 const expectedTextObjectTargets = [
   "word",


### PR DESCRIPTION
## Summary

This PR adds a vim-easymotion (https://github.com/easymotion/vim-easymotion) like capability. 

## Changes

 Changes

 - Add easymotion command binding and easymotion.goToChar
   to config-js and keymap descriptors
 - Implement three-state EasyMotion flow in modal engine:
   char (input target character) → highlight (inject
   address labels into editor) → restore (jump to target,
   restore original character)
 - Support case-insensitive character matching with up to
   52 labeled targets (a-z, A-Z)
 - Update pendingEasymotion type to include highlight kind
   with original character tracking
 - Inject address characters via edit effect during
   highlight, then restore originals on jump
 - Update display text to show available labels during
   highlight phase
 - Add easymotion description to command descriptions

## Testing

- [x] `bun test` passes
- [x] `bun run check-types` passes
- [x] `bun run lint` passes
- [x] Manually tested in Pi

## Related Issues

Closes #
