### PR TITLE
fix(modal): preserve character search direction when doing reverse repeats while doing f/F

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -43,4 +43,5 @@ export default (vim) => {
 
 ## Bug fixes
 
+- Fixed repeated reverse character searches with `,` alternating direction instead of continuing opposite to original `f`, `F`, `t`, or `T` search.
 - Fixed normal-mode `a` crossing into the next logical line when invoked at end of line, including on wrapped prompts followed by a blank line.

--- a/src/modal/normal.ts
+++ b/src/modal/normal.ts
@@ -610,6 +610,7 @@ function applyCharSearch(
   command: CharSearchCommand,
   target: string,
   count = 1,
+  recordLastCharSearch = true,
 ): ModalUpdate {
   const position = findCharOnLine(
     snapshot.text,
@@ -619,20 +620,13 @@ function applyCharSearch(
     count,
   );
   if (!position) return invalidate(state);
-  return withEffects(
-    {
-      ...state,
-      lastCharSearch: {
-        command: command as
-          | "findCharForward"
-          | "findCharBackward"
-          | "tillCharForward"
-          | "tillCharBackward",
-        target,
-      },
-    },
-    [{ type: "restoreCursor", position }, { type: "invalidate" }],
-  );
+  const searchedState = recordLastCharSearch
+    ? {
+        ...state,
+        lastCharSearch: { command, target },
+      }
+    : state;
+  return withEffects(searchedState, [{ type: "restoreCursor", position }, { type: "invalidate" }]);
 }
 
 function repeatCharSearch(
@@ -645,7 +639,7 @@ function repeatCharSearch(
   const command = reverse
     ? oppositeCharSearch(state.lastCharSearch.command)
     : state.lastCharSearch.command;
-  return applyCharSearch(state, snapshot, command, state.lastCharSearch.target, count);
+  return applyCharSearch(state, snapshot, command, state.lastCharSearch.target, count, false);
 }
 
 export function applyOperatorCharSearchRepeat(
@@ -668,6 +662,8 @@ export function applyOperatorCharSearchRepeat(
     state.lastCharSearch.target,
     options,
     count,
+    true,
+    false,
   );
 }
 
@@ -680,20 +676,20 @@ export function applyOperatorCharSearch(
   options: ModalOptions,
   count = 1,
   recordRepeat = true,
+  recordLastCharSearch = true,
 ): ModalUpdate {
   const baseState = clearCommandPending(state);
-  const lastCharSearch = { command, target };
+  const searchedState = recordLastCharSearch
+    ? { ...baseState, lastCharSearch: { command, target } }
+    : baseState;
   const kind = charSearchKind(command);
   if (operator === "yank") {
     const register = yankByCharSearch(snapshot.text, snapshot.cursor, kind, target, count);
-    return yankUpdate(register ? { ...baseState, lastCharSearch } : baseState, register);
+    return yankUpdate(register ? searchedState : baseState, register);
   }
 
   const result = deleteByCharSearch(snapshot.text, snapshot.cursor, kind, target, count);
-  const written = editStateAndEffects(
-    result.changed ? { ...baseState, lastCharSearch } : baseState,
-    result,
-  );
+  const written = editStateAndEffects(result.changed ? searchedState : baseState, result);
   let edited = written.state;
   if (recordRepeat) {
     edited = withRepeatableChange(

--- a/test/modal.test.ts
+++ b/test/modal.test.ts
@@ -3077,6 +3077,31 @@ describe("modal engine", () => {
     );
     expect(repeated.effects[0]).toEqual({ type: "restoreCursor", position: { line: 0, col: 3 } });
 
+    const reversedRepeated = applyModalKeys({ mode: "normal" }, "banana apple alpha", p(0, 0), [
+      "f",
+      "a",
+      ";",
+      ";",
+      ",",
+      ",",
+    ]);
+    expect(reversedRepeated.cursor).toEqual(p(0, 1));
+    expect(reversedRepeated.state.lastCharSearch).toEqual({
+      command: "findCharForward",
+      target: "a",
+    });
+
+    const backwardReversed = applyModalKeys({ mode: "normal" }, "banana apple alpha", p(0, 17), [
+      "F",
+      "a",
+      ",",
+    ]);
+    expect(backwardReversed.cursor).toEqual(p(0, 17));
+    expect(backwardReversed.state.lastCharSearch).toEqual({
+      command: "findCharBackward",
+      target: "a",
+    });
+
     const replacePending = handleModalInput({ mode: "normal" }, snapshot, options, "r");
     const replaced = handleModalInput(replacePending.state, snapshot, options, "z");
     const repeatedChange = handleModalInput(
@@ -3329,6 +3354,7 @@ describe("modal engine", () => {
     expect(reversed.text).toBe("ac");
     expect(reversed.state.mode).toBe("insert");
     expect(reversed.state.register).toEqual({ type: "char", text: ":b:" });
+    expect(reversed.state.lastCharSearch).toEqual({ command: "findCharForward", target: ":" });
   });
 
   test("normal mode supports WORD and previous-end motions", () => {


### PR DESCRIPTION
## Summary

<!-- What does this PR do? Why? -->

## Changes

- Reverse repeats must not replace original f/F/t/T command.

## Testing

- [x] `bun test` passes
- [x] `bun run check-types` passes
- [x] `bun run lint` passes
- [x] Manually tested in Pi

## Related Issues

Closes #
