### PR TITLE
feat(config): expose trusted JavaScript option tree

### DIFF
--- a/openspec/changes/ship-pi-vimmode-0-9-0/tasks.md
+++ b/openspec/changes/ship-pi-vimmode-0-9-0/tasks.md
@@ -11,7 +11,7 @@
 
 ## 3. Public Config Behavior and Reload
 
-- [ ] 3.1 Implement [#38](https://github.com/pekochan069/pi-vimmode/issues/38): expose every finite `piVimMode` option through validated domain-grouped trusted JavaScript properties and prove source-order/replacement/fallback behavior. **Blocked by:** #37.
+- [x] 3.1 Implement [#38](https://github.com/pekochan069/pi-vimmode/issues/38): expose every finite `piVimMode` option through validated domain-grouped trusted JavaScript properties and prove source-order/replacement/fallback behavior. **Blocked by:** #37.
 - [ ] 3.2 Implement [#39](https://github.com/pekochan069/pi-vimmode/issues/39): add opaque action descriptors and finite mode-scoped mappings with unmapping, deterministic conflicts, bounded replay, insert/operator restrictions, protected override, compatibility aliases, and project precedence. **Blocked by:** #37; may run parallel with #38.
 - [ ] 3.3 Implement [#40](https://github.com/pekochan069/pi-vimmode/issues/40): reconfigure tracked active editors atomically on generation-guarded reload, preserving durable state and clearing specified transient grammar through lifecycle and real-editor tests. **Blocked by:** #38 and #39.
 

--- a/src/config-js.ts
+++ b/src/config-js.ts
@@ -171,14 +171,14 @@ function hasOptionChild(path: string): boolean {
   return OPTION_ENTRIES.some((entry) => entry.path.startsWith(`${path}.`));
 }
 
-function readPath(value: unknown, path: string): unknown {
+export function optionValueAtPath(value: unknown, path: string): unknown {
   return path.split(".").reduce<unknown>((current, key) => {
     if (!current || typeof current !== "object") return undefined;
     return (current as Record<string, unknown>)[key];
   }, value);
 }
 
-function setPath(value: Record<string, unknown>, path: string, next: unknown): void {
+export function setOptionPath(value: Record<string, unknown>, path: string, next: unknown): void {
   const keys = path.split(".");
   const leaf = keys.pop();
   if (!leaf) return;
@@ -474,7 +474,7 @@ function createSession(
     },
     readOption: (path) => {
       assertOpen();
-      return readPath(staged, path);
+      return optionValueAtPath(staged, path);
     },
     setOption: (path, value) => {
       assertOpen();
@@ -484,7 +484,7 @@ function createSession(
         return;
       }
       const next = structuredClone(staged);
-      setPath(next, path, frozenSnapshot(result.value));
+      setOptionPath(next, path, frozenSnapshot(result.value));
       staged = next;
       operations.push({ kind: "leaf", path, value: frozenSnapshot(result.value) });
     },
@@ -496,7 +496,7 @@ function createSession(
       }
       const next =
         rules?.applyPreset(structuredClone(staged), value as VimPreset) ?? structuredClone(staged);
-      setPath(next, "preset", value);
+      setOptionPath(next, "preset", value);
       staged = next;
       operations.push({ kind: "preset", preset: value as VimPreset });
     },

--- a/src/config-js.ts
+++ b/src/config-js.ts
@@ -4,13 +4,7 @@ import { join } from "node:path";
 import { pathToFileURL } from "node:url";
 
 import type { BindablePromptTransformActionId } from "./prompt-transform-actions.ts";
-import type {
-  VimActionBindingMode,
-  VimEditorOptions,
-  VimInsertAction,
-  VimMode,
-  VimPreset,
-} from "./types.ts";
+import type { VimActionBindingMode, VimInsertAction, VimMode, VimPreset } from "./types.ts";
 
 import { protectedShortcutForKey } from "./customization.ts";
 import { VIM_PRESETS } from "./types.ts";
@@ -43,9 +37,19 @@ export type VimJsConfigMapOperation =
 
 export type VimJsConfigOperation =
   | { kind: "preset"; preset: VimPreset }
-  | { kind: "leaf"; path: "leader"; value: string | null }
+  | { kind: "leaf"; path: string; value: unknown }
   | { kind: "map"; mapping: VimJsConfigMapOperation }
   | { kind: "unmap"; key: string; modes: readonly VimMode[] };
+
+export type VimJsConfigRules = {
+  validate(
+    path: string,
+    value: unknown,
+  ):
+    | { readonly ok: true; readonly value: unknown }
+    | { readonly ok: false; readonly message: string };
+  applyPreset(state: Record<string, unknown>, preset: VimPreset): Record<string, unknown>;
+};
 
 export type VimJsConfigLoadResult =
   | { kind: "missing"; warnings: readonly string[] }
@@ -56,8 +60,8 @@ type ConfigSession = {
   vim: object;
   assertOpen(): void;
   close(): void;
-  readLeader(): string | null | undefined;
-  setMapleader(value: unknown): void;
+  readOption(path: string): unknown;
+  setOption(path: string, value: unknown): void;
   setPreset(value: unknown): void;
   warning(message: string): void;
   recordMap(mapping: VimJsConfigMapOperation): void;
@@ -112,6 +116,112 @@ function frozenSnapshot<T>(value: T): T {
   return Object.freeze(
     Object.fromEntries(Object.entries(value).map(([key, child]) => [key, frozenSnapshot(child)])),
   ) as T;
+}
+
+type OptionEntry = { path: string };
+
+const OPTION_ENTRIES: readonly OptionEntry[] = [
+  { path: "leader" },
+  { path: "startMode" },
+  ...["insert", "normal", "visual", "visualLine", "visualBlock"].map((mode) => ({
+    path: `cursor.${mode}`,
+  })),
+  { path: "keymap.actionPresets" },
+  { path: "keymap.operatorMotions" },
+  { path: "ui.status.enabled" },
+  { path: "ui.status.position" },
+  { path: "ui.status.items" },
+  { path: "ui.mode.enabled" },
+  { path: "ui.mode.labels" },
+  { path: "ui.mode.narrowLabels" },
+  { path: "ui.selection.enabled" },
+  { path: "ui.selection.previewMaxChars" },
+  { path: "ui.cursorPosition.enabled" },
+  { path: "ui.cursorPosition.base" },
+  { path: "ui.cursorPosition.format" },
+  { path: "ui.workbench.reservedRows" },
+  { path: "macros.enabled" },
+  { path: "macros.slots" },
+  { path: "macros.maxReplaySteps" },
+  { path: "marks.enabled" },
+  { path: "marks.slots" },
+  { path: "search.highlight" },
+  { path: "search.highlightCurrent" },
+  { path: "search.clearOnCancel" },
+  { path: "search.clearOnInsert" },
+  { path: "search.maxHighlights" },
+  { path: "exCommand.autocomplete" },
+  { path: "feedback.noop" },
+  { path: "promptStructures.enabled" },
+  { path: "promptStructures.targets" },
+  { path: "promptTransforms.enabled" },
+  { path: "promptTransforms.actions" },
+  { path: "promptTransforms.commands" },
+];
+
+function optionPath(prefix: string, property: string): string {
+  return prefix ? `${prefix}.${property}` : property;
+}
+
+function hasOption(path: string): boolean {
+  return OPTION_ENTRIES.some((entry) => entry.path === path);
+}
+
+function hasOptionChild(path: string): boolean {
+  return OPTION_ENTRIES.some((entry) => entry.path.startsWith(`${path}.`));
+}
+
+function readPath(value: unknown, path: string): unknown {
+  return path.split(".").reduce<unknown>((current, key) => {
+    if (!current || typeof current !== "object") return undefined;
+    return (current as Record<string, unknown>)[key];
+  }, value);
+}
+
+function setPath(value: Record<string, unknown>, path: string, next: unknown): void {
+  const keys = path.split(".");
+  const leaf = keys.pop();
+  if (!leaf) return;
+  let target = value;
+  for (const key of keys) {
+    const child = target[key];
+    if (!child || typeof child !== "object") target[key] = {};
+    target = target[key] as Record<string, unknown>;
+  }
+  target[leaf] = next;
+}
+
+function createOptionNamespace(
+  session: ConfigSession,
+  prefix: string,
+  target: object = {},
+): object {
+  return new Proxy(target, {
+    get(current, property, receiver) {
+      if (typeof property !== "string") return Reflect.get(current, property, receiver);
+      if (Reflect.has(current, property)) return Reflect.get(current, property, receiver);
+      const path = optionPath(prefix, property);
+      if (hasOption(path)) return frozenSnapshot(session.readOption(path));
+      if (hasOptionChild(path)) return createOptionNamespace(session, path);
+      return undefined;
+    },
+    set(current, property, value, receiver) {
+      session.assertOpen();
+      if (typeof property !== "string") return Reflect.set(current, property, value, receiver);
+      if (Reflect.has(current, property)) return Reflect.set(current, property, value, receiver);
+      const path = optionPath(prefix, property);
+      if (hasOption(path)) {
+        session.setOption(path, value);
+        return true;
+      }
+      session.warning(`unknown vim${prefix ? `.${prefix}` : ""} property ${property}`);
+      return true;
+    },
+    defineProperty(current, property, descriptor) {
+      session.assertOpen();
+      return Reflect.defineProperty(current, property, descriptor);
+    },
+  });
 }
 
 function modesFor(rawMode: unknown): readonly VimMode[] | undefined {
@@ -304,10 +414,14 @@ function createGlobalApi(session: ConfigSession): object {
   return new Proxy(
     {
       get mapleader() {
-        return session.readLeader();
+        return session.readOption("leader");
       },
       set mapleader(value: unknown) {
-        session.setMapleader(value);
+        if (value !== null && !isPrintableLeader(value)) {
+          session.warning("vim.g.mapleader must be one printable character or null");
+          return;
+        }
+        session.setOption("leader", value);
       },
     },
     {
@@ -325,37 +439,28 @@ function createGlobalApi(session: ConfigSession): object {
 }
 
 function createVimApi(session: ConfigSession, g: object): object {
-  return new Proxy(
-    {
-      g,
-      get preset() {
-        return undefined;
-      },
-      set preset(value: unknown) {
-        session.setPreset(value);
-      },
-      prompt: createPromptApi(),
-      keymap: Object.freeze({
-        set: (mode: unknown, lhs: unknown, rhs: unknown) => compileMapping(session, mode, lhs, rhs),
-      }),
+  const keymap = createOptionNamespace(session, "keymap", {
+    set: (mode: unknown, lhs: unknown, rhs: unknown) => compileMapping(session, mode, lhs, rhs),
+  });
+  return createOptionNamespace(session, "", {
+    g,
+    get preset() {
+      return session.readOption("preset");
     },
-    {
-      set(target, property, value, receiver) {
-        if (property === "preset") return Reflect.set(target, property, value, receiver);
-        session.warning(`unknown vim property ${String(property)}`);
-        return true;
-      },
-      defineProperty(target, property, descriptor) {
-        session.assertOpen();
-        return Reflect.defineProperty(target, property, descriptor);
-      },
+    set preset(value: unknown) {
+      session.setPreset(value);
     },
-  );
+    prompt: createPromptApi(),
+    keymap,
+  });
 }
 
-function createSession(seed: Pick<VimEditorOptions, "leader"> = {}): ConfigSession {
+function createSession(
+  seed: Record<string, unknown> = {},
+  rules?: VimJsConfigRules,
+): ConfigSession {
   let closed = false;
-  let leader = seed.leader;
+  let staged = frozenSnapshot(seed) as Record<string, unknown>;
   const warnings: string[] = [];
   const operations: VimJsConfigOperation[] = [];
   const assertOpen = () => {
@@ -367,26 +472,33 @@ function createSession(seed: Pick<VimEditorOptions, "leader"> = {}): ConfigSessi
     close: () => {
       closed = true;
     },
-    readLeader: () => {
+    readOption: (path) => {
       assertOpen();
-      return leader;
+      return readPath(staged, path);
     },
-    setMapleader: (value) => {
+    setOption: (path, value) => {
       assertOpen();
-      if (value === null || isPrintableLeader(value)) {
-        leader = value;
-        operations.push({ kind: "leaf", path: "leader", value });
+      const result = rules?.validate(path, value) ?? { ok: true as const, value };
+      if (!result.ok) {
+        warnings.push(warning(result.message));
         return;
       }
-      warnings.push(warning("vim.g.mapleader must be one printable character or null"));
+      const next = structuredClone(staged);
+      setPath(next, path, frozenSnapshot(result.value));
+      staged = next;
+      operations.push({ kind: "leaf", path, value: frozenSnapshot(result.value) });
     },
     setPreset: (value) => {
       assertOpen();
-      if (typeof value === "string" && VIM_PRESET_SET.has(value as VimPreset)) {
-        operations.push({ kind: "preset", preset: value as VimPreset });
+      if (typeof value !== "string" || !VIM_PRESET_SET.has(value as VimPreset)) {
+        warnings.push(warning("vim.preset must be a supported preset"));
         return;
       }
-      warnings.push(warning("vim.preset must be a supported preset"));
+      const next =
+        rules?.applyPreset(structuredClone(staged), value as VimPreset) ?? structuredClone(staged);
+      setPath(next, "preset", value);
+      staged = next;
+      operations.push({ kind: "preset", preset: value as VimPreset });
     },
     warning: (message) => {
       assertOpen();
@@ -425,7 +537,8 @@ function isThenable(value: unknown): value is PromiseLike<unknown> {
 
 export async function loadVimJsConfig(
   configPath = DEFAULT_JS_CONFIG_PATH,
-  seed: Pick<VimEditorOptions, "leader"> = {},
+  seed: Record<string, unknown> = {},
+  rules?: VimJsConfigRules,
 ): Promise<VimJsConfigLoadResult> {
   if (!existsSync(configPath)) return { kind: "missing", warnings: [] };
 
@@ -440,7 +553,7 @@ export async function loadVimJsConfig(
   }
   if (typeof exported !== "function") return fatal(new Error("default export must be a function"));
 
-  const session = createSession(seed);
+  const session = createSession(seed, rules);
   try {
     const result = exported(session.vim);
     if (isThenable(result)) await result;

--- a/src/config.ts
+++ b/src/config.ts
@@ -45,6 +45,7 @@ import {
   isPrintableLeader,
   loadVimJsConfig,
   type VimJsConfigOperation,
+  type VimJsConfigRules,
 } from "./config-js.ts";
 import { protectedShortcutForKey } from "./customization.ts";
 import {
@@ -341,6 +342,7 @@ type PartialKeymapOptions = {
     targets?: Partial<Record<VimTextObjectTarget, string[]>>;
   };
   operatorMotions?: Partial<Record<VimMotionOperatorAction, VimMotionAction[]>>;
+  replaceOperatorMotions?: boolean;
   insert?: Partial<ResolvedVimInsertKeymap>;
   actionPresets?: VimActionKeybindingPreset[];
   actions?: Partial<Record<BindablePromptTransformActionId, ResolvedVimActionBinding[]>>;
@@ -1595,6 +1597,53 @@ function parsePiVimMode(
   return { partial, warnings };
 }
 
+function setOptionPath(value: Record<string, unknown>, path: string, next: unknown): void {
+  const keys = path.split(".");
+  const leaf = keys.pop();
+  if (!leaf) return;
+  let target = value;
+  for (const key of keys) {
+    const child = target[key];
+    if (!child || typeof child !== "object") target[key] = {};
+    target = target[key] as Record<string, unknown>;
+  }
+  target[leaf] = next;
+}
+
+function optionValueAtPath(value: unknown, path: string): unknown {
+  return path.split(".").reduce<unknown>((current, key) => {
+    if (!current || typeof current !== "object") return undefined;
+    return (current as Record<string, unknown>)[key];
+  }, value);
+}
+
+function configRuleFor(path: string, value: unknown): ReturnType<VimJsConfigRules["validate"]> {
+  const config: Record<string, unknown> = {};
+  setOptionPath(config, path, value);
+  const parsed = parsePiVimMode(config, "global JS config");
+  const parsedValue = optionValueAtPath(parsed.partial, path);
+  const unknownRecordMember =
+    isRecord(value) &&
+    isRecord(parsedValue) &&
+    Object.keys(value).some((key) => !Object.hasOwn(parsedValue, key));
+  if (parsed.warnings.length === 0 && parsedValue !== undefined && !unknownRecordMember) {
+    return { ok: true, value: parsedValue };
+  }
+  const message = parsed.warnings[0] ?? `unsupported piVimMode.${path}`;
+  return { ok: false, message: message.replace(/^global JS config: /, "") };
+}
+
+function jsConfigRules(): VimJsConfigRules {
+  return {
+    validate: configRuleFor,
+    applyPreset(state, preset) {
+      const options = cloneResolvedVimOptions(state as ResolvedVimEditorOptions);
+      mergePartialOptions(options, presetOptions(preset));
+      return options as unknown as Record<string, unknown>;
+    },
+  };
+}
+
 function configuredTopLevelKeymapSequences(partial: PartialKeymapOptions): Set<string> {
   const sequences = new Set<string>();
   for (const group of [partial.operators, partial.motions, partial.macros, partial.marks]) {
@@ -1680,7 +1729,11 @@ function mergeKeymap(target: ResolvedVimKeymap, partial: PartialKeymapOptions): 
     };
   }
   if (partial.operatorMotions) {
-    target.operatorMotions = { ...target.operatorMotions, ...partial.operatorMotions };
+    target.operatorMotions = (
+      partial.replaceOperatorMotions
+        ? { ...partial.operatorMotions }
+        : { ...target.operatorMotions, ...partial.operatorMotions }
+    ) as typeof target.operatorMotions;
   }
   if (partial.insert) {
     target.insert = { ...target.insert, ...partial.insert };
@@ -1727,6 +1780,7 @@ function removePartialRemaps(target: PartialKeymapOptions, sequences: Set<string
 }
 
 function mergeKeymapOverlay(target: PartialKeymapOptions, partial: PartialKeymapOptions): void {
+  if (partial.replaceOperatorMotions) target.replaceOperatorMotions = true;
   removePartialRemaps(target, configuredTopLevelKeymapSequences(partial));
   if (partial.escape) target.escape = [...partial.escape];
   if (partial.operators) target.operators = { ...target.operators, ...partial.operators };
@@ -1741,7 +1795,11 @@ function mergeKeymapOverlay(target: PartialKeymapOptions, partial: PartialKeymap
     };
   }
   if (partial.operatorMotions) {
-    target.operatorMotions = { ...target.operatorMotions, ...partial.operatorMotions };
+    target.operatorMotions = (
+      partial.replaceOperatorMotions
+        ? { ...partial.operatorMotions }
+        : { ...target.operatorMotions, ...partial.operatorMotions }
+    ) as typeof target.operatorMotions;
   }
   if (partial.insert) {
     target.insert = { ...target.insert, ...partial.insert };
@@ -2465,10 +2523,7 @@ function partialFromJsOperations(operations: readonly VimJsConfigOperation[]): V
       partial.preset = operation.preset;
       continue;
     }
-    if (operation.kind === "leaf") {
-      partial.leader = operation.value;
-      continue;
-    }
+    if (operation.kind === "leaf") continue;
     const keymap = (partial.keymap ??= {});
     if (operation.kind === "unmap") {
       removeJsMappings(keymap as PartialKeymapOptions, operation.key, operation.modes);
@@ -2503,6 +2558,79 @@ function partialFromJsOperations(operations: readonly VimJsConfigOperation[]): V
     ];
   }
   return partial;
+}
+
+const JS_REPLACED_RECORD_PATHS = new Set([
+  "ui.mode.labels",
+  "ui.mode.narrowLabels",
+  "promptStructures.targets",
+  "promptTransforms.actions",
+  "promptTransforms.commands",
+]);
+
+function replaceJsRecord(
+  options: ResolvedVimEditorOptions,
+  path: string,
+  partial: PartialVimOptions,
+): void {
+  if (!JS_REPLACED_RECORD_PATHS.has(path)) return;
+  const value = optionValueAtPath(partial, path);
+  if (value !== undefined)
+    setOptionPath(options as unknown as Record<string, unknown>, path, value);
+}
+
+function appendJsMapLayer(
+  keymapLayers: PartialKeymapOptions[],
+  operations: readonly VimJsConfigOperation[],
+  warnings: string[],
+): void {
+  if (operations.length === 0) return;
+  const source = partialFromJsOperations(operations);
+  const rawKeymap = source.keymap as PartialKeymapOptions | undefined;
+  const parsed = parsePiVimMode(source, "global JS config");
+  if (!parsed.partial.keymap) return;
+  warnings.push(...parsed.warnings);
+  const layer = additiveKeymapLayer(keymapLayers, parsed.partial.keymap);
+  layer.unmaps = rawKeymap?.unmaps;
+  keymapLayers.push(layer);
+}
+
+function applyJsOptionOperations(
+  options: ResolvedVimEditorOptions,
+  keymapLayers: PartialKeymapOptions[],
+  operations: readonly VimJsConfigOperation[],
+  warnings: string[],
+): void {
+  let mapOperations: VimJsConfigOperation[] = [];
+  const flushMapOperations = () => {
+    appendJsMapLayer(keymapLayers, mapOperations, warnings);
+    mapOperations = [];
+  };
+
+  for (const operation of operations) {
+    if (operation.kind === "map" || operation.kind === "unmap") {
+      mapOperations.push(operation);
+      continue;
+    }
+    flushMapOperations();
+    if (operation.kind === "preset") {
+      const preset = presetOptions(operation.preset);
+      mergePartialOptions(options, preset);
+      if (preset.keymap) keymapLayers.push(preset.keymap);
+      continue;
+    }
+    const value: Record<string, unknown> = {};
+    setOptionPath(value, operation.path, operation.value);
+    const parsed = parsePiVimMode(value, "global JS config");
+    mergePartialOptions(options, parsed.partial);
+    replaceJsRecord(options, operation.path, parsed.partial);
+    if (operation.path === "keymap.operatorMotions" && parsed.partial.keymap) {
+      parsed.partial.keymap.replaceOperatorMotions = true;
+    }
+    if (parsed.partial.keymap) keymapLayers.push(parsed.partial.keymap);
+    warnings.push(...parsed.warnings);
+  }
+  flushMapOperations();
 }
 
 function compileJsConfig(jsConfig: Parameters<typeof resolveVimOptions>[2]): {
@@ -2774,10 +2902,14 @@ export function resolveVimOptions(
   if (parsedGlobal.partial.keymap) keymapLayers.push(parsedGlobal.partial.keymap);
   warnings.push(...parsedGlobal.warnings);
 
-  const compiledJs = compileJsConfig(jsConfig);
-  const parsedJs = parsePiVimMode(compiledJs.source, "global JS config");
-  const appendJsKeymap = jsConfig?.kind === "success" || jsConfig?.appendKeymap;
-  if (parsedJs.partial.preset) {
+  const compiledJs = jsConfig?.operations ? undefined : compileJsConfig(jsConfig);
+  if (jsConfig?.operations) {
+    applyJsOptionOperations(options, keymapLayers, jsConfig.operations, warnings);
+  }
+  const parsedJs = parsePiVimMode(compiledJs?.source, "global JS config");
+  const appendJsKeymap =
+    !jsConfig?.operations && (jsConfig?.kind === "success" || jsConfig?.appendKeymap);
+  if (!jsConfig?.operations && parsedJs.partial.preset) {
     const preset = presetOptions(parsedJs.partial.preset);
     mergePartialOptions(options, preset);
     if (preset.keymap) keymapLayers.push(preset.keymap);
@@ -2788,7 +2920,7 @@ export function resolveVimOptions(
           ...parsedJs.partial,
           keymap: {
             ...additiveKeymapLayer(keymapLayers, parsedJs.partial.keymap),
-            unmaps: compiledJs.unmaps,
+            unmaps: compiledJs?.unmaps,
           },
         }
       : parsedJs.partial;
@@ -2844,7 +2976,11 @@ export async function loadVimOptions(paths: VimConfigPaths = {}): Promise<VimCon
   const globalRead = readJsonFile(globalPath, "global settings");
   const projectRead = readJsonFile(projectPath, "project settings");
   const globalSeed = resolveVimOptions(globalRead.settings).options;
-  const jsRead = await loadVimJsConfig(jsConfigPath, { leader: globalSeed.leader });
+  const jsRead = await loadVimJsConfig(
+    jsConfigPath,
+    globalSeed as unknown as Record<string, unknown>,
+    jsConfigRules(),
+  );
   const resolved = resolveVimOptions(globalRead.settings, projectRead.settings, jsRead);
 
   const warnings = [...globalRead.warnings, ...projectRead.warnings, ...resolved.warnings];

--- a/src/config.ts
+++ b/src/config.ts
@@ -44,6 +44,8 @@ import {
   DEFAULT_JS_CONFIG_PATH,
   isPrintableLeader,
   loadVimJsConfig,
+  optionValueAtPath,
+  setOptionPath,
   type VimJsConfigOperation,
   type VimJsConfigRules,
 } from "./config-js.ts";
@@ -345,6 +347,7 @@ type PartialKeymapOptions = {
   replaceOperatorMotions?: boolean;
   insert?: Partial<ResolvedVimInsertKeymap>;
   actionPresets?: VimActionKeybindingPreset[];
+  presetActionBindings?: ResolvedVimActionBinding[];
   actions?: Partial<Record<BindablePromptTransformActionId, ResolvedVimActionBinding[]>>;
   remaps?: ResolvedVimKeymap["remaps"];
   unmaps?: Array<{ key: string; modes: readonly VimMode[] }>;
@@ -902,7 +905,7 @@ function parseActionPresets(
     mergeParsedActionBindings(actions, presetActions);
   }
   return {
-    presets: presets.length > 0 ? presets : undefined,
+    presets,
     actions: Object.keys(actions).length > 0 ? actions : undefined,
   };
 }
@@ -1026,6 +1029,7 @@ function parseKeymap(
 
   const actionPresets = parseActionPresets(value.actionPresets, sourceLabel, warnings);
   partial.actionPresets = actionPresets.presets;
+  partial.presetActionBindings = Object.values(actionPresets.actions ?? {}).flat();
   const actions: Partial<Record<BindablePromptTransformActionId, ResolvedVimActionBinding[]>> = {};
   mergeParsedActionBindings(actions, actionPresets.actions);
   mergeParsedActionBindings(
@@ -1383,12 +1387,13 @@ function parseBooleanMap<T extends string>(
   for (const [key, enabled] of Object.entries(value)) {
     if (!allowed.has(key)) {
       warnings.push(`${label}.${key} is unsupported`);
-      continue;
+    } else if (typeof enabled === "boolean") {
+      parsed[key as T] = enabled;
+    } else {
+      warnings.push(`${label}.${key} must be a boolean`);
     }
-    if (typeof enabled === "boolean") parsed[key as T] = enabled;
-    else warnings.push(`${label}.${key} must be a boolean`);
   }
-  return Object.keys(parsed).length > 0 ? parsed : undefined;
+  return parsed;
 }
 
 function parseMarks(
@@ -1489,7 +1494,7 @@ function parsePromptTransforms(
         )?.filter((name) => /^[A-Za-z]+$/.test(name));
         if (names) commands[action as PromptTransformAction] = names;
       }
-      if (Object.keys(commands).length > 0) partial.commands = commands;
+      partial.commands = commands;
     }
   }
 
@@ -1597,27 +1602,22 @@ function parsePiVimMode(
   return { partial, warnings };
 }
 
-function setOptionPath(value: Record<string, unknown>, path: string, next: unknown): void {
-  const keys = path.split(".");
-  const leaf = keys.pop();
-  if (!leaf) return;
-  let target = value;
-  for (const key of keys) {
-    const child = target[key];
-    if (!child || typeof child !== "object") target[key] = {};
-    target = target[key] as Record<string, unknown>;
-  }
-  target[leaf] = next;
-}
-
-function optionValueAtPath(value: unknown, path: string): unknown {
-  return path.split(".").reduce<unknown>((current, key) => {
-    if (!current || typeof current !== "object") return undefined;
-    return (current as Record<string, unknown>)[key];
-  }, value);
+function hasValidPromptTransformCommands(value: unknown): boolean {
+  return (
+    isRecord(value) &&
+    Object.entries(value).every(
+      ([action, names]) =>
+        PROMPT_TRANSFORM_ACTION_SET.has(action) &&
+        Array.isArray(names) &&
+        names.every((name) => typeof name === "string" && /^[A-Za-z]+$/.test(name)),
+    )
+  );
 }
 
 function configRuleFor(path: string, value: unknown): ReturnType<VimJsConfigRules["validate"]> {
+  if (path === "promptTransforms.commands" && !hasValidPromptTransformCommands(value)) {
+    return { ok: false, message: "piVimMode.promptTransforms.commands must contain letters only" };
+  }
   const config: Record<string, unknown> = {};
   setOptionPath(config, path, value);
   const parsed = parsePiVimMode(config, "global JS config");
@@ -1706,6 +1706,14 @@ function removeScopedKeymapBindings(
   });
 }
 
+function mergeOperatorMotions(
+  current: Partial<Record<VimMotionOperatorAction, readonly VimMotionAction[]>>,
+  next: Partial<Record<VimMotionOperatorAction, readonly VimMotionAction[]>>,
+  replace?: boolean,
+): Partial<Record<VimMotionOperatorAction, readonly VimMotionAction[]>> {
+  return replace ? { ...next } : { ...current, ...next };
+}
+
 function mergeKeymap(target: ResolvedVimKeymap, partial: PartialKeymapOptions): void {
   for (const unmap of partial.unmaps ?? []) {
     if (unmap.modes.includes("insert")) {
@@ -1729,10 +1737,10 @@ function mergeKeymap(target: ResolvedVimKeymap, partial: PartialKeymapOptions): 
     };
   }
   if (partial.operatorMotions) {
-    target.operatorMotions = (
-      partial.replaceOperatorMotions
-        ? { ...partial.operatorMotions }
-        : { ...target.operatorMotions, ...partial.operatorMotions }
+    target.operatorMotions = mergeOperatorMotions(
+      target.operatorMotions,
+      partial.operatorMotions,
+      partial.replaceOperatorMotions,
     ) as typeof target.operatorMotions;
   }
   if (partial.insert) {
@@ -1795,10 +1803,10 @@ function mergeKeymapOverlay(target: PartialKeymapOptions, partial: PartialKeymap
     };
   }
   if (partial.operatorMotions) {
-    target.operatorMotions = (
-      partial.replaceOperatorMotions
-        ? { ...partial.operatorMotions }
-        : { ...target.operatorMotions, ...partial.operatorMotions }
+    target.operatorMotions = mergeOperatorMotions(
+      target.operatorMotions ?? {},
+      partial.operatorMotions,
+      partial.replaceOperatorMotions,
     ) as typeof target.operatorMotions;
   }
   if (partial.insert) {
@@ -2602,6 +2610,24 @@ function applyJsOptionOperations(
   warnings: string[],
 ): void {
   let mapOperations: VimJsConfigOperation[] = [];
+  const actionPresetBindings = new Set(
+    keymapLayers.flatMap((layer) => layer.presetActionBindings ?? []),
+  );
+  const clearActionPresetBindings = () => {
+    for (const layer of keymapLayers) {
+      layer.presetActionBindings = undefined;
+      if (!layer.actions) continue;
+      for (const [actionId, bindings] of Object.entries(layer.actions)) {
+        const remaining = (bindings ?? []).filter((binding) => !actionPresetBindings.has(binding));
+        if (remaining.length > 0) {
+          layer.actions[actionId as BindablePromptTransformActionId] = remaining;
+        } else {
+          delete layer.actions[actionId as BindablePromptTransformActionId];
+        }
+      }
+    }
+    actionPresetBindings.clear();
+  };
   const flushMapOperations = () => {
     appendJsMapLayer(keymapLayers, mapOperations, warnings);
     mapOperations = [];
@@ -2619,13 +2645,21 @@ function applyJsOptionOperations(
       if (preset.keymap) keymapLayers.push(preset.keymap);
       continue;
     }
+    if (operation.path === "keymap.actionPresets") clearActionPresetBindings();
     const value: Record<string, unknown> = {};
     setOptionPath(value, operation.path, operation.value);
     const parsed = parsePiVimMode(value, "global JS config");
     mergePartialOptions(options, parsed.partial);
     replaceJsRecord(options, operation.path, parsed.partial);
-    if (operation.path === "keymap.operatorMotions" && parsed.partial.keymap) {
-      parsed.partial.keymap.replaceOperatorMotions = true;
+    if (parsed.partial.keymap) {
+      if (operation.path === "keymap.operatorMotions") {
+        parsed.partial.keymap.replaceOperatorMotions = true;
+      }
+      if (operation.path === "keymap.actionPresets") {
+        for (const binding of parsed.partial.keymap.presetActionBindings ?? []) {
+          actionPresetBindings.add(binding);
+        }
+      }
     }
     if (parsed.partial.keymap) keymapLayers.push(parsed.partial.keymap);
     warnings.push(...parsed.warnings);

--- a/test/config-js.test.ts
+++ b/test/config-js.test.ts
@@ -859,6 +859,105 @@ export default (vim) => {
     }
   });
 
+  test("replays preset and leaf operations in source order", () => {
+    const afterLeaf = resolveVimOptions(undefined, undefined, {
+      kind: "success",
+      warnings: [],
+      operations: [
+        { kind: "leaf", path: "startMode", value: "insert" },
+        { kind: "preset", preset: "vim-heavy" },
+      ],
+    });
+    const afterPreset = resolveVimOptions(undefined, undefined, {
+      kind: "success",
+      warnings: [],
+      operations: [
+        { kind: "preset", preset: "vim-heavy" },
+        { kind: "leaf", path: "startMode", value: "insert" },
+      ],
+    });
+
+    expect(afterLeaf.options.startMode).toBe("normal");
+    expect(afterPreset.options.startMode).toBe("insert");
+  });
+
+  test("exposes validated domain options from global JSON without project settings", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "pi-vimmode-js-options-"));
+    try {
+      const globalPath = join(dir, "settings.json");
+      const projectPath = join(dir, "project-settings.json");
+      const jsConfigPath = join(dir, "pi-vimmode.config.js");
+      writeFileSync(globalPath, JSON.stringify({ piVimMode: { startMode: "normal" } }));
+      writeFileSync(projectPath, JSON.stringify({ piVimMode: { startMode: "insert" } }));
+      writeFileSync(
+        jsConfigPath,
+        `export default (vim) => {
+  if (vim.startMode !== "normal") throw new Error("missing global seed");
+  vim.cursor.normal = "bar";
+  vim.ui.status.items = ["mode"];
+  vim.macros.enabled = false;
+  vim.marks.enabled = false;
+  vim.search.maxHighlights = 10;
+  vim.exCommand.autocomplete = false;
+  vim.feedback.noop = "status";
+  vim.promptStructures.targets = { codeFence: false };
+  vim.promptTransforms.commands = { quote: ["quoteit"] };
+  vim.keymap.actionPresets = ["paragraph-editing"];
+  vim.keymap.operatorMotions = { delete: ["wordForward"] };
+};`,
+      );
+
+      const result = await loadVimOptions({
+        globalSettingsPath: globalPath,
+        projectSettingsPath: projectPath,
+        jsConfigPath,
+      });
+      expect(result.options.startMode).toBe("insert");
+      expect(result.options.cursor.normal).toBe("bar");
+      expect(result.options.ui?.status.items).toEqual(["mode"]);
+      expect(result.options.macros?.enabled).toBe(false);
+      expect(result.options.marks?.enabled).toBe(false);
+      expect(result.options.search?.maxHighlights).toBe(10);
+      expect(result.options.exCommand?.autocomplete).toBe(false);
+      expect(result.options.feedback?.noop).toBe("status");
+      expect(result.options.promptStructures?.targets).toMatchObject({ codeFence: false });
+      expect(Object.keys(result.options.promptStructures?.targets ?? [])).toEqual(["codeFence"]);
+      expect(result.options.promptTransforms?.commands).toMatchObject({ quote: ["quoteit"] });
+      expect(Object.keys(result.options.promptTransforms?.commands ?? [])).toEqual(["quote"]);
+      expect(result.options.keymap?.operatorMotions).toMatchObject({ delete: ["wordForward"] });
+      expect(Object.keys(result.options.keymap?.operatorMotions ?? [])).toEqual(["delete"]);
+      expect(result.warnings).toEqual([]);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("rejects invalid composite writes without changing frozen staged reads", async () => {
+    const f = fixture();
+    try {
+      f.write(`export default (vim) => {
+  const slots = vim.macros.slots;
+  if (!Object.isFrozen(slots)) throw new Error("slots must be frozen");
+  vim.macros.slots = ["a", "!"];
+  if (vim.macros.slots.join(",") !== slots.join(",")) throw new Error("invalid slots replaced staged value");
+  vim.macros.enabled = false;
+  vim.search.unknown = true;
+};`);
+      const result = await loadVimOptions({
+        globalSettingsPath: join(tmpdir(), "missing-settings.json"),
+        projectSettingsPath: join(tmpdir(), "missing-project-settings.json"),
+        jsConfigPath: f.path,
+      });
+      expect(result.options.macros?.enabled).toBe(false);
+      expect(result.warnings).toEqual([
+        "global JS config: piVimMode.macros.slots only supports lowercase a-z slots",
+        "global JS config: unknown vim.search property unknown",
+      ]);
+    } finally {
+      f.cleanup();
+    }
+  });
+
   test("loadVimOptions includes JS string remaps", async () => {
     const dir = mkdtempSync(join(tmpdir(), "pi-vimmode-js-remap-load-"));
     try {

--- a/test/config-js.test.ts
+++ b/test/config-js.test.ts
@@ -881,6 +881,55 @@ export default (vim) => {
     expect(afterPreset.options.startMode).toBe("insert");
   });
 
+  test("replaces action presets on each assignment", async () => {
+    const f = fixture();
+    try {
+      f.write(`export default (vim) => {
+  vim.keymap.set("n", "za", vim.prompt.quote());
+  vim.keymap.actionPresets = ["paragraph-editing"];
+  vim.keymap.set("n", "zq", vim.prompt.reflow());
+  vim.keymap.actionPresets = [];
+};`);
+      const result = await loadVimOptions({
+        globalSettingsPath: join(tmpdir(), "missing-settings.json"),
+        projectSettingsPath: join(tmpdir(), "missing-project-settings.json"),
+        jsConfigPath: f.path,
+      });
+
+      expect(result.options.keymap?.actions.accepted).toEqual([
+        {
+          key: "za",
+          actionId: "prompt.transform.quote",
+          args: { action: "quote" },
+          modes: ["normal"],
+        },
+        {
+          key: "zq",
+          actionId: "prompt.transform.reflow",
+          args: { action: "reflow" },
+          modes: ["normal"],
+        },
+      ]);
+      expect(result.warnings).toEqual([]);
+    } finally {
+      f.cleanup();
+    }
+  });
+
+  test("JS action preset assignment replaces global JSON preset bindings", () => {
+    const result = resolveVimOptions(
+      { piVimMode: { keymap: { actionPresets: ["paragraph-editing"] } } },
+      undefined,
+      {
+        kind: "success",
+        warnings: [],
+        operations: [{ kind: "leaf", path: "keymap.actionPresets", value: [] }],
+      },
+    );
+
+    expect(result.options.keymap?.actions.accepted).toEqual([]);
+  });
+
   test("exposes validated domain options from global JSON without project settings", async () => {
     const dir = mkdtempSync(join(tmpdir(), "pi-vimmode-js-options-"));
     try {
@@ -956,6 +1005,61 @@ export default (vim) => {
     } finally {
       f.cleanup();
     }
+  });
+
+  test("rejects invalid prompt records and accepts empty replacements", async () => {
+    const f = fixture();
+    try {
+      f.write(`export default (vim) => {
+  vim.promptStructures.targets = { codeFence: false };
+  vim.promptTransforms.actions = { quote: false };
+  vim.promptTransforms.commands = { quote: ["quoteit"] };
+  vim.promptStructures.targets = { codeFence: true, unknown: true };
+  vim.promptTransforms.actions = { quote: true, unknown: true };
+  vim.promptTransforms.commands = { quote: ["valid", "not-valid!"] };
+};`);
+      const rejected = await loadVimOptions({
+        globalSettingsPath: join(tmpdir(), "missing-settings.json"),
+        projectSettingsPath: join(tmpdir(), "missing-project-settings.json"),
+        jsConfigPath: f.path,
+      });
+      expect(rejected.options.promptStructures?.targets).toMatchObject({ codeFence: false });
+      expect(rejected.options.promptTransforms?.actions).toMatchObject({ quote: false });
+      expect(rejected.options.promptTransforms?.commands).toMatchObject({ quote: ["quoteit"] });
+
+      const empty = fixture();
+      try {
+        empty.write(`export default (vim) => {
+  vim.promptStructures.targets = {};
+  vim.promptTransforms.actions = {};
+  vim.promptTransforms.commands = {};
+};`);
+        const cleared = await loadVimOptions({
+          globalSettingsPath: join(tmpdir(), "missing-settings.json"),
+          projectSettingsPath: join(tmpdir(), "missing-project-settings.json"),
+          jsConfigPath: empty.path,
+        });
+        expect(Object.keys(cleared.options.promptStructures?.targets ?? {})).toEqual([]);
+        expect(Object.keys(cleared.options.promptTransforms?.actions ?? {})).toEqual([]);
+        expect(Object.keys(cleared.options.promptTransforms?.commands ?? {})).toEqual([]);
+      } finally {
+        empty.cleanup();
+      }
+    } finally {
+      f.cleanup();
+    }
+  });
+
+  test("keeps valid prompt records from JSON when siblings are invalid", () => {
+    const result = resolveVimOptions({
+      piVimMode: {
+        promptStructures: { targets: { codeFence: false, unknown: true } },
+        promptTransforms: { commands: { quote: ["quoteit", "not-valid!"], unknown: ["ignored"] } },
+      },
+    });
+
+    expect(result.options.promptStructures?.targets).toMatchObject({ codeFence: false });
+    expect(result.options.promptTransforms?.commands).toMatchObject({ quote: ["quoteit"] });
   });
 
   test("loadVimOptions includes JS string remaps", async () => {

--- a/test/config-js.test.ts
+++ b/test/config-js.test.ts
@@ -859,6 +859,49 @@ export default (vim) => {
     }
   });
 
+  test("applies presets to staged reads and replaces UI mode label records", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "pi-vimmode-js-ui-labels-"));
+    try {
+      const globalPath = join(dir, "settings.json");
+      const jsConfigPath = join(dir, "pi-vimmode.config.js");
+      writeFileSync(
+        globalPath,
+        JSON.stringify({
+          piVimMode: {
+            ui: {
+              mode: {
+                labels: { insert: "GLOBAL-INSERT" },
+                narrowLabels: { insert: "GI" },
+              },
+            },
+          },
+        }),
+      );
+      writeFileSync(
+        jsConfigPath,
+        `export default (vim) => {
+  vim.preset = "vim-heavy";
+  if (vim.startMode !== "normal") throw new Error("preset did not update staged reads");
+  vim.ui.mode.labels = { normal: "JS-NORMAL" };
+  vim.ui.mode.narrowLabels = { normal: "JN" };
+};`,
+      );
+
+      const result = await loadVimOptions({
+        globalSettingsPath: globalPath,
+        projectSettingsPath: join(dir, "missing-project-settings.json"),
+        jsConfigPath,
+      });
+      expect(result.options.ui?.mode.labels).toMatchObject({ normal: "JS-NORMAL" });
+      expect(Object.keys(result.options.ui?.mode.labels ?? {})).toEqual(["normal"]);
+      expect(result.options.ui?.mode.narrowLabels).toMatchObject({ normal: "JN" });
+      expect(Object.keys(result.options.ui?.mode.narrowLabels ?? {})).toEqual(["normal"]);
+      expect(result.warnings).toEqual([]);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
   test("replays preset and leaf operations in source order", () => {
     const afterLeaf = resolveVimOptions(undefined, undefined, {
       kind: "success",
@@ -978,6 +1021,97 @@ export default (vim) => {
       expect(result.warnings).toEqual([]);
     } finally {
       rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("exposes every finite option path through trusted JavaScript", async () => {
+    const f = fixture();
+    try {
+      f.write(`export default (vim) => {
+  vim.leader = ",";
+  vim.startMode = "normal";
+  vim.cursor.insert = "underline";
+  vim.cursor.normal = "bar";
+  vim.cursor.visual = "block";
+  vim.cursor.visualLine = "underline";
+  vim.cursor.visualBlock = "bar";
+  vim.keymap.actionPresets = [];
+  vim.keymap.operatorMotions = { delete: ["wordForward"] };
+  vim.ui.status.enabled = false;
+  vim.ui.status.position = "right";
+  vim.ui.status.items = ["mode"];
+  vim.ui.mode.enabled = false;
+  vim.ui.mode.labels = { normal: "NORMAL" };
+  vim.ui.mode.narrowLabels = { normal: "N" };
+  vim.ui.selection.enabled = false;
+  vim.ui.selection.previewMaxChars = 24;
+  vim.ui.cursorPosition.enabled = false;
+  vim.ui.cursorPosition.base = 1;
+  vim.ui.cursorPosition.format = "{line}:{column}";
+  vim.ui.workbench.reservedRows = 3;
+  vim.macros.enabled = false;
+  vim.macros.slots = ["a"];
+  vim.macros.maxReplaySteps = 12;
+  vim.marks.enabled = false;
+  vim.marks.slots = ["a"];
+  vim.search.highlight = false;
+  vim.search.highlightCurrent = false;
+  vim.search.clearOnCancel = false;
+  vim.search.clearOnInsert = true;
+  vim.search.maxHighlights = 12;
+  vim.exCommand.autocomplete = false;
+  vim.feedback.noop = "status";
+  vim.promptStructures.enabled = false;
+  vim.promptStructures.targets = { codeFence: false };
+  vim.promptTransforms.enabled = false;
+  vim.promptTransforms.actions = { quote: false };
+  vim.promptTransforms.commands = { quote: ["quoteit"] };
+};`);
+      const result = await loadVimOptions({
+        globalSettingsPath: join(tmpdir(), "missing-settings.json"),
+        projectSettingsPath: join(tmpdir(), "missing-project-settings.json"),
+        jsConfigPath: f.path,
+      });
+
+      expect(result.options).toMatchObject({
+        leader: ",",
+        startMode: "normal",
+        cursor: {
+          insert: "underline",
+          normal: "bar",
+          visual: "block",
+          visualLine: "underline",
+          visualBlock: "bar",
+        },
+        keymap: { operatorMotions: { delete: ["wordForward"] } },
+        ui: {
+          status: { enabled: false, position: "right", items: ["mode"] },
+          mode: { enabled: false, labels: { normal: "NORMAL" }, narrowLabels: { normal: "N" } },
+          selection: { enabled: false, previewMaxChars: 24 },
+          cursorPosition: { enabled: false, base: 1, format: "{line}:{column}" },
+          workbench: { reservedRows: 3 },
+        },
+        macros: { enabled: false, slots: ["a"], maxReplaySteps: 12 },
+        marks: { enabled: false, slots: ["a"] },
+        search: {
+          highlight: false,
+          highlightCurrent: false,
+          clearOnCancel: false,
+          clearOnInsert: true,
+          maxHighlights: 12,
+        },
+        exCommand: { autocomplete: false },
+        feedback: { noop: "status" },
+        promptStructures: { enabled: false, targets: { codeFence: false } },
+        promptTransforms: {
+          enabled: false,
+          actions: { quote: false },
+          commands: { quote: ["quoteit"] },
+        },
+      });
+      expect(result.warnings).toEqual([]);
+    } finally {
+      f.cleanup();
     }
   });
 


### PR DESCRIPTION
## Summary

Trusted global JavaScript config can now set validated finite pi-vimmode options without bypassing JSON/project precedence.

## Changes

- Expose curated `vim` option tree with staged reads and source-ordered writes.
- Validate option writes before staging; keep prior state after invalid composite writes.
- Preserve atomic collection replacement plus action-preset replacement semantics.
- Add regression coverage for every supported JS option path, preset staging, UI label replacement, and precedence.

## Testing

- [x] `bun test` passes (807 tests)
- [x] `bun run check-types` passes
- [x] `bun run lint` passes
- [ ] Manually tested in Pi
- [x] `bun run format:check` passes
- [x] `bun run build` passes
- [x] `openspec validate ship-pi-vimmode-0-9-0 --strict` passes

## Related Issues

Closes #38