### PR TITLE
v0.8.1 feat: add scoped action keymaps

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -12,6 +12,8 @@ export default (vim) => {
 };
 ```
 
+- Added scoped action-keymap descriptors for trusted JavaScript. `vim.keymap.set` accepts finite actions in normal, visual, insert, or operator-pending scopes; supports compatibility mode aliases, scoped `unmap`, deterministic conflict resolution, protected-shortcut overrides, and bounded replay mappings. Project settings remain final authority.
+
 - Added configurable Vim leader mappings. Set `piVimMode.leader` in JSON or `vim.g.mapleader` in trusted JavaScript, then use `<leader>` at the start of mapping keys. Project settings can override or clear inherited leaders.
 
 ```json
@@ -62,4 +64,3 @@ export default (vim) => {
 
 - Fixed character-search repeats: `,` now keeps opposite original `f`, `F`, `t`, or `T` direction, and `;` now advances `t` and `T` searches.
 - Fixed normal-mode `a` crossing into the next logical line when invoked at end of line, including on wrapped prompts followed by a blank line.
-- Prevented `/quit` from hiding the shell cursor after using pi-vimmode's bar cursor. #53

--- a/docs/settings.md
+++ b/docs/settings.md
@@ -53,7 +53,7 @@ Common warning causes:
 
 `~/.pi/agent/pi-vimmode.config.js` is trusted local code executed with Pi process privileges. It is not sandboxed. Project-local executable JS config is intentionally unsupported.
 
-Use `vim.keymap.set(mode, key, vim.prompt.<builtin>(args?))` for built-ins or `vim.keymap.set(mode, key, "keys")` for a literal key replay. The key is a string using the same key syntax as JSON settings. Built-in pi-vimmode actions are accessed through `vim.prompt.*`, not string action IDs.
+Use `vim.keymap.set(mode, key, rhs, options?)`. `rhs` is an opaque `vim.action.*` descriptor, a compatible `vim.prompt.*` built-in, a literal key replay string, or `null` to unmap that exact key in selected scopes. The key uses JSON key syntax; string RHS values are replayed keys, never internal action IDs.
 
 ```js
 export default (vim) => {
@@ -61,15 +61,17 @@ export default (vim) => {
   vim.keymap.set("i", "<A-w>", vim.prompt.deleteWordBackward());
   vim.keymap.set("n", "<leader>q", vim.prompt.reflow({ width: 88 }));
   vim.keymap.set("v", "z>", vim.prompt.quote());
+  vim.keymap.set("n", "H", vim.action.motion.wordForward(), { desc: "Next word" });
   vim.keymap.set("n", "zz", "llll");
+  vim.keymap.set("n", "zq", null);
 };
 ```
 
-Modes: `"i"`/`"insert"`, `"n"`/`"normal"`, `"v"` for all visual modes, or exact `"visual"`, `"visualLine"`, `"visualBlock"`. Arrays of modes are accepted.
+Modes: `"i"`/`"insert"`, `"n"`/`"normal"`, `"v"`/`"x"`/`"visual"` for all visual modes, exact `"visualLine"` or `"visualBlock"`, and `"o"`/`"operatorPending"`/`"operator-pending"` while an operator awaits its target. Arrays of modes are accepted. Each descriptor declares allowed scopes; unsupported scope combinations warn and do not install that mapping.
 
-Prompt transform built-ins: `quote`, `unquote`, `bulletize`, `fence({ language })`, `indent`, `dedent`, `reflow({ width })`.
+`vim.action` exposes finite operator, motion, command, macro, mark, insert, text-object, and prompt-transform descriptor factories. `vim.prompt.*` remains the compatible alias for prompt-transform and insert built-ins. Prompt transform factories are `quote`, `unquote`, `bulletize`, `fence({ language })`, `indent`, `dedent`, and `reflow({ width })`; insert factories are `openLineBelow`, `openLineAbove`, `deleteWordBackward`, `deleteWordForward`, `deleteLineBackward`, `deleteLineForward`, `moveWordBackward`, `moveWordForward`, `moveLineStart`, and `moveLineEnd`.
 
-Insert-mode built-ins: `openLineBelow`, `openLineAbove`, `deleteWordBackward`, `deleteWordForward`, `deleteLineBackward`, `deleteLineForward`, `moveWordBackward`, `moveWordForward`, `moveLineStart`, `moveLineEnd`.
+Literal replay strings work only in normal or visual scopes, are bounded, and do not recursively expand mappings. `null` removes only the exact selected-scope mapping. `options` accepts only `allowProtected: true` and diagnostic `desc: string`; an override does not guarantee that Pi or terminal delivers that key. Same-scope exact mappings are source-ordered; same-scope executable prefix overlaps warn and are rejected because keymaps have no timeout.
 
 Set `vim.g.mapleader` to one printable character or `null`. Assignment affects every retained `<leader>` mapping after project settings apply, regardless of assignment order inside the JS file. Invalid assignments warn and preserve the last valid value.
 

--- a/openspec/changes/ship-pi-vimmode-0-9-0/tasks.md
+++ b/openspec/changes/ship-pi-vimmode-0-9-0/tasks.md
@@ -12,7 +12,7 @@
 ## 3. Public Config Behavior and Reload
 
 - [x] 3.1 Implement [#38](https://github.com/pekochan069/pi-vimmode/issues/38): expose every finite `piVimMode` option through validated domain-grouped trusted JavaScript properties and prove source-order/replacement/fallback behavior. **Blocked by:** #37.
-- [ ] 3.2 Implement [#39](https://github.com/pekochan069/pi-vimmode/issues/39): add opaque action descriptors and finite mode-scoped mappings with unmapping, deterministic conflicts, bounded replay, insert/operator restrictions, protected override, compatibility aliases, and project precedence. **Blocked by:** #37; may run parallel with #38.
+- [x] 3.2 Implement [#39](https://github.com/pekochan069/pi-vimmode/issues/39): add opaque action descriptors and finite mode-scoped mappings with unmapping, deterministic conflicts, bounded replay, insert/operator restrictions, protected override, compatibility aliases, and project precedence. **Blocked by:** #37; may run parallel with #38.
 - [ ] 3.3 Implement [#40](https://github.com/pekochan069/pi-vimmode/issues/40): reconfigure tracked active editors atomically on generation-guarded reload, preserving durable state and clearing specified transient grammar through lifecycle and real-editor tests. **Blocked by:** #38 and #39.
 
 ## 4. Public Types and Canonical Documentation

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -157,7 +157,9 @@ type EncodedCharCommandPending = { type: "charCommand"; command: VimCommandActio
 type EncodedTextObjectPending = {
   type: "textObject";
   operatorSequence: string;
-  kind: VimTextObjectKind;
+  kind?: VimTextObjectKind;
+  kindPrefix: string;
+  targetPrefix?: string;
   count?: number;
 };
 type EncodedOperatorMotionPending = {
@@ -272,13 +274,23 @@ export function scopedKeysForAction(
     .map((binding) => binding.key);
 }
 
-function scopedActionFor(
-  key: string,
+function scopedTextObjectSequenceFor(
   keymap: ResolvedVimKeymap,
-  prefix: string,
-): string | undefined {
-  const binding = scopedKeymapBindingFor(keymap, key, "operatorPending");
-  return binding?.actionId.startsWith(prefix) ? binding.actionId.slice(prefix.length) : undefined;
+  sequence: string,
+  prefix: "textObject.kind." | "textObject.target.",
+): { action?: string; isPrefix: boolean } {
+  const bindings = keymap.scoped.filter(
+    (binding) => binding.modes.includes("operatorPending") && binding.actionId.startsWith(prefix),
+  );
+  return {
+    action: [...bindings]
+      .reverse()
+      .find((binding) => binding.key === sequence)
+      ?.actionId.slice(prefix.length),
+    isPrefix: bindings.some(
+      (binding) => binding.key !== sequence && binding.key.startsWith(sequence),
+    ),
+  };
 }
 
 function textObjectKindForKey(
@@ -287,8 +299,9 @@ function textObjectKindForKey(
 ): VimTextObjectKind | undefined {
   if (isKeyUnmapped(keymap, key, "operatorPending")) return undefined;
   return (
-    (scopedActionFor(key, keymap, "textObject.kind.") as VimTextObjectKind | undefined) ??
-    compiledKeymapFor(keymap).textObjects.kinds.get(key)
+    (scopedTextObjectSequenceFor(keymap, key, "textObject.kind.").action as
+      | VimTextObjectKind
+      | undefined) ?? compiledKeymapFor(keymap).textObjects.kinds.get(key)
   );
 }
 
@@ -298,8 +311,9 @@ function textObjectTargetForKey(
 ): VimTextObjectTarget | undefined {
   if (isKeyUnmapped(keymap, key, "operatorPending")) return undefined;
   return (
-    (scopedActionFor(key, keymap, "textObject.target.") as VimTextObjectTarget | undefined) ??
-    compiledKeymapFor(keymap).textObjects.targets.get(key)
+    (scopedTextObjectSequenceFor(keymap, key, "textObject.target.").action as
+      | VimTextObjectTarget
+      | undefined) ?? compiledKeymapFor(keymap).textObjects.targets.get(key)
   );
 }
 
@@ -671,7 +685,8 @@ export function pendingDisplay(pending: string | undefined): string | undefined 
   const charCommand = decodeCharCommandPending(pending);
   if (charCommand) return commandSequenceFor(charCommand.command, DEFAULT_VIM_KEYMAP);
   const textObject = decodeTextObjectPending(pending);
-  if (textObject) return `${textObject.operatorSequence}${textObject.kind === "inner" ? "i" : "a"}`;
+  if (textObject)
+    return `${textObject.operatorSequence}${textObject.kindPrefix}${textObject.targetPrefix ?? ""}`;
   const operatorMotion = decodeOperatorMotionPending(pending);
   if (operatorMotion) return `${operatorMotion.operatorSequence}${operatorMotion.motionPrefix}`;
   const operatorLine = decodeOperatorLinePending(pending);
@@ -714,22 +729,39 @@ function decodeCharCommandPending(pending: string): EncodedCharCommandPending | 
 
 function encodeTextObjectPending(
   operatorSequence: string,
-  kind: VimTextObjectKind,
+  kindPrefix: string,
+  kind: VimTextObjectKind | undefined,
+  targetPrefix?: string,
   count?: number,
 ): string {
-  return `${operatorSequence}${TEXT_OBJECT_SEPARATOR}${kind}${TEXT_OBJECT_SEPARATOR}${count ?? ""}`;
+  return [operatorSequence, kindPrefix, kind ?? "", targetPrefix ?? "", count ?? ""].join(
+    TEXT_OBJECT_SEPARATOR,
+  );
 }
 
 function decodeTextObjectPending(pending: string): EncodedTextObjectPending | undefined {
   const parts = pending.split(TEXT_OBJECT_SEPARATOR);
-  if (parts.length !== 3) return undefined;
-  const kind = parts[1] as VimTextObjectKind;
-  if (kind !== "inner" && kind !== "around") return undefined;
+  if (parts.length === 3) {
+    const kind = parts[1] as VimTextObjectKind;
+    if (kind !== "inner" && kind !== "around") return undefined;
+    return {
+      type: "textObject",
+      operatorSequence: parts[0] ?? "",
+      kindPrefix: kind === "inner" ? "i" : "a",
+      kind,
+      count: parts[2] ? Number(parts[2]) : undefined,
+    };
+  }
+  if (parts.length !== 5) return undefined;
+  const kind = parts[2] as VimTextObjectKind | "";
+  if (kind && kind !== "inner" && kind !== "around") return undefined;
   return {
     type: "textObject",
     operatorSequence: parts[0] ?? "",
-    kind,
-    count: parts[2] ? Number(parts[2]) : undefined,
+    kindPrefix: parts[1] ?? "",
+    kind: kind || undefined,
+    targetPrefix: parts[3] || undefined,
+    count: parts[4] ? Number(parts[4]) : undefined,
   };
 }
 
@@ -901,7 +933,16 @@ function hasOperatorPrefix(
   keymap: ResolvedVimKeymap,
   operator: VimOperatorAction,
 ): boolean {
-  return operatorLookupFor(keymap, operator)?.longerPrefixes.has(sequence) ?? false;
+  return (
+    keymap.scoped.some(
+      (binding) =>
+        binding.actionId === `operator.${operator}` &&
+        binding.modes.includes("normal") &&
+        binding.key !== sequence &&
+        binding.key.startsWith(sequence),
+    ) ||
+    (operatorLookupFor(keymap, operator)?.longerPrefixes.has(sequence) ?? false)
+  );
 }
 
 function operatorSequenceMatches(
@@ -909,7 +950,10 @@ function operatorSequenceMatches(
   keymap: ResolvedVimKeymap,
   operator: VimOperatorAction,
 ): boolean {
-  return operatorLookupFor(keymap, operator)?.exact.has(sequence) ?? false;
+  return (
+    operatorActionForSequence(sequence, keymap) === operator ||
+    (operatorLookupFor(keymap, operator)?.exact.has(sequence) ?? false)
+  );
 }
 
 function withCount<T extends SemanticCommandResult>(
@@ -1121,14 +1165,63 @@ function resolveTextObjectPending(
   keymap: ResolvedVimKeymap,
 ): SemanticCommandResult {
   const operator = operatorActionForSequence(pending.operatorSequence, keymap);
-  const target = textObjectTargetForKey(key, keymap);
-  if (!operator || !isMotionOperator(operator) || !target) return { type: "invalid" };
-  return {
-    type: "operatorTextObject",
-    operator,
-    textObject: { kind: pending.kind, target },
-    count: pending.count,
-  };
+  if (!operator || !isMotionOperator(operator)) return { type: "invalid" };
+
+  if (!pending.kind) {
+    const kindSequence = pending.kindPrefix + key;
+    const scoped = scopedTextObjectSequenceFor(keymap, kindSequence, "textObject.kind.");
+    const kind = textObjectKindForKey(kindSequence, keymap);
+    if (kind && !scoped.isPrefix) {
+      return {
+        type: "pending",
+        pending: encodeTextObjectPending(
+          pending.operatorSequence,
+          kindSequence,
+          kind,
+          undefined,
+          pending.count,
+        ),
+      };
+    }
+    if (scoped.isPrefix) {
+      return {
+        type: "pending",
+        pending: encodeTextObjectPending(
+          pending.operatorSequence,
+          kindSequence,
+          undefined,
+          undefined,
+          pending.count,
+        ),
+      };
+    }
+    return { type: "invalid" };
+  }
+
+  const targetSequence = `${pending.targetPrefix ?? ""}${key}`;
+  const scoped = scopedTextObjectSequenceFor(keymap, targetSequence, "textObject.target.");
+  const target = textObjectTargetForKey(targetSequence, keymap);
+  if (target && !scoped.isPrefix) {
+    return {
+      type: "operatorTextObject",
+      operator,
+      textObject: { kind: pending.kind, target },
+      count: pending.count,
+    };
+  }
+  if (scoped.isPrefix) {
+    return {
+      type: "pending",
+      pending: encodeTextObjectPending(
+        pending.operatorSequence,
+        pending.kindPrefix,
+        pending.kind,
+        targetSequence,
+        pending.count,
+      ),
+    };
+  }
+  return { type: "invalid" };
 }
 
 function resolveAfterOperator(
@@ -1201,11 +1294,18 @@ function resolveAfterOperator(
     }
   }
 
+  const scopedTextObjectKind = scopedTextObjectSequenceFor(keymap, key, "textObject.kind.");
   const textObjectKind = textObjectKindForKey(key, keymap);
-  if (textObjectKind) {
+  if (textObjectKind && !scopedTextObjectKind.isPrefix) {
     return {
       type: "pending",
-      pending: encodeTextObjectPending(operatorSequence, textObjectKind, count),
+      pending: encodeTextObjectPending(operatorSequence, key, textObjectKind, undefined, count),
+    };
+  }
+  if (scopedTextObjectKind.isPrefix) {
+    return {
+      type: "pending",
+      pending: encodeTextObjectPending(operatorSequence, key, undefined, undefined, count),
     };
   }
 

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -235,20 +235,33 @@ function isPrintableCharArgument(key: string): boolean {
   return key.length === 1 && key.charCodeAt(0) >= 32 && key.charCodeAt(0) !== 127;
 }
 
+export function scopedKeymapBindingFor(
+  keymap: ResolvedVimKeymap,
+  key: string,
+  mode: VimActionBindingMode | "operatorPending",
+) {
+  return [...keymap.scoped]
+    .reverse()
+    .find((binding) => binding.key === key && binding.modes.includes(mode));
+}
+
+export function scopedKeysForAction(
+  keymap: ResolvedVimKeymap,
+  actionId: ResolvedVimKeymap["scoped"][number]["actionId"],
+  mode: VimActionBindingMode | "operatorPending",
+): string[] {
+  return keymap.scoped
+    .filter((binding) => binding.actionId === actionId && binding.modes.includes(mode))
+    .map((binding) => binding.key);
+}
+
 function scopedActionFor(
   key: string,
   keymap: ResolvedVimKeymap,
   prefix: string,
 ): string | undefined {
-  return [...keymap.scoped]
-    .reverse()
-    .find(
-      (binding) =>
-        binding.key === key &&
-        binding.modes.includes("operatorPending") &&
-        binding.actionId.startsWith(prefix),
-    )
-    ?.actionId.slice(prefix.length);
+  const binding = scopedKeymapBindingFor(keymap, key, "operatorPending");
+  return binding?.actionId.startsWith(prefix) ? binding.actionId.slice(prefix.length) : undefined;
 }
 
 function textObjectKindForKey(
@@ -478,9 +491,7 @@ function scopedBinding(
   keymap: ResolvedVimKeymap,
   mode?: VimActionBindingMode | "operatorPending",
 ): Binding | undefined {
-  const mapping = [...keymap.scoped]
-    .reverse()
-    .find((binding) => binding.key === sequence && (!mode || binding.modes.includes(mode)));
+  const mapping = mode ? scopedKeymapBindingFor(keymap, sequence, mode) : undefined;
   if (!mapping) return undefined;
   const [family, ...parts] = mapping.actionId.split(".");
   const action = parts.join(".");

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -268,6 +268,7 @@ function textObjectKindForKey(
   key: string,
   keymap: ResolvedVimKeymap,
 ): VimTextObjectKind | undefined {
+  if (isKeyUnmapped(keymap, key, "operatorPending")) return undefined;
   return (
     (scopedActionFor(key, keymap, "textObject.kind.") as VimTextObjectKind | undefined) ??
     compiledKeymapFor(keymap).textObjects.kinds.get(key)
@@ -278,6 +279,7 @@ function textObjectTargetForKey(
   key: string,
   keymap: ResolvedVimKeymap,
 ): VimTextObjectTarget | undefined {
+  if (isKeyUnmapped(keymap, key, "operatorPending")) return undefined;
   return (
     (scopedActionFor(key, keymap, "textObject.target.") as VimTextObjectTarget | undefined) ??
     compiledKeymapFor(keymap).textObjects.targets.get(key)
@@ -564,7 +566,9 @@ function searchDirectionForBinding(
   sequence: string,
   keymap: ResolvedVimKeymap,
 ): "forward" | "backward" | undefined {
-  return compiledKeymapFor(keymap).commands.searchDirections.get(sequence);
+  return isKeyUnmapped(keymap, sequence, "operatorPending")
+    ? undefined
+    : compiledKeymapFor(keymap).commands.searchDirections.get(sequence);
 }
 
 function hasSearchLongerPrefix(sequence: string, keymap: ResolvedVimKeymap): boolean {
@@ -575,7 +579,9 @@ function charSearchCommandForBinding(
   sequence: string,
   keymap: ResolvedVimKeymap,
 ): OperatorCharSearchCommand | undefined {
-  return compiledKeymapFor(keymap).commands.charSearch.get(sequence);
+  return isKeyUnmapped(keymap, sequence, "operatorPending")
+    ? undefined
+    : compiledKeymapFor(keymap).commands.charSearch.get(sequence);
 }
 
 function hasCharSearchLongerPrefix(sequence: string, keymap: ResolvedVimKeymap): boolean {
@@ -586,7 +592,9 @@ function repeatCharSearchCommandForBinding(
   sequence: string,
   keymap: ResolvedVimKeymap,
 ): Extract<VimCommandAction, "repeatCharSearch" | "repeatCharSearchReverse"> | undefined {
-  return compiledKeymapFor(keymap).commands.repeatCharSearch.get(sequence);
+  return isKeyUnmapped(keymap, sequence, "operatorPending")
+    ? undefined
+    : compiledKeymapFor(keymap).commands.repeatCharSearch.get(sequence);
 }
 
 function hasRepeatCharSearchLongerPrefix(sequence: string, keymap: ResolvedVimKeymap): boolean {
@@ -827,11 +835,12 @@ function decodeOperatorCharSearchRepeatPending(
 export function operatorActionForSequence(
   sequence: string | undefined,
   keymap: ResolvedVimKeymap = DEFAULT_VIM_KEYMAP,
+  mode: VimActionBindingMode = "normal",
 ): VimOperatorAction | undefined {
   if (!sequence) return undefined;
   const count = decodeCountPending(sequence);
-  if (count) return operatorActionForSequence(count.inner, keymap);
-  const binding = exactBinding(sequence, keymap);
+  if (count) return operatorActionForSequence(count.inner, keymap, mode);
+  const binding = exactBinding(sequence, keymap, mode);
   return binding?.kind === "operator" ? binding.operator : undefined;
 }
 
@@ -852,6 +861,7 @@ function motionForSequence(
   sequence: string,
   keymap: ResolvedVimKeymap,
 ): VimMotionAction | undefined {
+  if (isKeyUnmapped(keymap, sequence, "operatorPending")) return undefined;
   const scoped = exactBinding(sequence, keymap, "operatorPending");
   return scoped?.kind === "motion"
     ? scoped.motion

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -28,6 +28,8 @@ import {
 } from "./keymap-descriptors.ts";
 import { grammarEntriesForKeymap, type KeymapGrammarEntry } from "./keymap-grammar.ts";
 import {
+  displayMappingSequence,
+  MAPPING_TOKEN_SEPARATOR,
   mappingSequencePrefixes,
   mappingScopesForKeymapEntry,
   type VimMappingScope,
@@ -514,6 +516,22 @@ function liveGrammarEntries(
   );
 }
 
+function appendMappingSequence(
+  prefix: string,
+  key: string,
+  keymap: ResolvedVimKeymap,
+  mode?: VimActionBindingMode | "operatorPending",
+): string {
+  const separated = `${prefix}${MAPPING_TOKEN_SEPARATOR}${key}`;
+  const isSeparatedContinuation = (sequence: string) =>
+    sequence === separated || mappingSequencePrefixes(sequence).includes(separated);
+  const usesSeparatedBoundary =
+    keymap.scoped.some(
+      (binding) => (!mode || binding.modes.includes(mode)) && isSeparatedContinuation(binding.key),
+    ) || liveGrammarEntries(keymap, mode).some((entry) => isSeparatedContinuation(entry.sequence));
+  return usesSeparatedBoundary ? separated : `${prefix}${key}`;
+}
+
 export function isKeyUnmapped(
   keymap: ResolvedVimKeymap,
   sequence: string,
@@ -698,9 +716,14 @@ export function resolveMacroCommand(
 }
 
 export function pendingDisplay(pending: string | undefined): string | undefined {
+  const display = pendingDisplayInternal(pending);
+  return display === undefined ? undefined : displayMappingSequence(display);
+}
+
+function pendingDisplayInternal(pending: string | undefined): string | undefined {
   if (!pending) return undefined;
   const count = decodeCountPending(pending);
-  if (count) return `${count.count}${pendingDisplay(count.inner) ?? count.inner}`;
+  if (count) return `${count.count}${pendingDisplayInternal(count.inner) ?? count.inner}`;
   const charCommand = decodeCharCommandPending(pending);
   if (charCommand) return commandSequenceFor(charCommand.command, DEFAULT_VIM_KEYMAP);
   const textObject = decodeTextObjectPending(pending);
@@ -1009,7 +1032,12 @@ function resolveOperatorMotionPending(
 ): SemanticCommandResult {
   const operator = operatorActionForSequence(pending.operatorSequence, keymap);
   if (!operator || !isMotionOperator(operator)) return { type: "invalid" };
-  const motionSequence = pending.motionPrefix + key;
+  const motionSequence = appendMappingSequence(
+    pending.motionPrefix,
+    key,
+    keymap,
+    "operatorPending",
+  );
   const motion = motionForSequence(motionSequence, keymap);
   if (motion && keymap.operatorMotions[operator].includes(motion)) {
     return { type: "operatorMotion", operator, motion, count: pending.count };
@@ -1030,7 +1058,12 @@ function resolveOperatorLinePending(
 ): SemanticCommandResult {
   const operator = operatorActionForSequence(pending.operatorSequence, keymap);
   if (!operator) return { type: "invalid" };
-  const repeatSequence = pending.repeatPrefix + key;
+  const repeatSequence = appendMappingSequence(
+    pending.repeatPrefix,
+    key,
+    keymap,
+    "operatorPending",
+  );
   if (operatorSequenceMatches(repeatSequence, keymap, operator)) {
     return { type: "lineCommand", operator, count: pending.count };
   }
@@ -1050,7 +1083,12 @@ function resolveOperatorSearchPending(
 ): SemanticCommandResult {
   const operator = operatorActionForSequence(pending.operatorSequence, keymap);
   if (!operator || !isMotionOperator(operator)) return { type: "invalid" };
-  const searchSequence = pending.searchPrefix + key;
+  const searchSequence = appendMappingSequence(
+    pending.searchPrefix,
+    key,
+    keymap,
+    "operatorPending",
+  );
   const direction = searchDirectionForBinding(searchSequence, keymap);
   if (direction) {
     return { type: "operatorSearch", operator, direction, count: pending.count };
@@ -1120,7 +1158,12 @@ function resolveOperatorCharSearchPending(
       effectiveOperatorCharSearchCount(pending.count, pending.targetCount),
     );
   }
-  const commandSequence = pending.commandPrefix + key;
+  const commandSequence = appendMappingSequence(
+    pending.commandPrefix,
+    key,
+    keymap,
+    "operatorPending",
+  );
   const command = charSearchCommandForBinding(commandSequence, keymap);
   if (command) {
     return {
@@ -1155,7 +1198,12 @@ function resolveOperatorCharSearchRepeatPending(
 ): SemanticCommandResult {
   const operator = operatorActionForSequence(pending.operatorSequence, keymap);
   if (!operator || !isMotionOperator(operator)) return { type: "invalid" };
-  const repeatSequence = pending.repeatPrefix + key;
+  const repeatSequence = appendMappingSequence(
+    pending.repeatPrefix,
+    key,
+    keymap,
+    "operatorPending",
+  );
   const command = repeatCharSearchCommandForBinding(repeatSequence, keymap);
   if (command) {
     return {
@@ -1187,7 +1235,7 @@ function resolveTextObjectPending(
   if (!operator || !isMotionOperator(operator)) return { type: "invalid" };
 
   if (!pending.kind) {
-    const kindSequence = pending.kindPrefix + key;
+    const kindSequence = appendMappingSequence(pending.kindPrefix, key, keymap, "operatorPending");
     const scoped = scopedTextObjectSequenceFor(keymap, kindSequence, "textObject.kind.");
     const kind = textObjectKindForKey(kindSequence, keymap);
     if (kind && !scoped.isPrefix) {
@@ -1217,7 +1265,12 @@ function resolveTextObjectPending(
     return { type: "invalid" };
   }
 
-  const targetSequence = `${pending.targetPrefix ?? ""}${key}`;
+  const targetSequence = appendMappingSequence(
+    pending.targetPrefix ?? "",
+    key,
+    keymap,
+    "operatorPending",
+  );
   const scoped = scopedTextObjectSequenceFor(keymap, targetSequence, "textObject.target.");
   const target = textObjectTargetForKey(targetSequence, keymap);
   if (target && !scoped.isPrefix) {
@@ -1416,7 +1469,7 @@ export function resolveNormalCommand(
     const pendingOperator = operatorActionForSequence(pending, keymap);
     if (pendingOperator) return resolveAfterOperator(pending, key, keymap);
 
-    const combined = pending + key;
+    const combined = appendMappingSequence(pending, key, keymap, mode);
     if (hasLongerPrefix(combined, keymap, mode)) return { type: "pending", pending: combined };
     const combinedBinding = exactBinding(combined, keymap, mode);
     if (combinedBinding?.kind === "motion")

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -26,8 +26,12 @@ import {
   KEYMAP_MOTION_DESCRIPTORS,
   KEYMAP_OPERATOR_DESCRIPTORS,
 } from "./keymap-descriptors.ts";
-import { grammarEntriesForKeymap } from "./keymap-grammar.ts";
-import { isAtomicMappingSequence } from "./mapping-scopes.ts";
+import { grammarEntriesForKeymap, type KeymapGrammarEntry } from "./keymap-grammar.ts";
+import {
+  isAtomicMappingSequence,
+  mappingScopesForKeymapEntry,
+  type VimMappingScope,
+} from "./mapping-scopes.ts";
 
 const LEGACY_VIM_OPERATORS = new Set<string>(
   Object.keys(deriveLegacyKeyToAction(KEYMAP_OPERATOR_DESCRIPTORS)),
@@ -121,20 +125,9 @@ type ActionBinding = Extract<Binding, { kind: "action" }>;
 
 type CompiledKeymap = {
   exactBindings: Map<string, Binding>;
-  longerPrefixes: Set<string>;
   actionBindings: Map<string, ActionBinding[]>;
   actionLongerPrefixes: Map<string, ActionBinding[]>;
-  motions: {
-    exact: Map<string, VimMotionAction>;
-    longerPrefixes: Set<string>;
-  };
-  operators: Map<
-    VimOperatorAction,
-    {
-      exact: Set<string>;
-      longerPrefixes: Set<string>;
-    }
-  >;
+  motions: { exact: Map<string, VimMotionAction> };
   textObjects: {
     kinds: Map<string, VimTextObjectKind>;
     targets: Map<string, VimTextObjectTarget>;
@@ -280,7 +273,10 @@ function scopedTextObjectSequenceFor(
   prefix: "textObject.kind." | "textObject.target.",
 ): { action?: string; isPrefix: boolean } {
   const bindings = keymap.scoped.filter(
-    (binding) => binding.modes.includes("operatorPending") && binding.actionId.startsWith(prefix),
+    (binding) =>
+      binding.modes.includes("operatorPending") &&
+      binding.actionId.startsWith(prefix) &&
+      !isKeyUnmapped(keymap, binding.key, "operatorPending"),
   );
   return {
     action: [...bindings]
@@ -382,15 +378,9 @@ function compiledKeymapFor(keymap: ResolvedVimKeymap): CompiledKeymap {
 
 function compileKeymap(keymap: ResolvedVimKeymap): CompiledKeymap {
   const exactBindings = new Map<string, Binding>();
-  const longerPrefixes = new Set<string>();
   const actionBindings = new Map<string, ActionBinding[]>();
   const actionLongerPrefixes = new Map<string, ActionBinding[]>();
   const motionExact = new Map<string, VimMotionAction>();
-  const motionLongerPrefixes = new Set<string>();
-  const operators = new Map<
-    VimOperatorAction,
-    { exact: Set<string>; longerPrefixes: Set<string> }
-  >();
   const textObjectKinds = new Map<string, VimTextObjectKind>();
   const textObjectTargets = new Map<string, VimTextObjectTarget>();
   const searchDirections = new Map<string, "forward" | "backward">();
@@ -405,34 +395,23 @@ function compileKeymap(keymap: ResolvedVimKeymap): CompiledKeymap {
 
   for (const entry of grammarEntriesForKeymap(keymap)) {
     if (entry.family === "operator") {
-      const operatorLookup = operators.get(entry.id) ?? {
-        exact: new Set<string>(),
-        longerPrefixes: new Set<string>(),
-      };
       setFirstBinding(exactBindings, {
         sequence: entry.sequence,
         kind: "operator",
         operator: entry.id,
       });
-      addLongerPrefixes(longerPrefixes, entry.sequence);
-      operatorLookup.exact.add(entry.sequence);
-      addLongerPrefixes(operatorLookup.longerPrefixes, entry.sequence);
-      operators.set(entry.id, operatorLookup);
     } else if (entry.family === "motion") {
       setFirstBinding(exactBindings, {
         sequence: entry.sequence,
         kind: "motion",
         motion: entry.id,
       });
-      addLongerPrefixes(longerPrefixes, entry.sequence);
-      addLongerPrefixes(motionLongerPrefixes, entry.sequence);
     } else if (entry.family === "command") {
       setFirstBinding(exactBindings, {
         sequence: entry.sequence,
         kind: "command",
         command: entry.id,
       });
-      addLongerPrefixes(longerPrefixes, entry.sequence);
     } else if (entry.family === "textObjectKind") {
       setFirstValue(textObjectKinds, entry.sequence, entry.id);
     } else if (entry.family === "textObjectTarget") {
@@ -490,11 +469,9 @@ function compileKeymap(keymap: ResolvedVimKeymap): CompiledKeymap {
 
   return {
     exactBindings,
-    longerPrefixes,
     actionBindings,
     actionLongerPrefixes,
-    motions: { exact: motionExact, longerPrefixes: motionLongerPrefixes },
-    operators,
+    motions: { exact: motionExact },
     textObjects: { kinds: textObjectKinds, targets: textObjectTargets },
     commands: {
       searchDirections,
@@ -516,6 +493,27 @@ function actionBindingMatchesMode(
     mode === undefined ||
     !binding.modes ||
     (mode !== "operatorPending" && binding.modes.includes(mode))
+  );
+}
+
+function grammarEntryScopes(entry: KeymapGrammarEntry): readonly VimMappingScope[] {
+  const family =
+    entry.family === "textObjectKind"
+      ? "textObject.kind"
+      : entry.family === "textObjectTarget"
+        ? "textObject.target"
+        : entry.family;
+  return mappingScopesForKeymapEntry(family, entry.id);
+}
+
+function liveGrammarEntries(
+  keymap: ResolvedVimKeymap,
+  mode?: VimActionBindingMode | "operatorPending",
+): KeymapGrammarEntry[] {
+  return grammarEntriesForKeymap(keymap).filter(
+    (entry) =>
+      !isKeyUnmapped(keymap, entry.sequence, mode) &&
+      (!mode || grammarEntryScopes(entry).includes(mode)),
   );
 }
 
@@ -565,7 +563,10 @@ function exactBinding(
   const compiled = compiledKeymapFor(keymap);
   const action = compiled.actionBindings
     .get(sequence)
-    ?.find((binding) => actionBindingMatchesMode(binding, mode));
+    ?.find(
+      (binding) =>
+        actionBindingMatchesMode(binding, mode) && !isKeyUnmapped(keymap, binding.sequence, mode),
+    );
   return action ?? compiled.exactBindings.get(sequence);
 }
 
@@ -579,17 +580,29 @@ function hasLongerPrefix(
       (binding) =>
         binding.key !== sequence &&
         binding.key.startsWith(sequence) &&
-        (!mode || binding.modes.includes(mode)),
+        (!mode || binding.modes.includes(mode)) &&
+        !isKeyUnmapped(keymap, binding.key, mode),
     )
   ) {
     return true;
   }
-  const compiled = compiledKeymapFor(keymap);
-  if (compiled.longerPrefixes.has(sequence)) return true;
+  if (
+    liveGrammarEntries(keymap, mode).some(
+      (entry) =>
+        !isAtomicMappingSequence(entry.sequence) &&
+        entry.sequence !== sequence &&
+        entry.sequence.startsWith(sequence),
+    )
+  ) {
+    return true;
+  }
   return (
-    compiled.actionLongerPrefixes
-      .get(sequence)
-      ?.some((binding) => actionBindingMatchesMode(binding, mode)) ?? false
+    compiledKeymapFor(keymap)
+      .actionLongerPrefixes.get(sequence)
+      ?.some(
+        (binding) =>
+          actionBindingMatchesMode(binding, mode) && !isKeyUnmapped(keymap, binding.sequence, mode),
+      ) ?? false
   );
 }
 
@@ -918,14 +931,7 @@ function motionForSequence(
 }
 
 function hasMotionPrefix(sequence: string, keymap: ResolvedVimKeymap): boolean {
-  return (
-    hasLongerPrefix(sequence, keymap, "operatorPending") ||
-    compiledKeymapFor(keymap).motions.longerPrefixes.has(sequence)
-  );
-}
-
-function operatorLookupFor(keymap: ResolvedVimKeymap, operator: VimOperatorAction) {
-  return compiledKeymapFor(keymap).operators.get(operator);
+  return hasLongerPrefix(sequence, keymap, "operatorPending");
 }
 
 function hasOperatorPrefix(
@@ -939,9 +945,18 @@ function hasOperatorPrefix(
         binding.actionId === `operator.${operator}` &&
         binding.modes.includes("normal") &&
         binding.key !== sequence &&
-        binding.key.startsWith(sequence),
+        binding.key.startsWith(sequence) &&
+        !isKeyUnmapped(keymap, binding.key, "operatorPending"),
     ) ||
-    (operatorLookupFor(keymap, operator)?.longerPrefixes.has(sequence) ?? false)
+    liveGrammarEntries(keymap).some(
+      (entry) =>
+        entry.family === "operator" &&
+        entry.id === operator &&
+        !isAtomicMappingSequence(entry.sequence) &&
+        entry.sequence !== sequence &&
+        entry.sequence.startsWith(sequence) &&
+        !isKeyUnmapped(keymap, entry.sequence, "operatorPending"),
+    )
   );
 }
 
@@ -951,8 +966,8 @@ function operatorSequenceMatches(
   operator: VimOperatorAction,
 ): boolean {
   return (
-    operatorActionForSequence(sequence, keymap) === operator ||
-    (operatorLookupFor(keymap, operator)?.exact.has(sequence) ?? false)
+    !isKeyUnmapped(keymap, sequence, "operatorPending") &&
+    operatorActionForSequence(sequence, keymap) === operator
   );
 }
 

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -486,7 +486,7 @@ function actionBindingMatchesMode(
   );
 }
 
-function isUnmapped(
+export function isKeyUnmapped(
   keymap: ResolvedVimKeymap,
   sequence: string,
   mode: VimActionBindingMode | "operatorPending" | undefined,
@@ -528,7 +528,7 @@ function exactBinding(
 ): Binding | undefined {
   const scoped = scopedBinding(sequence, keymap, mode);
   if (scoped) return scoped;
-  if (isUnmapped(keymap, sequence, mode)) return undefined;
+  if (isKeyUnmapped(keymap, sequence, mode)) return undefined;
   const compiled = compiledKeymapFor(keymap);
   const action = compiled.actionBindings
     .get(sequence)

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -486,6 +486,16 @@ function actionBindingMatchesMode(
   );
 }
 
+function isUnmapped(
+  keymap: ResolvedVimKeymap,
+  sequence: string,
+  mode: VimActionBindingMode | "operatorPending" | undefined,
+): boolean {
+  return Boolean(
+    mode && keymap.unmaps.some((unmap) => unmap.key === sequence && unmap.modes.includes(mode)),
+  );
+}
+
 function scopedBinding(
   sequence: string,
   keymap: ResolvedVimKeymap,
@@ -518,6 +528,7 @@ function exactBinding(
 ): Binding | undefined {
   const scoped = scopedBinding(sequence, keymap, mode);
   if (scoped) return scoped;
+  if (isUnmapped(keymap, sequence, mode)) return undefined;
   const compiled = compiledKeymapFor(keymap);
   const action = compiled.actionBindings
     .get(sequence)

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -28,7 +28,7 @@ import {
 } from "./keymap-descriptors.ts";
 import { grammarEntriesForKeymap, type KeymapGrammarEntry } from "./keymap-grammar.ts";
 import {
-  isAtomicMappingSequence,
+  mappingSequencePrefixes,
   mappingScopesForKeymapEntry,
   type VimMappingScope,
 } from "./mapping-scopes.ts";
@@ -328,8 +328,7 @@ function lineCommandFor(operator: VimOperator): NormalCommand {
 }
 
 function addLongerPrefixes(prefixes: Set<string>, sequence: string): void {
-  if (isAtomicMappingSequence(sequence)) return;
-  for (let index = 1; index < sequence.length; index += 1) prefixes.add(sequence.slice(0, index));
+  for (const prefix of mappingSequencePrefixes(sequence)) prefixes.add(prefix);
 }
 
 function setFirstBinding(bindings: Map<string, Binding>, binding: Binding): void {
@@ -341,9 +340,7 @@ function addActionBinding(bindings: Map<string, ActionBinding[]>, binding: Actio
 }
 
 function addActionPrefixes(prefixes: Map<string, ActionBinding[]>, binding: ActionBinding): void {
-  if (isAtomicMappingSequence(binding.sequence)) return;
-  for (let index = 1; index < binding.sequence.length; index += 1) {
-    const prefix = binding.sequence.slice(0, index);
+  for (const prefix of mappingSequencePrefixes(binding.sequence)) {
     prefixes.set(prefix, [...(prefixes.get(prefix) ?? []), binding]);
   }
 }
@@ -587,11 +584,8 @@ function hasLongerPrefix(
     return true;
   }
   if (
-    liveGrammarEntries(keymap, mode).some(
-      (entry) =>
-        !isAtomicMappingSequence(entry.sequence) &&
-        entry.sequence !== sequence &&
-        entry.sequence.startsWith(sequence),
+    liveGrammarEntries(keymap, mode).some((entry) =>
+      mappingSequencePrefixes(entry.sequence).includes(sequence),
     )
   ) {
     return true;
@@ -616,7 +610,11 @@ function searchDirectionForBinding(
 }
 
 function hasSearchLongerPrefix(sequence: string, keymap: ResolvedVimKeymap): boolean {
-  return compiledKeymapFor(keymap).commands.searchLongerPrefixes.has(sequence);
+  return [...compiledKeymapFor(keymap).commands.searchDirections.keys()].some(
+    (candidate) =>
+      mappingSequencePrefixes(candidate).includes(sequence) &&
+      !isKeyUnmapped(keymap, candidate, "operatorPending"),
+  );
 }
 
 function charSearchCommandForBinding(
@@ -629,7 +627,11 @@ function charSearchCommandForBinding(
 }
 
 function hasCharSearchLongerPrefix(sequence: string, keymap: ResolvedVimKeymap): boolean {
-  return compiledKeymapFor(keymap).commands.charSearchLongerPrefixes.has(sequence);
+  return [...compiledKeymapFor(keymap).commands.charSearch.keys()].some(
+    (candidate) =>
+      mappingSequencePrefixes(candidate).includes(sequence) &&
+      !isKeyUnmapped(keymap, candidate, "operatorPending"),
+  );
 }
 
 function repeatCharSearchCommandForBinding(
@@ -642,7 +644,11 @@ function repeatCharSearchCommandForBinding(
 }
 
 function hasRepeatCharSearchLongerPrefix(sequence: string, keymap: ResolvedVimKeymap): boolean {
-  return compiledKeymapFor(keymap).commands.repeatCharSearchLongerPrefixes.has(sequence);
+  return [...compiledKeymapFor(keymap).commands.repeatCharSearch.keys()].some(
+    (candidate) =>
+      mappingSequencePrefixes(candidate).includes(sequence) &&
+      !isKeyUnmapped(keymap, candidate, "operatorPending"),
+  );
 }
 
 export const DEFAULT_MACRO_SLOTS = "abcdefghijklmnopqrstuvwxyz".split("");
@@ -952,9 +958,7 @@ function hasOperatorPrefix(
       (entry) =>
         entry.family === "operator" &&
         entry.id === operator &&
-        !isAtomicMappingSequence(entry.sequence) &&
-        entry.sequence !== sequence &&
-        entry.sequence.startsWith(sequence) &&
+        mappingSequencePrefixes(entry.sequence).includes(sequence) &&
         !isKeyUnmapped(keymap, entry.sequence, "operatorPending"),
     )
   );

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -245,6 +245,23 @@ export function scopedKeymapBindingFor(
     .find((binding) => binding.key === key && binding.modes.includes(mode));
 }
 
+export function scopedKeymapSequenceFor(
+  keymap: ResolvedVimKeymap,
+  sequence: string,
+  mode: VimActionBindingMode | "operatorPending",
+): { exact?: ResolvedVimKeymap["scoped"][number]; isPrefix: boolean } {
+  const exact = scopedKeymapBindingFor(keymap, sequence, mode);
+  return {
+    exact,
+    isPrefix: keymap.scoped.some(
+      (binding) =>
+        binding.modes.includes(mode) &&
+        binding.key.startsWith(sequence) &&
+        binding.key !== sequence,
+    ),
+  };
+}
+
 export function scopedKeysForAction(
   keymap: ResolvedVimKeymap,
   actionId: ResolvedVimKeymap["scoped"][number]["actionId"],

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -235,18 +235,40 @@ function isPrintableCharArgument(key: string): boolean {
   return key.length === 1 && key.charCodeAt(0) >= 32 && key.charCodeAt(0) !== 127;
 }
 
+function scopedActionFor(
+  key: string,
+  keymap: ResolvedVimKeymap,
+  prefix: string,
+): string | undefined {
+  return [...keymap.scoped]
+    .reverse()
+    .find(
+      (binding) =>
+        binding.key === key &&
+        binding.modes.includes("operatorPending") &&
+        binding.actionId.startsWith(prefix),
+    )
+    ?.actionId.slice(prefix.length);
+}
+
 function textObjectKindForKey(
   key: string,
   keymap: ResolvedVimKeymap,
 ): VimTextObjectKind | undefined {
-  return compiledKeymapFor(keymap).textObjects.kinds.get(key);
+  return (
+    (scopedActionFor(key, keymap, "textObject.kind.") as VimTextObjectKind | undefined) ??
+    compiledKeymapFor(keymap).textObjects.kinds.get(key)
+  );
 }
 
 function textObjectTargetForKey(
   key: string,
   keymap: ResolvedVimKeymap,
 ): VimTextObjectTarget | undefined {
-  return compiledKeymapFor(keymap).textObjects.targets.get(key);
+  return (
+    (scopedActionFor(key, keymap, "textObject.target.") as VimTextObjectTarget | undefined) ??
+    compiledKeymapFor(keymap).textObjects.targets.get(key)
+  );
 }
 
 function isLegacyVimOperator(key: string): key is VimOperator {
@@ -441,21 +463,50 @@ function compileKeymap(keymap: ResolvedVimKeymap): CompiledKeymap {
 
 function actionBindingMatchesMode(
   binding: Binding,
-  mode: VimActionBindingMode | undefined,
+  mode: VimActionBindingMode | "operatorPending" | undefined,
 ): boolean {
   return (
     binding.kind !== "action" ||
     mode === undefined ||
     !binding.modes ||
-    binding.modes.includes(mode)
+    (mode !== "operatorPending" && binding.modes.includes(mode))
   );
+}
+
+function scopedBinding(
+  sequence: string,
+  keymap: ResolvedVimKeymap,
+  mode?: VimActionBindingMode | "operatorPending",
+): Binding | undefined {
+  const mapping = [...keymap.scoped]
+    .reverse()
+    .find((binding) => binding.key === sequence && (!mode || binding.modes.includes(mode)));
+  if (!mapping) return undefined;
+  const [family, ...parts] = mapping.actionId.split(".");
+  const action = parts.join(".");
+  if (family === "operator")
+    return { sequence, kind: "operator", operator: action as VimOperatorAction };
+  if (family === "motion") return { sequence, kind: "motion", motion: action as VimMotionAction };
+  if (family === "command")
+    return { sequence, kind: "command", command: action as VimCommandAction };
+  if (mapping.actionId.startsWith("prompt.transform.")) {
+    return {
+      sequence,
+      kind: "action",
+      actionId: mapping.actionId as BindablePromptTransformActionId,
+      args: mapping.args as PromptTransform,
+    };
+  }
+  return undefined;
 }
 
 function exactBinding(
   sequence: string,
   keymap: ResolvedVimKeymap,
-  mode?: VimActionBindingMode,
+  mode?: VimActionBindingMode | "operatorPending",
 ): Binding | undefined {
+  const scoped = scopedBinding(sequence, keymap, mode);
+  if (scoped) return scoped;
   const compiled = compiledKeymapFor(keymap);
   const action = compiled.actionBindings
     .get(sequence)
@@ -466,8 +517,18 @@ function exactBinding(
 function hasLongerPrefix(
   sequence: string,
   keymap: ResolvedVimKeymap,
-  mode?: VimActionBindingMode,
+  mode?: VimActionBindingMode | "operatorPending",
 ): boolean {
+  if (
+    keymap.scoped.some(
+      (binding) =>
+        binding.key !== sequence &&
+        binding.key.startsWith(sequence) &&
+        (!mode || binding.modes.includes(mode)),
+    )
+  ) {
+    return true;
+  }
   const compiled = compiledKeymapFor(keymap);
   if (compiled.longerPrefixes.has(sequence)) return true;
   return (
@@ -769,11 +830,17 @@ function motionForSequence(
   sequence: string,
   keymap: ResolvedVimKeymap,
 ): VimMotionAction | undefined {
-  return compiledKeymapFor(keymap).motions.exact.get(sequence);
+  const scoped = exactBinding(sequence, keymap, "operatorPending");
+  return scoped?.kind === "motion"
+    ? scoped.motion
+    : compiledKeymapFor(keymap).motions.exact.get(sequence);
 }
 
 function hasMotionPrefix(sequence: string, keymap: ResolvedVimKeymap): boolean {
-  return compiledKeymapFor(keymap).motions.longerPrefixes.has(sequence);
+  return (
+    hasLongerPrefix(sequence, keymap, "operatorPending") ||
+    compiledKeymapFor(keymap).motions.longerPrefixes.has(sequence)
+  );
 }
 
 function operatorLookupFor(keymap: ResolvedVimKeymap, operator: VimOperatorAction) {

--- a/src/config-js.ts
+++ b/src/config-js.ts
@@ -23,6 +23,7 @@ import {
   KEYMAP_TEXT_OBJECT_TARGET_DESCRIPTORS,
 } from "./keymap-descriptors.ts";
 import {
+  encodeMappingTokens,
   mappingScopesForKeymapEntry,
   VIM_MAPPING_SCOPES,
   type VimMappingFamily,
@@ -486,7 +487,7 @@ function compileMapping(
     session.warning("keymap lhs must contain supported key syntax");
     return;
   }
-  const key = lhsKeys.join("");
+  const key = encodeMappingTokens(lhsKeys);
   const protectedKey = lhsKeys.find((candidate) => protectedShortcutForKey(candidate));
   const protectedShortcut = protectedKey ? protectedShortcutForKey(protectedKey) : undefined;
   if (protectedKey && protectedShortcut && !options.allowProtected) {

--- a/src/config-js.ts
+++ b/src/config-js.ts
@@ -562,6 +562,16 @@ function createPromptApi() {
   });
 }
 
+function actionFactory(actionId: VimFiniteActionId): (args?: unknown) => object {
+  const factory = (args?: unknown) => descriptor(actionId, args);
+  // EasyMotion historically exposed its default char target as the command leaf.
+  // Keep that call while making the documented nested form available.
+  if (actionId === "command.easymotion") {
+    Object.assign(factory, { goToChar: () => descriptor(actionId) });
+  }
+  return Object.freeze(factory);
+}
+
 function actionApiTree(prefix = ""): object {
   const tree: Record<string, unknown> = {};
   for (const actionId of ACTION_SCOPES.keys()) {
@@ -570,7 +580,7 @@ function actionApiTree(prefix = ""): object {
     const [name, ...rest] = suffix.split(".");
     if (!name) continue;
     if (rest.length === 0) {
-      tree[name] = (args?: unknown) => descriptor(actionId, args);
+      tree[name] = actionFactory(actionId);
       continue;
     }
     tree[name] ??= actionApiTree(`${prefix}${name}.`);

--- a/src/config-js.ts
+++ b/src/config-js.ts
@@ -364,7 +364,11 @@ function normalizeKey(value: string): string | undefined {
   });
 
   if (modifiers.some((modifier) => modifier === undefined)) return undefined;
-  return [...(modifiers as string[]), key].join("+");
+  const normalizedModifiers = modifiers as string[];
+  if (new Set(normalizedModifiers).size !== normalizedModifiers.length) return undefined;
+  const order = ["shift", "ctrl", "alt", "super"];
+  normalizedModifiers.sort((left, right) => order.indexOf(left) - order.indexOf(right));
+  return [...normalizedModifiers, key].join("+");
 }
 
 function tokenizeKeys(value: string): string[] | undefined {

--- a/src/config-js.ts
+++ b/src/config-js.ts
@@ -72,6 +72,8 @@ export type VimJsConfigMapOperation =
       key: string;
       inputs: readonly string[];
       modes: readonly VimActionBindingMode[];
+      allowProtected?: boolean;
+      desc?: string;
     }
   | {
       kind: "command";
@@ -501,7 +503,7 @@ function compileMapping(
     return;
   }
   if (typeof rhs === "string") {
-    recordStringRemap(session, key, rhs, modes);
+    recordStringRemap(session, key, rhs, modes, options);
     return;
   }
   const action = actionDescriptor(rhs);
@@ -519,6 +521,7 @@ function recordStringRemap(
   key: string,
   rhs: string,
   modes: readonly VimMappingScope[],
+  options: MappingOptions,
 ): void {
   const actionModes = modes.filter(
     (mode): mode is VimActionBindingMode =>
@@ -533,7 +536,14 @@ function recordStringRemap(
     session.warning("string rhs must contain supported key syntax");
     return;
   }
-  session.recordMap({ kind: "remap", key, inputs, modes: actionModes });
+  session.recordMap({
+    kind: "remap",
+    key,
+    inputs,
+    modes: actionModes,
+    ...(options.allowProtected ? { allowProtected: true } : {}),
+    ...(options.desc === undefined ? {} : { desc: options.desc }),
+  });
 }
 
 export function isPrintableLeader(value: unknown): value is string {

--- a/src/config-js.ts
+++ b/src/config-js.ts
@@ -4,7 +4,12 @@ import { join } from "node:path";
 import { pathToFileURL } from "node:url";
 
 import type { BindablePromptTransformActionId } from "./prompt-transform-actions.ts";
-import type { VimActionBindingMode, VimInsertAction, VimPreset } from "./types.ts";
+import type {
+  VimActionBindingMode,
+  VimFiniteActionId,
+  VimInsertAction,
+  VimPreset,
+} from "./types.ts";
 
 import { protectedShortcutForKey } from "./customization.ts";
 import {
@@ -29,7 +34,7 @@ import { VIM_PRESETS } from "./types.ts";
 export const DEFAULT_JS_CONFIG_PATH = join(homedir(), ".pi", "agent", "pi-vimmode.config.js");
 
 type ActionDescriptor = {
-  actionId: string;
+  actionId: VimFiniteActionId;
   args?: Readonly<Record<string, unknown>>;
 };
 
@@ -38,20 +43,28 @@ const ACTION_DESCRIPTORS = new WeakMap<object, ActionDescriptor>();
 export type VimJsConfigMapOperation =
   | {
       kind: "descriptor";
-      actionId: string;
+      actionId: VimFiniteActionId;
       key: string;
       modes: readonly VimMappingScope[];
       args?: Readonly<Record<string, unknown>>;
       allowProtected?: boolean;
       desc?: string;
     }
-  | { kind: "insert"; action: VimInsertAction; key: string }
+  | {
+      kind: "insert";
+      action: VimInsertAction;
+      key: string;
+      allowProtected?: boolean;
+      desc?: string;
+    }
   | {
       kind: "action";
       actionId: BindablePromptTransformActionId;
       key: string;
       args?: Readonly<Record<string, unknown>>;
       modes: readonly VimActionBindingMode[];
+      allowProtected?: boolean;
+      desc?: string;
     }
   | {
       kind: "remap";
@@ -132,15 +145,35 @@ const INSERT_ACTIONS = new Set<VimInsertAction>(
   Object.keys(KEYMAP_INSERT_DESCRIPTORS) as VimInsertAction[],
 );
 
-const ACTION_SCOPES = new Map<string, readonly VimMappingScope[]>([
+const ACTION_SCOPES = new Map<VimFiniteActionId, readonly VimMappingScope[]>([
   ["escape", VIM_MAPPING_SCOPES.filter((scope) => scope !== "normal")],
   ...ACTION_FAMILIES.flatMap(([family, actions]) =>
     Object.keys(actions).map(
-      (action) => [`${family}.${action}`, mappingScopesForKeymapEntry(family, action)] as const,
+      (action) =>
+        [
+          `${family}.${action}` as VimFiniteActionId,
+          mappingScopesForKeymapEntry(family, action),
+        ] as const,
     ),
   ),
-  ...PROMPT_TRANSFORM_ACTIONS.map(({ id, modes }) => [id, modes] as const),
+  ...PROMPT_TRANSFORM_ACTIONS.map(({ id, modes }) => [id as VimFiniteActionId, modes] as const),
 ]);
+
+function hasValidDescriptorArguments(
+  actionId: VimFiniteActionId,
+  args: Readonly<Record<string, unknown>> | undefined,
+): boolean {
+  if (!args) return true;
+  if (actionId === "prompt.transform.fence") {
+    return Object.keys(args).every(
+      (key) => key === "language" && typeof args.language === "string",
+    );
+  }
+  if (actionId === "prompt.transform.reflow") {
+    return Object.keys(args).every((key) => key === "width" && typeof args.width === "number");
+  }
+  return Object.keys(args).length === 0;
+}
 
 const VIM_PRESET_SET = new Set<VimPreset>(VIM_PRESETS);
 
@@ -287,7 +320,7 @@ function modesFor(rawMode: unknown): readonly VimMappingScope[] | undefined {
   return MODE_ALIASES[rawMode];
 }
 
-function descriptor(actionId: string, args?: Record<string, unknown>): object {
+function descriptor(actionId: VimFiniteActionId, args?: Record<string, unknown>): object {
   const value = Object.freeze({});
   ACTION_DESCRIPTORS.set(value, { actionId, args: args && frozenSnapshot(args) });
   return value;
@@ -298,7 +331,7 @@ function actionDescriptor(value: unknown): ActionDescriptor | undefined {
 }
 
 function builtinPromptTransform(action: string, args?: Record<string, unknown>): object {
-  return descriptor(`prompt.transform.${action}`, args);
+  return descriptor(`prompt.transform.${action}` as VimFiniteActionId, args);
 }
 
 function builtinInsert(action: VimInsertAction): object {
@@ -420,13 +453,23 @@ function compileMapping(
     session.warning(`${action.actionId} does not support selected mode`);
     return;
   }
+  if (!hasValidDescriptorArguments(action.actionId, action.args)) {
+    session.warning(`${action.actionId} does not accept these arguments`);
+    return;
+  }
   if (action.actionId.startsWith("insert.")) {
     const insertAction = action.actionId.slice("insert.".length) as VimInsertAction;
     if (!INSERT_ACTIONS.has(insertAction)) {
       session.warning(`unsupported insert action ${insertAction}`);
       return;
     }
-    session.recordMap({ kind: "insert", action: insertAction, key });
+    session.recordMap({
+      kind: "insert",
+      action: insertAction,
+      key,
+      ...(options.allowProtected ? { allowProtected: true } : {}),
+      ...(options.desc === undefined ? {} : { desc: options.desc }),
+    });
     return;
   }
   if (action.actionId.startsWith("prompt.transform.")) {
@@ -436,6 +479,8 @@ function compileMapping(
       key,
       args: action.args,
       modes: modes as VimActionBindingMode[],
+      ...(options.allowProtected ? { allowProtected: true } : {}),
+      ...(options.desc === undefined ? {} : { desc: options.desc }),
     });
     return;
   }

--- a/src/config-js.ts
+++ b/src/config-js.ts
@@ -35,7 +35,7 @@ export const DEFAULT_JS_CONFIG_PATH = join(homedir(), ".pi", "agent", "pi-vimmod
 
 type ActionDescriptor = {
   actionId: VimFiniteActionId;
-  args?: Readonly<Record<string, unknown>>;
+  args?: unknown;
 };
 
 const ACTION_DESCRIPTORS = new WeakMap<object, ActionDescriptor>();
@@ -159,20 +159,19 @@ const ACTION_SCOPES = new Map<VimFiniteActionId, readonly VimMappingScope[]>([
   ...PROMPT_TRANSFORM_ACTIONS.map(({ id, modes }) => [id as VimFiniteActionId, modes] as const),
 ]);
 
-function hasValidDescriptorArguments(
-  actionId: VimFiniteActionId,
-  args: Readonly<Record<string, unknown>> | undefined,
-): boolean {
-  if (!args) return true;
+function hasValidDescriptorArguments(actionId: VimFiniteActionId, args: unknown): boolean {
+  if (args === undefined) return true;
+  if (!args || typeof args !== "object" || Array.isArray(args)) return false;
+  const record = args as Record<string, unknown>;
   if (actionId === "prompt.transform.fence") {
-    return Object.keys(args).every(
-      (key) => key === "language" && typeof args.language === "string",
+    return Object.keys(record).every(
+      (key) => key === "language" && typeof record.language === "string",
     );
   }
   if (actionId === "prompt.transform.reflow") {
-    return Object.keys(args).every((key) => key === "width" && typeof args.width === "number");
+    return Object.keys(record).every((key) => key === "width" && typeof record.width === "number");
   }
-  return Object.keys(args).length === 0;
+  return false;
 }
 
 const VIM_PRESET_SET = new Set<VimPreset>(VIM_PRESETS);
@@ -320,9 +319,12 @@ function modesFor(rawMode: unknown): readonly VimMappingScope[] | undefined {
   return MODE_ALIASES[rawMode];
 }
 
-function descriptor(actionId: VimFiniteActionId, args?: Record<string, unknown>): object {
+function descriptor(actionId: VimFiniteActionId, args?: unknown): object {
   const value = Object.freeze({});
-  ACTION_DESCRIPTORS.set(value, { actionId, args: args && frozenSnapshot(args) });
+  ACTION_DESCRIPTORS.set(value, {
+    actionId,
+    args: args === undefined ? undefined : frozenSnapshot(args),
+  });
   return value;
 }
 
@@ -330,7 +332,7 @@ function actionDescriptor(value: unknown): ActionDescriptor | undefined {
   return value && typeof value === "object" ? ACTION_DESCRIPTORS.get(value) : undefined;
 }
 
-function builtinPromptTransform(action: string, args?: Record<string, unknown>): object {
+function builtinPromptTransform(action: string, args?: unknown): object {
   return descriptor(`prompt.transform.${action}` as VimFiniteActionId, args);
 }
 
@@ -477,7 +479,7 @@ function compileMapping(
       kind: "action",
       actionId: action.actionId as BindablePromptTransformActionId,
       key,
-      args: action.args,
+      args: action.args as Readonly<Record<string, unknown>> | undefined,
       modes: modes as VimActionBindingMode[],
       ...(options.allowProtected ? { allowProtected: true } : {}),
       ...(options.desc === undefined ? {} : { desc: options.desc }),
@@ -489,7 +491,7 @@ function compileMapping(
     actionId: action.actionId,
     key,
     modes,
-    args: action.args,
+    args: action.args as Readonly<Record<string, unknown>> | undefined,
     ...(options.allowProtected ? { allowProtected: true } : {}),
     ...(options.desc === undefined ? {} : { desc: options.desc }),
   });
@@ -505,7 +507,7 @@ function recordStringRemap(
     (mode): mode is VimActionBindingMode =>
       mode === "normal" || mode === "visual" || mode === "visualLine" || mode === "visualBlock",
   );
-  if (actionModes.length === 0) {
+  if (actionModes.length !== modes.length) {
     session.warning("string rhs keymaps only support normal and visual modes");
     return;
   }
@@ -556,7 +558,7 @@ function actionApiTree(prefix = ""): object {
     const [name, ...rest] = suffix.split(".");
     if (!name) continue;
     if (rest.length === 0) {
-      tree[name] = (args?: Record<string, unknown>) => descriptor(actionId, args);
+      tree[name] = (args?: unknown) => descriptor(actionId, args);
       continue;
     }
     tree[name] ??= actionApiTree(`${prefix}${name}.`);

--- a/src/config-js.ts
+++ b/src/config-js.ts
@@ -4,22 +4,47 @@ import { join } from "node:path";
 import { pathToFileURL } from "node:url";
 
 import type { BindablePromptTransformActionId } from "./prompt-transform-actions.ts";
-import type { VimActionBindingMode, VimInsertAction, VimMode, VimPreset } from "./types.ts";
+import type { VimActionBindingMode, VimInsertAction, VimPreset } from "./types.ts";
 
 import { protectedShortcutForKey } from "./customization.ts";
+import {
+  KEYMAP_COMMAND_DESCRIPTORS,
+  KEYMAP_INSERT_DESCRIPTORS,
+  KEYMAP_MARK_DESCRIPTORS,
+  KEYMAP_MACRO_DESCRIPTORS,
+  KEYMAP_MOTION_DESCRIPTORS,
+  KEYMAP_OPERATOR_DESCRIPTORS,
+  KEYMAP_TEXT_OBJECT_KIND_DESCRIPTORS,
+  KEYMAP_TEXT_OBJECT_TARGET_DESCRIPTORS,
+} from "./keymap-descriptors.ts";
+import {
+  mappingScopesForKeymapEntry,
+  VIM_MAPPING_SCOPES,
+  type VimMappingFamily,
+  type VimMappingScope,
+} from "./mapping-scopes.ts";
+import { PROMPT_TRANSFORM_ACTIONS } from "./prompt-transform-actions.ts";
 import { VIM_PRESETS } from "./types.ts";
 
 export const DEFAULT_JS_CONFIG_PATH = join(homedir(), ".pi", "agent", "pi-vimmode.config.js");
 
-type BuiltinCommand =
-  | { kind: "insert"; action: VimInsertAction }
-  | {
-      kind: "promptTransform";
-      actionId: BindablePromptTransformActionId;
-      args?: Record<string, unknown>;
-    };
+type ActionDescriptor = {
+  actionId: string;
+  args?: Readonly<Record<string, unknown>>;
+};
+
+const ACTION_DESCRIPTORS = new WeakMap<object, ActionDescriptor>();
 
 export type VimJsConfigMapOperation =
+  | {
+      kind: "descriptor";
+      actionId: string;
+      key: string;
+      modes: readonly VimMappingScope[];
+      args?: Readonly<Record<string, unknown>>;
+      allowProtected?: boolean;
+      desc?: string;
+    }
   | { kind: "insert"; action: VimInsertAction; key: string }
   | {
       kind: "action";
@@ -45,7 +70,7 @@ export type VimJsConfigOperation =
   | { kind: "preset"; preset: VimPreset }
   | { kind: "leaf"; path: string; value: unknown }
   | { kind: "map"; mapping: VimJsConfigMapOperation }
-  | { kind: "unmap"; key: string; modes: readonly VimMode[] };
+  | { kind: "unmap"; key: string; modes: readonly VimMappingScope[]; allowProtected?: boolean };
 
 export type VimJsConfigRules = {
   validate(
@@ -71,80 +96,50 @@ type ConfigSession = {
   setPreset(value: unknown): void;
   warning(message: string): void;
   recordMap(mapping: VimJsConfigMapOperation): void;
-  recordUnmap(key: string, modes: readonly VimMode[]): void;
+  recordUnmap(key: string, modes: readonly VimMappingScope[], allowProtected?: boolean): void;
   success(): Extract<VimJsConfigLoadResult, { kind: "success" }>;
 };
 
-const MODE_ALIASES: Record<string, readonly VimMode[]> = {
+const MODE_ALIASES: Record<string, readonly VimMappingScope[]> = {
   i: ["insert"],
   insert: ["insert"],
   n: ["normal"],
   normal: ["normal"],
   v: ["visual", "visualLine", "visualBlock"],
-  visual: ["visual"],
+  x: ["visual", "visualLine", "visualBlock"],
+  visual: ["visual", "visualLine", "visualBlock"],
   visualLine: ["visualLine"],
   visualBlock: ["visualBlock"],
+  o: ["operatorPending"],
+  operatorPending: ["operatorPending"],
+  "operator-pending": ["operatorPending"],
 };
 
-// Known command actions from KEYMAP_COMMAND_DESCRIPTORS — string RHS matching these
-// become command bindings instead of keystroke-replay remaps.
-const KNOWN_COMMANDS = new Set([
-  "insertBefore",
-  "insertAfter",
-  "insertLineStart",
-  "insertLineEnd",
-  "openLineBelow",
-  "openLineAbove",
-  "visualChar",
-  "visualLine",
-  "visualBlock",
-  "deleteChar",
-  "deleteCharBefore",
-  "deleteToLineEnd",
-  "changeToLineEnd",
-  "yankLine",
-  "joinLine",
-  "pasteAfter",
-  "pasteBefore",
-  "incrementNumber",
-  "decrementNumber",
-  "toggleCase",
-  "replaceChar",
-  "substituteChar",
-  "substituteLine",
-  "findCharForward",
-  "findCharBackward",
-  "tillCharForward",
-  "tillCharBackward",
-  "repeatCharSearch",
-  "repeatCharSearchReverse",
-  "startSearch",
-  "startSearchBackward",
-  "repeatSearch",
-  "repeatSearchReverse",
-  "searchWordForward",
-  "searchWordBackward",
-  "startExCommand",
-  "repeatChange",
-  "undo",
-  "redo",
-  "showKeybindings",
-  "reselectVisual",
-  "easymotion",
-  "easymotion.goToChar",
-]);
+const ACTION_FAMILIES: ReadonlyArray<
+  readonly [VimMappingFamily, Record<string, { defaults: readonly string[] }>]
+> = [
+  ["operator", KEYMAP_OPERATOR_DESCRIPTORS],
+  ["motion", KEYMAP_MOTION_DESCRIPTORS],
+  ["command", KEYMAP_COMMAND_DESCRIPTORS],
+  ["macro", KEYMAP_MACRO_DESCRIPTORS],
+  ["mark", KEYMAP_MARK_DESCRIPTORS],
+  ["insert", KEYMAP_INSERT_DESCRIPTORS],
+  ["textObject.kind", KEYMAP_TEXT_OBJECT_KIND_DESCRIPTORS],
+  ["textObject.target", KEYMAP_TEXT_OBJECT_TARGET_DESCRIPTORS],
+];
 
-const INSERT_ACTIONS = new Set<VimInsertAction>([
-  "openLineBelow",
-  "openLineAbove",
-  "deleteWordBackward",
-  "deleteWordForward",
-  "deleteLineBackward",
-  "deleteLineForward",
-  "moveWordBackward",
-  "moveWordForward",
-  "moveLineStart",
-  "moveLineEnd",
+const INSERT_ACTIONS = new Set<VimInsertAction>(
+  Object.keys(KEYMAP_INSERT_DESCRIPTORS) as VimInsertAction[],
+);
+
+const ACTION_SCOPES = new Map<string, readonly VimMappingScope[]>([
+  ["escape", VIM_MAPPING_SCOPES.filter((scope) => scope !== "normal")],
+  ...ACTION_FAMILIES.flatMap(([family, actions]) =>
+    Object.keys(actions).map(
+      (action) => [`${family}.${action}`, mappingScopesForKeymapEntry(family, action)] as const,
+    ),
+  ),
+  ...PROMPT_TRANSFORM_ACTIONS.map(({ id, modes }) => [id, modes] as const),
 ]);
 
 const VIM_PRESET_SET = new Set<VimPreset>(VIM_PRESETS);
@@ -278,31 +273,36 @@ function createOptionNamespace(
   });
 }
 
-function modesFor(rawMode: unknown): readonly VimMode[] | undefined {
+function modesFor(rawMode: unknown): readonly VimMappingScope[] | undefined {
   if (Array.isArray(rawMode)) {
-    const modes = rawMode.flatMap((mode) => modesFor(mode) ?? []);
-    return modes.length > 0 ? [...new Set(modes)] : undefined;
+    const modes: VimMappingScope[] = [];
+    for (const mode of rawMode) {
+      const resolved = modesFor(mode);
+      if (!resolved) return undefined;
+      modes.push(...resolved);
+    }
+    return [...new Set(modes)];
   }
   if (typeof rawMode !== "string") return undefined;
   return MODE_ALIASES[rawMode];
 }
 
-function isBuiltinCommand(value: unknown): value is BuiltinCommand {
-  if (!value || typeof value !== "object") return false;
-  const command = value as Partial<BuiltinCommand>;
-  return command.kind === "insert" || command.kind === "promptTransform";
+function descriptor(actionId: string, args?: Record<string, unknown>): object {
+  const value = Object.freeze({});
+  ACTION_DESCRIPTORS.set(value, { actionId, args: args && frozenSnapshot(args) });
+  return value;
 }
 
-function builtinPromptTransform(action: string, args?: Record<string, unknown>): BuiltinCommand {
-  return {
-    kind: "promptTransform",
-    actionId: `prompt.transform.${action}` as BindablePromptTransformActionId,
-    args,
-  };
+function actionDescriptor(value: unknown): ActionDescriptor | undefined {
+  return value && typeof value === "object" ? ACTION_DESCRIPTORS.get(value) : undefined;
 }
 
-function builtinInsert(action: VimInsertAction): BuiltinCommand {
-  return { kind: "insert", action };
+function builtinPromptTransform(action: string, args?: Record<string, unknown>): object {
+  return descriptor(`prompt.transform.${action}`, args);
+}
+
+function builtinInsert(action: VimInsertAction): object {
+  return descriptor(`insert.${action}`);
 }
 
 function normalizeKey(value: string): string | undefined {
@@ -350,7 +350,27 @@ function tokenizeReplayInputs(value: string): string[] | undefined {
   return keys.map((key) => RHS_INPUT_ALIASES[key] ?? key);
 }
 
-function compileMapping(session: ConfigSession, mode: unknown, lhs: unknown, rhs: unknown): void {
+type MappingOptions = { allowProtected?: boolean; desc?: string };
+
+function mappingOptions(value: unknown): MappingOptions | undefined {
+  if (value === undefined) return {};
+  if (!value || typeof value !== "object" || Array.isArray(value)) return undefined;
+  const entries = Object.entries(value);
+  if (entries.some(([key]) => key !== "allowProtected" && key !== "desc")) return undefined;
+  const options = value as MappingOptions;
+  if (options.allowProtected !== undefined && typeof options.allowProtected !== "boolean")
+    return undefined;
+  if (options.desc !== undefined && typeof options.desc !== "string") return undefined;
+  return options;
+}
+
+function compileMapping(
+  session: ConfigSession,
+  mode: unknown,
+  lhs: unknown,
+  rhs: unknown,
+  rawOptions?: unknown,
+): void {
   session.assertOpen();
   const modes = modesFor(mode);
   if (!modes) {
@@ -361,6 +381,11 @@ function compileMapping(session: ConfigSession, mode: unknown, lhs: unknown, rhs
     session.warning("keymap lhs must be a non-empty string");
     return;
   }
+  const options = mappingOptions(rawOptions);
+  if (!options) {
+    session.warning("keymap options only support allowProtected:boolean and desc:string");
+    return;
+  }
   const lhsKeys = tokenizeLhsKeys(lhs);
   if (!lhsKeys || lhsKeys.length === 0) {
     session.warning("keymap lhs must contain supported key syntax");
@@ -369,57 +394,59 @@ function compileMapping(session: ConfigSession, mode: unknown, lhs: unknown, rhs
   const key = lhsKeys.join("");
   const protectedKey = lhsKeys.find((candidate) => protectedShortcutForKey(candidate));
   const protectedShortcut = protectedKey ? protectedShortcutForKey(protectedKey) : undefined;
-  if (protectedKey && protectedShortcut) {
+  if (protectedKey && protectedShortcut && !options.allowProtected) {
     session.warning(
       `keymap lhs contains protected key ${protectedKey} (${protectedShortcut.reason})`,
     );
     return;
   }
   if (rhs === null) {
-    session.recordUnmap(key, modes);
+    session.recordUnmap(key, modes, options.allowProtected);
     return;
   }
   if (typeof rhs === "string") {
-    // If the string matches a known command action, create a command binding
-    // instead of treating it as a keystroke-replay remap.
-    if (KNOWN_COMMANDS.has(rhs)) {
-      const actionModes = modes.filter((m) => m !== "insert") as VimActionBindingMode[];
-      if (actionModes.length > 0) {
-        session.recordMap({ kind: "command", command: rhs, key, modes: actionModes });
-      }
-      return;
-    }
     recordStringRemap(session, key, rhs, modes);
     return;
   }
-  if (!isBuiltinCommand(rhs)) {
-    session.warning("keymap rhs must be a vim.prompt.* builtin command or key string");
+  const action = actionDescriptor(rhs);
+  if (!action) {
+    session.warning(
+      "keymap rhs must be an opaque vim.action descriptor, vim.prompt alias, key string, or null",
+    );
     return;
   }
-  if (rhs.kind === "insert") {
-    if (!modes.includes("insert") || modes.length !== 1) {
-      session.warning(`vim.prompt.${rhs.action}() only supports insert mode`);
-      return;
-    }
-    if (!INSERT_ACTIONS.has(rhs.action)) {
-      session.warning(`unsupported insert action ${rhs.action}`);
-      return;
-    }
-    session.recordMap({ kind: "insert", action: rhs.action, key });
+  const scopes = ACTION_SCOPES.get(action.actionId);
+  if (!scopes || !modes.every((candidate) => scopes.includes(candidate))) {
+    session.warning(`${action.actionId} does not support selected mode`);
     return;
   }
-
-  const actionModes = modes.filter((candidate) => candidate !== "insert") as VimActionBindingMode[];
-  if (actionModes.length === 0) {
-    session.warning(`${rhs.actionId} does not support insert mode`);
+  if (action.actionId.startsWith("insert.")) {
+    const insertAction = action.actionId.slice("insert.".length) as VimInsertAction;
+    if (!INSERT_ACTIONS.has(insertAction)) {
+      session.warning(`unsupported insert action ${insertAction}`);
+      return;
+    }
+    session.recordMap({ kind: "insert", action: insertAction, key });
+    return;
+  }
+  if (action.actionId.startsWith("prompt.transform.")) {
+    session.recordMap({
+      kind: "action",
+      actionId: action.actionId as BindablePromptTransformActionId,
+      key,
+      args: action.args,
+      modes: modes as VimActionBindingMode[],
+    });
     return;
   }
   session.recordMap({
-    kind: "action",
-    actionId: rhs.actionId,
+    kind: "descriptor",
+    actionId: action.actionId,
     key,
-    args: rhs.args,
-    modes: actionModes,
+    modes,
+    args: action.args,
+    ...(options.allowProtected ? { allowProtected: true } : {}),
+    ...(options.desc === undefined ? {} : { desc: options.desc }),
   });
 }
 
@@ -427,9 +454,12 @@ function recordStringRemap(
   session: ConfigSession,
   key: string,
   rhs: string,
-  modes: readonly VimMode[],
+  modes: readonly VimMappingScope[],
 ): void {
-  const actionModes = modes.filter((mode) => mode !== "insert") as VimActionBindingMode[];
+  const actionModes = modes.filter(
+    (mode): mode is VimActionBindingMode =>
+      mode === "normal" || mode === "visual" || mode === "visualLine" || mode === "visualBlock",
+  );
   if (actionModes.length === 0) {
     session.warning("string rhs keymaps only support normal and visual modes");
     return;
@@ -473,6 +503,22 @@ function createPromptApi() {
   });
 }
 
+function actionApiTree(prefix = ""): object {
+  const tree: Record<string, unknown> = {};
+  for (const actionId of ACTION_SCOPES.keys()) {
+    if (!actionId.startsWith(prefix)) continue;
+    const suffix = actionId.slice(prefix.length);
+    const [name, ...rest] = suffix.split(".");
+    if (!name) continue;
+    if (rest.length === 0) {
+      tree[name] = (args?: Record<string, unknown>) => descriptor(actionId, args);
+      continue;
+    }
+    tree[name] ??= actionApiTree(`${prefix}${name}.`);
+  }
+  return Object.freeze(tree);
+}
+
 function createGlobalApi(session: ConfigSession): object {
   return new Proxy(
     {
@@ -503,7 +549,8 @@ function createGlobalApi(session: ConfigSession): object {
 
 function createVimApi(session: ConfigSession, g: object): object {
   const keymap = createOptionNamespace(session, "keymap", {
-    set: (mode: unknown, lhs: unknown, rhs: unknown) => compileMapping(session, mode, lhs, rhs),
+    set: (mode: unknown, lhs: unknown, rhs: unknown, options?: unknown) =>
+      compileMapping(session, mode, lhs, rhs, options),
   });
   return createOptionNamespace(session, "", {
     g,
@@ -513,6 +560,7 @@ function createVimApi(session: ConfigSession, g: object): object {
     set preset(value: unknown) {
       session.setPreset(value);
     },
+    action: actionApiTree(),
     prompt: createPromptApi(),
     keymap,
   });
@@ -571,9 +619,14 @@ function createSession(
       assertOpen();
       operations.push({ kind: "map", mapping: frozenSnapshot(mapping) });
     },
-    recordUnmap: (key, modes) => {
+    recordUnmap: (key, modes, allowProtected) => {
       assertOpen();
-      operations.push({ kind: "unmap", key, modes: frozenSnapshot(modes) });
+      operations.push({
+        kind: "unmap",
+        key,
+        modes: frozenSnapshot(modes),
+        ...(allowProtected ? { allowProtected: true } : {}),
+      });
     },
     success: () => ({
       kind: "success",

--- a/src/config-js.ts
+++ b/src/config-js.ts
@@ -152,7 +152,9 @@ const ACTION_SCOPES = new Map<VimFiniteActionId, readonly VimMappingScope[]>([
       (action) =>
         [
           `${family}.${action}` as VimFiniteActionId,
-          mappingScopesForKeymapEntry(family, action),
+          mappingScopesForKeymapEntry(family, action).filter(
+            (scope) => family !== "mark" || scope !== "operatorPending",
+          ),
         ] as const,
     ),
   ),
@@ -399,6 +401,60 @@ function mappingOptions(value: unknown): MappingOptions | undefined {
   return options;
 }
 
+function recordDescriptorMapping(
+  session: ConfigSession,
+  key: string,
+  modes: readonly VimMappingScope[],
+  action: ActionDescriptor,
+  options: MappingOptions,
+): void {
+  const scopes = ACTION_SCOPES.get(action.actionId);
+  if (!scopes || !modes.every((candidate) => scopes.includes(candidate))) {
+    session.warning(`${action.actionId} does not support selected mode`);
+    return;
+  }
+  if (!hasValidDescriptorArguments(action.actionId, action.args)) {
+    session.warning(`${action.actionId} does not accept these arguments`);
+    return;
+  }
+  if (action.actionId.startsWith("insert.")) {
+    const insertAction = action.actionId.slice("insert.".length) as VimInsertAction;
+    if (!INSERT_ACTIONS.has(insertAction)) {
+      session.warning(`unsupported insert action ${insertAction}`);
+      return;
+    }
+    session.recordMap({
+      kind: "insert",
+      action: insertAction,
+      key,
+      ...(options.allowProtected ? { allowProtected: true } : {}),
+      ...(options.desc === undefined ? {} : { desc: options.desc }),
+    });
+    return;
+  }
+  if (action.actionId.startsWith("prompt.transform.")) {
+    session.recordMap({
+      kind: "action",
+      actionId: action.actionId as BindablePromptTransformActionId,
+      key,
+      args: action.args as Readonly<Record<string, unknown>> | undefined,
+      modes: modes as VimActionBindingMode[],
+      ...(options.allowProtected ? { allowProtected: true } : {}),
+      ...(options.desc === undefined ? {} : { desc: options.desc }),
+    });
+    return;
+  }
+  session.recordMap({
+    kind: "descriptor",
+    actionId: action.actionId,
+    key,
+    modes,
+    args: action.args as Readonly<Record<string, unknown>> | undefined,
+    ...(options.allowProtected ? { allowProtected: true } : {}),
+    ...(options.desc === undefined ? {} : { desc: options.desc }),
+  });
+}
+
 function compileMapping(
   session: ConfigSession,
   mode: unknown,
@@ -450,51 +506,7 @@ function compileMapping(
     );
     return;
   }
-  const scopes = ACTION_SCOPES.get(action.actionId);
-  if (!scopes || !modes.every((candidate) => scopes.includes(candidate))) {
-    session.warning(`${action.actionId} does not support selected mode`);
-    return;
-  }
-  if (!hasValidDescriptorArguments(action.actionId, action.args)) {
-    session.warning(`${action.actionId} does not accept these arguments`);
-    return;
-  }
-  if (action.actionId.startsWith("insert.")) {
-    const insertAction = action.actionId.slice("insert.".length) as VimInsertAction;
-    if (!INSERT_ACTIONS.has(insertAction)) {
-      session.warning(`unsupported insert action ${insertAction}`);
-      return;
-    }
-    session.recordMap({
-      kind: "insert",
-      action: insertAction,
-      key,
-      ...(options.allowProtected ? { allowProtected: true } : {}),
-      ...(options.desc === undefined ? {} : { desc: options.desc }),
-    });
-    return;
-  }
-  if (action.actionId.startsWith("prompt.transform.")) {
-    session.recordMap({
-      kind: "action",
-      actionId: action.actionId as BindablePromptTransformActionId,
-      key,
-      args: action.args as Readonly<Record<string, unknown>> | undefined,
-      modes: modes as VimActionBindingMode[],
-      ...(options.allowProtected ? { allowProtected: true } : {}),
-      ...(options.desc === undefined ? {} : { desc: options.desc }),
-    });
-    return;
-  }
-  session.recordMap({
-    kind: "descriptor",
-    actionId: action.actionId,
-    key,
-    modes,
-    args: action.args as Readonly<Record<string, unknown>> | undefined,
-    ...(options.allowProtected ? { allowProtected: true } : {}),
-    ...(options.desc === undefined ? {} : { desc: options.desc }),
-  });
+  recordDescriptorMapping(session, key, modes, action, options);
 }
 
 function recordStringRemap(

--- a/src/config.ts
+++ b/src/config.ts
@@ -75,6 +75,7 @@ import {
   mappingScopesForKeymapEntry,
   mappingSequencesOverlap,
   VIM_MAPPING_SCOPES,
+  type VimMappingFamily,
   type VimMappingScope,
 } from "./mapping-scopes.ts";
 import {
@@ -649,7 +650,7 @@ function parseStringArray(
     parsed.push(sequence);
   }
 
-  return parsed.length > 0 ? parsed : undefined;
+  return parsed.length > 0 || value.length === 0 ? parsed : undefined;
 }
 
 function isPrintableTextSequence(sequence: string): boolean {
@@ -1882,10 +1883,10 @@ function projectExactMappings(
   };
   const addRecord = (
     record: Partial<Record<string, readonly string[]>> | undefined,
-    modes: readonly VimMappingScope[],
-    family: string,
+    family: VimMappingFamily,
   ) => {
     for (const [action, bindings] of Object.entries(record ?? {})) {
+      const modes = mappingScopesForKeymapEntry(family, action);
       for (const key of bindings ?? []) add(key, modes, `${family}.${action}`);
     }
   };
@@ -1893,12 +1894,14 @@ function projectExactMappings(
   for (const key of keymap.escape ?? []) {
     add(key, ["insert", "visual", "visualLine", "visualBlock"]);
   }
-  addRecord(keymap.operators, ACTION_BINDING_MODES, "operator");
-  addRecord(keymap.motions, [...ACTION_BINDING_MODES, "operatorPending"], "motion");
-  addRecord(keymap.commands, ["normal"], "command");
-  addRecord(keymap.macros, ["normal"], "macro");
-  addRecord(keymap.marks, ACTION_BINDING_MODES, "mark");
-  addRecord(keymap.insert, ["insert"], "insert");
+  addRecord(keymap.operators, "operator");
+  addRecord(keymap.motions, "motion");
+  addRecord(keymap.commands, "command");
+  addRecord(keymap.macros, "macro");
+  addRecord(keymap.marks, "mark");
+  addRecord(keymap.insert, "insert");
+  addRecord(keymap.textObjects?.kinds, "textObjectKind");
+  addRecord(keymap.textObjects?.targets, "textObjectTarget");
   for (const bindings of Object.values(keymap.actions ?? {})) {
     for (const binding of bindings ?? []) {
       add(binding.key, binding.modes ?? ACTION_BINDING_MODES, binding.actionId);
@@ -1924,15 +1927,47 @@ function removeJsActionMappings(
   });
 }
 
+function projectConfiguredActions(
+  keymap: PartialKeymapOptions,
+): Array<{ actionId: string; modes: readonly VimMappingScope[] }> {
+  const actions: Array<{ actionId: string; modes: readonly VimMappingScope[] }> = [];
+  const addRecord = (
+    record: Partial<Record<string, readonly unknown[]>> | undefined,
+    family: VimMappingFamily,
+  ) => {
+    for (const action of Object.keys(record ?? {})) {
+      actions.push({
+        actionId: `${family}.${action}`,
+        modes: mappingScopesForKeymapEntry(family, action),
+      });
+    }
+  };
+  addRecord(keymap.operators, "operator");
+  addRecord(keymap.motions, "motion");
+  addRecord(keymap.commands, "command");
+  addRecord(keymap.macros, "macro");
+  addRecord(keymap.marks, "mark");
+  addRecord(keymap.insert, "insert");
+  addRecord(keymap.textObjects?.kinds, "textObjectKind");
+  addRecord(keymap.textObjects?.targets, "textObjectTarget");
+  for (const actionId of Object.keys(keymap.actions ?? {})) {
+    actions.push({ actionId, modes: ACTION_BINDING_MODES });
+  }
+  return actions;
+}
+
 function applyProjectExactPrecedence(
   lowerLayers: readonly PartialKeymapOptions[],
   project: PartialKeymapOptions,
   leader: string | undefined,
 ): void {
-  for (const mapping of projectExactMappings(project, leader ?? null)) {
-    for (const layer of lowerLayers) {
+  for (const layer of lowerLayers) {
+    for (const action of projectConfiguredActions(project)) {
+      removeJsActionMappings(layer, action.actionId, action.modes);
+    }
+    for (const mapping of projectExactMappings(project, leader ?? null)) {
       removeJsMappings(layer, mapping.key, mapping.modes, leader ?? null);
-      if (mapping.actionId) removeJsActionMappings(layer, mapping.actionId, mapping.modes);
+      restoreJsUnmaps(layer, mapping.key, mapping.modes, leader ?? null);
     }
   }
 }
@@ -2613,9 +2648,12 @@ function restoreJsUnmaps(
   keymap: PartialKeymapOptions,
   key: string,
   modes: readonly VimMappingScope[],
+  leader?: string | null,
 ): void {
   keymap.unmaps = keymap.unmaps?.flatMap((unmap) => {
-    if (unmap.key !== key) return [unmap];
+    const unmapKey =
+      leader === undefined ? unmap.key : resolvedLeaderKey(unmap.key, leader ?? undefined);
+    if (unmapKey !== key) return [unmap];
     const remainingModes = unmap.modes.filter((mode) => !modes.includes(mode));
     return remainingModes.length ? [{ ...unmap, modes: remainingModes }] : [];
   });
@@ -2681,10 +2719,6 @@ function partialFromJsOperations(operations: readonly VimJsConfigOperation[]): V
     }
     if (mapping.kind === "descriptor") {
       restoreJsUnmaps(keymap as PartialKeymapOptions, mapping.key, mapping.modes);
-      if (mapping.actionId === "escape") {
-        keymap.escape = [...(keymap.escape ?? []), mapping.key];
-        continue;
-      }
       const scoped = ((keymap as PartialKeymapOptions).scoped ??= []);
       const retained = scoped.flatMap((binding) => {
         if (binding.key !== mapping.key) return [binding];
@@ -2980,7 +3014,14 @@ export function createVimConfigPlan(
     );
   }
   for (const binding of keymap.scoped) {
-    add(binding.modes, binding.key, { kind: "keymap", id: binding.actionId }, binding);
+    add(
+      binding.modes,
+      binding.key,
+      binding.actionId === "escape"
+        ? { kind: "escape", id: "escape" }
+        : { kind: "keymap", id: binding.actionId },
+      binding,
+    );
   }
 
   const compileWarnings = [...warnings];

--- a/src/config.ts
+++ b/src/config.ts
@@ -680,7 +680,10 @@ function parseInsertBindings(
   value: unknown,
   sourceLabel: string,
   warnings: string[],
-  options: { allowProtectedKey?: (key: string) => boolean } = {},
+  options: {
+    allowProtectedKey?: (key: string) => boolean;
+    allowProtectedBinding?: (action: keyof ResolvedVimInsertKeymap, key: string) => boolean;
+  } = {},
 ): Partial<ResolvedVimInsertKeymap> | undefined {
   if (value === undefined) return undefined;
   if (!isRecord(value)) {
@@ -697,7 +700,9 @@ function parseInsertBindings(
     }
     const label = `${sourceLabel}: piVimMode.keymap.insert.${action}`;
     const keys = parseStringArray(bindings, label, warnings, {
-      allowProtectedKey: options.allowProtectedKey,
+      allowProtectedKey: (key) =>
+        options.allowProtectedBinding?.(action as keyof ResolvedVimInsertKeymap, key) === true ||
+        options.allowProtectedKey?.(key) === true,
     });
     if (!keys) continue;
     const filtered = keys.filter((sequence) => {
@@ -804,10 +809,12 @@ function parseActionBindingEntry(
   let rawKey: unknown;
   let rawArgs: unknown;
   let modes: VimActionBindingMode[] | undefined;
+  let allowProtected = false;
   if (typeof entry === "string") rawKey = entry;
   else if (isRecord(entry)) {
     rawKey = entry.key;
     rawArgs = entry.args;
+    allowProtected = entry.allowProtected === true;
     if (entry.modes !== undefined) {
       if (!Array.isArray(entry.modes)) {
         warnings.push(`${label} contains unsupported action binding modes`);
@@ -839,7 +846,7 @@ function parseActionBindingEntry(
     return undefined;
   }
   const protectedShortcut = protectedShortcutForKey(key);
-  if (protectedShortcut && !options.allowProtectedKey?.(key)) {
+  if (protectedShortcut && !allowProtected && !options.allowProtectedKey?.(key)) {
     warnings.push(`${label} contains protected key ${key} (${protectedShortcut.reason})`);
     return undefined;
   }
@@ -853,7 +860,13 @@ function parseActionBindingEntry(
     warnings.push(`${label}.${key}: ${normalized.message}`);
     return undefined;
   }
-  return { key, actionId, args: normalized.transform, modes };
+  return {
+    key,
+    actionId,
+    args: normalized.transform,
+    modes,
+    ...(allowProtected ? { allowProtected: true } : {}),
+  };
 }
 
 function parseActionBindings(
@@ -1001,8 +1014,18 @@ function parseKeymap(
     { allowProtectedKey },
   );
 
+  const scopedAllowProtected = (action: keyof ResolvedVimInsertKeymap, key: string) =>
+    Array.isArray(value.scoped) &&
+    value.scoped.some(
+      (binding) =>
+        isRecord(binding) &&
+        binding.actionId === `insert.${action}` &&
+        binding.key === key &&
+        binding.allowProtected === true,
+    );
   partial.insert = parseInsertBindings(value.insert, sourceLabel, warnings, {
     allowProtectedKey,
+    allowProtectedBinding: scopedAllowProtected,
   });
 
   if (value.textObjects !== undefined) {
@@ -1900,8 +1923,8 @@ function projectExactMappings(
   addRecord(keymap.macros, "macro");
   addRecord(keymap.marks, "mark");
   addRecord(keymap.insert, "insert");
-  addRecord(keymap.textObjects?.kinds, "textObjectKind");
-  addRecord(keymap.textObjects?.targets, "textObjectTarget");
+  addRecord(keymap.textObjects?.kinds, "textObject.kind");
+  addRecord(keymap.textObjects?.targets, "textObject.target");
   for (const bindings of Object.values(keymap.actions ?? {})) {
     for (const binding of bindings ?? []) {
       add(binding.key, binding.modes ?? ACTION_BINDING_MODES, binding.actionId);
@@ -1948,8 +1971,8 @@ function projectConfiguredActions(
   addRecord(keymap.macros, "macro");
   addRecord(keymap.marks, "mark");
   addRecord(keymap.insert, "insert");
-  addRecord(keymap.textObjects?.kinds, "textObjectKind");
-  addRecord(keymap.textObjects?.targets, "textObjectTarget");
+  addRecord(keymap.textObjects?.kinds, "textObject.kind");
+  addRecord(keymap.textObjects?.targets, "textObject.target");
   for (const actionId of Object.keys(keymap.actions ?? {})) {
     actions.push({ actionId, modes: ACTION_BINDING_MODES });
   }
@@ -2093,6 +2116,17 @@ function expandLeaderMappings(
     "resolved settings: piVimMode.keymap.textObjects.targets",
   );
   expandRecord(overlay.insert, "resolved settings: piVimMode.keymap.insert");
+  if (overlay.unmaps) {
+    overlay.unmaps = overlay.unmaps.flatMap((unmap) => {
+      const result = expandLeaderSequence(
+        unmap.key,
+        "resolved settings: piVimMode.keymap.unmaps",
+        context,
+      );
+      usesNonActionLeader ||= result.usesLeader;
+      return result.sequence ? [{ ...unmap, key: result.sequence }] : [];
+    });
+  }
 
   const leaderActionBindings = new Set<ResolvedVimActionBinding>();
   for (const [actionId, bindings] of Object.entries(overlay.actions ?? {})) {
@@ -2971,7 +3005,11 @@ export function createVimConfigPlan(
     binding: VimPlanBinding,
     source?: ScopedPlanSource,
   ) => {
-    for (const scope of scopes) candidates[scope].push({ sequence, binding, source });
+    for (const scope of scopes) {
+      if (!keymap.unmaps.some((unmap) => unmap.key === sequence && unmap.modes.includes(scope))) {
+        candidates[scope].push({ sequence, binding, source });
+      }
+    }
   };
 
   for (const entry of grammarEntriesForKeymap(keymap)) {
@@ -2984,11 +3022,16 @@ export function createVimConfigPlan(
       id: `${entry.family}.${entry.id}`,
     });
   }
-  for (const sequence of keymap.escape) {
-    add(["insert", "visual", "visualLine", "visualBlock", "operatorPending"], sequence, {
-      kind: "escape",
-      id: "escape",
-    });
+  for (const scope of [
+    "insert",
+    "visual",
+    "visualLine",
+    "visualBlock",
+    "operatorPending",
+  ] as const) {
+    for (const sequence of escapeAliasesForScope(keymap, scope)) {
+      add([scope], sequence, { kind: "escape", id: "escape" });
+    }
   }
   for (const [action, sequences] of Object.entries(keymap.insert)) {
     for (const sequence of sequences) add(["insert"], sequence, { kind: "insert", id: action });
@@ -3237,6 +3280,25 @@ export async function loadVimOptions(paths: VimConfigPaths = {}): Promise<VimCon
 
 export function keymapForOptions(options: ResolvedVimEditorOptions): ResolvedVimKeymap {
   return options.keymap ?? DEFAULT_VIM_KEYMAP;
+}
+
+export function escapeAliasesForScope(
+  keymap: ResolvedVimKeymap,
+  scope: Extract<
+    VimMappingScope,
+    "insert" | "visual" | "visualLine" | "visualBlock" | "operatorPending"
+  >,
+): string[] {
+  return [
+    ...keymap.escape,
+    ...keymap.scoped
+      .filter((binding) => binding.actionId === "escape" && binding.modes.includes(scope))
+      .map((binding) => binding.key),
+  ].filter(
+    (key, index, aliases) =>
+      !keymap.unmaps.some((unmap) => unmap.key === key && unmap.modes.includes(scope)) &&
+      aliases.indexOf(key) === index,
+  );
 }
 
 export function uiForOptions(options: ResolvedVimEditorOptions): ResolvedVimUi {

--- a/src/config.ts
+++ b/src/config.ts
@@ -72,6 +72,7 @@ import {
 } from "./keymap-grammar.ts";
 import {
   isAtomicMappingSequence,
+  mappingSequencePrefixes,
   mappingScopesForKeymapEntry,
   mappingSequencesOverlap,
   VIM_MAPPING_SCOPES,
@@ -810,11 +811,13 @@ function parseActionBindingEntry(
   let rawArgs: unknown;
   let modes: VimActionBindingMode[] | undefined;
   let allowProtected = false;
+  let sourceOrder: number | undefined;
   if (typeof entry === "string") rawKey = entry;
   else if (isRecord(entry)) {
     rawKey = entry.key;
     rawArgs = entry.args;
     allowProtected = entry.allowProtected === true;
+    sourceOrder = typeof entry.__sourceOrder === "number" ? entry.__sourceOrder : undefined;
     if (entry.modes !== undefined) {
       if (!Array.isArray(entry.modes)) {
         warnings.push(`${label} contains unsupported action binding modes`);
@@ -866,6 +869,7 @@ function parseActionBindingEntry(
     args: normalized.transform,
     modes,
     ...(allowProtected ? { allowProtected: true } : {}),
+    ...(sourceOrder === undefined ? {} : { __sourceOrder: sourceOrder }),
   };
 }
 
@@ -1973,6 +1977,12 @@ function projectConfiguredActions(
   addRecord(keymap.insert, "insert");
   addRecord(keymap.textObjects?.kinds, "textObject.kind");
   addRecord(keymap.textObjects?.targets, "textObject.target");
+  if (keymap.escape !== undefined) {
+    actions.push({
+      actionId: "escape",
+      modes: ["insert", "visual", "visualLine", "visualBlock", "operatorPending"],
+    });
+  }
   for (const actionId of Object.keys(keymap.actions ?? {})) {
     actions.push({ actionId, modes: ACTION_BINDING_MODES });
   }
@@ -2696,7 +2706,7 @@ function restoreJsUnmaps(
 
 function partialFromJsOperations(operations: readonly VimJsConfigOperation[]): VimEditorOptions {
   const partial: VimEditorOptions = {};
-  for (const operation of operations) {
+  for (const [sourceOrder, operation] of operations.entries()) {
     if (operation.kind === "preset") {
       partial.preset = operation.preset;
       continue;
@@ -2722,6 +2732,7 @@ function partialFromJsOperations(operations: readonly VimJsConfigOperation[]): V
         modes: ["insert"],
         allowProtected: mapping.allowProtected,
         desc: mapping.desc,
+        __sourceOrder: sourceOrder,
       });
       (keymap as PartialKeymapOptions).scoped = scoped;
       continue;
@@ -2738,6 +2749,7 @@ function partialFromJsOperations(operations: readonly VimJsConfigOperation[]): V
           modes: mapping.modes,
           allowProtected: mapping.allowProtected,
           desc: mapping.desc,
+          __sourceOrder: sourceOrder,
         },
       ];
       continue;
@@ -2767,6 +2779,7 @@ function partialFromJsOperations(operations: readonly VimJsConfigOperation[]): V
         args: mapping.args,
         allowProtected: mapping.allowProtected,
         desc: mapping.desc,
+        __sourceOrder: sourceOrder,
       });
       (keymap as PartialKeymapOptions).scoped = retained;
       continue;
@@ -2776,7 +2789,12 @@ function partialFromJsOperations(operations: readonly VimJsConfigOperation[]): V
     const remaps = (keymap.remaps ??= { accepted: [] });
     remaps.accepted = [
       ...remaps.accepted,
-      { key: mapping.key, inputs: mapping.inputs, modes: mapping.modes },
+      {
+        key: mapping.key,
+        inputs: mapping.inputs,
+        modes: mapping.modes,
+        __sourceOrder: sourceOrder,
+      },
     ];
   }
   return partial;
@@ -2905,17 +2923,8 @@ function deepFreeze<T>(value: T): T {
   return Object.freeze(value);
 }
 
-function isAtomicMapping(sequence: string): boolean {
-  return isAtomicMappingSequence(sequence);
-}
-
 function hasStrictPrefixConflict(left: string, right: string): boolean {
-  return (
-    left !== right &&
-    !isAtomicMapping(left) &&
-    !isAtomicMapping(right) &&
-    (left.startsWith(right) || right.startsWith(left))
-  );
+  return left !== right && mappingSequencesOverlap(left, right);
 }
 
 function strictPrefixConflict<T>(
@@ -2982,9 +2991,7 @@ function compilePlanScope(
 
   const prefixes = Object.create(null) as Record<string, string[]>;
   for (const sequence of Object.keys(exact)) {
-    if (isAtomicMapping(sequence)) continue;
-    for (let index = 1; index < sequence.length; index += 1) {
-      const prefix = sequence.slice(0, index);
+    for (const prefix of mappingSequencePrefixes(sequence)) {
       (prefixes[prefix] ??= []).push(sequence);
     }
   }
@@ -3068,6 +3075,12 @@ export function createVimConfigPlan(
     );
   }
 
+  for (const scope of VIM_MAPPING_SCOPES) {
+    candidates[scope].sort(
+      (left, right) => (left.source?.__sourceOrder ?? -1) - (right.source?.__sourceOrder ?? -1),
+    );
+  }
+
   const compileWarnings = [...warnings];
   const acceptedScopes = new Map<ScopedPlanSource, Set<VimMappingScope>>();
   const scopes = Object.fromEntries(
@@ -3087,6 +3100,9 @@ export function createVimConfigPlan(
       acceptedScopes,
     );
     planOptions.keymap.scoped = retainAcceptedScopes(planOptions.keymap.scoped, acceptedScopes);
+    for (const binding of planOptions.keymap.actions.accepted) delete binding.__sourceOrder;
+    for (const remap of planOptions.keymap.remaps.accepted) delete remap.__sourceOrder;
+    for (const binding of planOptions.keymap.scoped) delete binding.__sourceOrder;
   }
   return deepFreeze({
     options: planOptions,

--- a/src/config.ts
+++ b/src/config.ts
@@ -199,6 +199,7 @@ export const DEFAULT_VIM_KEYMAP = Object.freeze({
     accepted: Object.freeze([]),
   }),
   scoped: Object.freeze([]),
+  unmaps: Object.freeze([]),
 }) as unknown as ResolvedVimKeymap;
 
 export const DEFAULT_VIM_UI = Object.freeze({
@@ -473,6 +474,7 @@ function cloneKeymap(keymap: ResolvedVimKeymap = DEFAULT_VIM_KEYMAP): ResolvedVi
       modes: [...binding.modes],
       args: binding.args ? { ...binding.args } : undefined,
     })),
+    unmaps: keymap.unmaps.map((unmap) => ({ ...unmap, modes: [...unmap.modes] })),
   };
 }
 
@@ -1742,6 +1744,7 @@ function mergeOperatorMotions(
 }
 
 function mergeKeymap(target: ResolvedVimKeymap, partial: PartialKeymapOptions): void {
+  target.unmaps = [...target.unmaps, ...(partial.unmaps ?? [])];
   for (const unmap of partial.unmaps ?? []) {
     if (unmap.modes.includes("insert")) {
       for (const action of Object.keys(target.insert) as Array<keyof ResolvedVimInsertKeymap>) {
@@ -2918,7 +2921,11 @@ export function createVimConfigPlan(
   };
 
   for (const entry of grammarEntriesForKeymap(keymap)) {
-    add(mappingScopesForKeymapEntry(entry.family, entry.id), entry.sequence, {
+    const scopes = mappingScopesForKeymapEntry(entry.family, entry.id).filter(
+      (scope) =>
+        !keymap.unmaps.some((unmap) => unmap.key === entry.sequence && unmap.modes.includes(scope)),
+    );
+    add(scopes, entry.sequence, {
       kind: "keymap",
       id: `${entry.family}.${entry.id}`,
     });

--- a/src/config.ts
+++ b/src/config.ts
@@ -2158,6 +2158,7 @@ function expandLeaderMappings(
         `resolved settings: piVimMode.keymap.${binding.actionId}`,
         context,
       );
+      usesNonActionLeader ||= result.usesLeader;
       return result.sequence ? [{ ...binding, key: result.sequence }] : [];
     });
   }

--- a/src/config.ts
+++ b/src/config.ts
@@ -71,7 +71,10 @@ import {
   grammarEntriesForKeymap,
 } from "./keymap-grammar.ts";
 import {
+  displayMappingSequence,
+  encodeMappingTokens,
   isAtomicMappingSequence,
+  MAPPING_TOKEN_SEPARATOR,
   mappingSequencePrefixes,
   mappingScopesForKeymapEntry,
   mappingSequencesOverlap,
@@ -655,6 +658,7 @@ function parseStringArray(
 }
 
 function isPrintableTextSequence(sequence: string): boolean {
+  if (sequence.includes(MAPPING_TOKEN_SEPARATOR)) return true;
   if (isAtomicMappingSequence(sequence)) return false;
   return [...sequence].every((char) => char.charCodeAt(0) >= 32);
 }
@@ -671,7 +675,9 @@ function parseInsertEscapeArray(
   const sequences = parseStringArray(value, label, warnings, options);
   const parsed = sequences?.filter((sequence) => {
     if (!isPrintableTextSequence(sequence)) return true;
-    warnings.push(`${label} contains unsupported printable text sequence ${sequence}`);
+    warnings.push(
+      `${label} contains unsupported printable text sequence ${sequence.replaceAll(MAPPING_TOKEN_SEPARATOR, "")}`,
+    );
     return false;
   });
   return parsed && parsed.length > 0 ? parsed : undefined;
@@ -708,7 +714,9 @@ function parseInsertBindings(
     if (!keys) continue;
     const filtered = keys.filter((sequence) => {
       if (!isPrintableTextSequence(sequence)) return true;
-      warnings.push(`${label} contains unsupported printable text sequence ${sequence}`);
+      warnings.push(
+        `${label} contains unsupported printable text sequence ${sequence.replaceAll(MAPPING_TOKEN_SEPARATOR, "")}`,
+      );
       return false;
     });
     if (filtered.length > 0) {
@@ -2026,7 +2034,7 @@ function expandLeaderSequence(
     context.warnings.push(`${label} uses <leader> but piVimMode.leader is unset`);
     return { usesLeader: false };
   }
-  const suffix = sequence.replace(/^(?:<leader>)+/i, "");
+  const suffix = sequence.replace(/^(?:<leader>)+/i, "").replaceAll(MAPPING_TOKEN_SEPARATOR, "");
   const protectedShortcut = protectedShortcutForKey(suffix);
   if (protectedShortcut) {
     context.warnings.push(
@@ -2038,8 +2046,15 @@ function expandLeaderSequence(
     context.warnings.push(`${label} cannot bind a lone <leader>`);
     return { usesLeader: false };
   }
+  const expanded = sequence.includes(MAPPING_TOKEN_SEPARATOR)
+    ? encodeMappingTokens(
+        sequence
+          .split(MAPPING_TOKEN_SEPARATOR)
+          .map((token) => (token.toLowerCase() === LEADER_TOKEN ? context.leader! : token)),
+      )
+    : sequence.replace(LEADER_TOKEN_PATTERN, context.leader);
   return {
-    sequence: context.expand ? sequence.replace(LEADER_TOKEN_PATTERN, context.leader) : sequence,
+    sequence: context.expand ? expanded : sequence,
     usesLeader: true,
   };
 }
@@ -3106,7 +3121,7 @@ export function createVimConfigPlan(
   }
   return deepFreeze({
     options: planOptions,
-    diagnostics: { warnings: compileWarnings },
+    diagnostics: { warnings: compileWarnings.map(displayMappingSequence) },
     scopes,
   });
 }

--- a/src/config.ts
+++ b/src/config.ts
@@ -198,6 +198,7 @@ export const DEFAULT_VIM_KEYMAP = Object.freeze({
   remaps: Object.freeze({
     accepted: Object.freeze([]),
   }),
+  scoped: Object.freeze([]),
 }) as unknown as ResolvedVimKeymap;
 
 export const DEFAULT_VIM_UI = Object.freeze({
@@ -357,7 +358,8 @@ type PartialKeymapOptions = {
   presetActionBindings?: ResolvedVimActionBinding[];
   actions?: Partial<Record<BindablePromptTransformActionId, ResolvedVimActionBinding[]>>;
   remaps?: ResolvedVimKeymap["remaps"];
-  unmaps?: Array<{ key: string; modes: readonly VimMode[] }>;
+  scoped?: ResolvedVimKeymap["scoped"];
+  unmaps?: Array<{ key: string; modes: readonly VimMappingScope[] }>;
   allowProtectedOverrides?: string[];
 };
 
@@ -466,6 +468,11 @@ function cloneKeymap(keymap: ResolvedVimKeymap = DEFAULT_VIM_KEYMAP): ResolvedVi
         modes: binding.modes ? [...binding.modes] : undefined,
       })),
     },
+    scoped: keymap.scoped.map((binding) => ({
+      ...binding,
+      modes: [...binding.modes],
+      args: binding.args ? { ...binding.args } : undefined,
+    })),
   };
 }
 
@@ -1700,14 +1707,14 @@ function removeTopLevelKeymapSequences(target: ResolvedVimKeymap, sequences: Set
 
 function remainingScopedModes(
   modes: readonly VimActionBindingMode[] | undefined,
-  removedModes: readonly VimMode[],
+  removedModes: readonly VimMappingScope[],
 ): readonly VimActionBindingMode[] {
   return (modes ?? ACTION_BINDING_MODES).filter((mode) => !removedModes.includes(mode));
 }
 
 function removeScopedKeymapBindings(
   target: ResolvedVimKeymap,
-  unmap: { key: string; modes: readonly VimMode[] },
+  unmap: { key: string; modes: readonly VimMappingScope[] },
 ): void {
   target.actions.accepted = target.actions.accepted.flatMap((binding) => {
     if (binding.key !== unmap.key) return [binding];
@@ -1718,6 +1725,11 @@ function removeScopedKeymapBindings(
     if (mapping.key !== unmap.key) return [mapping];
     const modes = remainingScopedModes(mapping.modes, unmap.modes);
     return modes.length ? [{ ...mapping, modes }] : [];
+  });
+  target.scoped = target.scoped.flatMap((binding) => {
+    if (binding.key !== unmap.key) return [binding];
+    const modes = binding.modes.filter((mode) => !unmap.modes.includes(mode));
+    return modes.length ? [{ ...binding, modes }] : [];
   });
 }
 
@@ -1765,6 +1777,18 @@ function mergeKeymap(target: ResolvedVimKeymap, partial: PartialKeymapOptions): 
   if (partial.remaps) {
     target.remaps = { accepted: [...target.remaps.accepted, ...partial.remaps.accepted] };
   }
+  if (partial.scoped) {
+    for (const binding of partial.scoped) {
+      target.scoped = [
+        ...target.scoped.flatMap((current) => {
+          if (current.key !== binding.key) return [current];
+          const modes = current.modes.filter((mode) => !binding.modes.includes(mode));
+          return modes.length ? [{ ...current, modes }] : [];
+        }),
+        binding,
+      ];
+    }
+  }
   for (const unmap of partial.unmaps ?? []) removeScopedKeymapBindings(target, unmap);
 }
 
@@ -1790,6 +1814,7 @@ function additiveKeymapLayer(
     }
     next.actions = actions;
   }
+  if (partial.scoped) next.scoped = [...(base.scoped ?? []), ...partial.scoped];
   return next;
 }
 
@@ -1833,6 +1858,7 @@ function mergeKeymapOverlay(target: PartialKeymapOptions, partial: PartialKeymap
   if (partial.remaps) {
     target.remaps = { accepted: [...(target.remaps?.accepted ?? []), ...partial.remaps.accepted] };
   }
+  if (partial.scoped) target.scoped = [...(target.scoped ?? []), ...partial.scoped];
   if (partial.unmaps) target.unmaps = [...(target.unmaps ?? []), ...partial.unmaps];
 }
 
@@ -2538,10 +2564,14 @@ function removeJsMappings(
   }
 }
 
+function editorModes(modes: readonly VimMappingScope[]): VimMode[] {
+  return modes.filter((mode): mode is VimMode => mode !== "operatorPending");
+}
+
 function restoreJsUnmaps(
   keymap: PartialKeymapOptions,
   key: string,
-  modes: readonly VimMode[],
+  modes: readonly VimMappingScope[],
 ): void {
   keymap.unmaps = keymap.unmaps?.flatMap((unmap) => {
     if (unmap.key !== key) return [unmap];
@@ -2560,7 +2590,7 @@ function partialFromJsOperations(operations: readonly VimJsConfigOperation[]): V
     if (operation.kind === "leaf") continue;
     const keymap = (partial.keymap ??= {});
     if (operation.kind === "unmap") {
-      removeJsMappings(keymap as PartialKeymapOptions, operation.key, operation.modes);
+      removeJsMappings(keymap as PartialKeymapOptions, operation.key, editorModes(operation.modes));
       const unmaps = ((keymap as PartialKeymapOptions).unmaps ??= []);
       unmaps.push({ key: operation.key, modes: operation.modes });
       continue;
@@ -2591,6 +2621,24 @@ function partialFromJsOperations(operations: readonly VimJsConfigOperation[]): V
         ...(commands[mapping.command as VimCommandAction] ?? []),
         mapping.key,
       ];
+      continue;
+    }
+    if (mapping.kind === "descriptor") {
+      restoreJsUnmaps(keymap as PartialKeymapOptions, mapping.key, mapping.modes);
+      const scoped = ((keymap as PartialKeymapOptions).scoped ??= []);
+      const retained = scoped.flatMap((binding) => {
+        if (binding.key !== mapping.key) return [binding];
+        const modes = binding.modes.filter((mode) => !mapping.modes.includes(mode));
+        return modes.length ? [{ ...binding, modes }] : [];
+      });
+      retained.push({
+        actionId: mapping.actionId,
+        key: mapping.key,
+        modes: mapping.modes,
+        args: mapping.args,
+        desc: mapping.desc,
+      });
+      (keymap as PartialKeymapOptions).scoped = retained;
       continue;
     }
     removeJsMappings(keymap as PartialKeymapOptions, mapping.key, mapping.modes);
@@ -2636,6 +2684,7 @@ function appendJsMapLayer(
   warnings.push(...parsed.warnings);
   const layer = additiveKeymapLayer(keymapLayers, parsed.partial.keymap);
   layer.unmaps = rawKeymap?.unmaps;
+  layer.scoped = rawKeymap?.scoped;
   keymapLayers.push(layer);
 }
 
@@ -2855,6 +2904,12 @@ export function createVimConfigPlan(
       { kind: "remap", id: "remap", inputs: remap.inputs },
       remap,
     );
+  }
+  for (const binding of keymap.scoped) {
+    add(binding.modes, binding.key, {
+      kind: "keymap",
+      id: binding.actionId,
+    });
   }
 
   const compileWarnings = [...warnings];

--- a/src/config.ts
+++ b/src/config.ts
@@ -819,12 +819,18 @@ function parseActionBindingEntry(
   let rawArgs: unknown;
   let modes: VimActionBindingMode[] | undefined;
   let allowProtected = false;
+  let desc: string | undefined;
   let sourceOrder: number | undefined;
   if (typeof entry === "string") rawKey = entry;
   else if (isRecord(entry)) {
     rawKey = entry.key;
     rawArgs = entry.args;
     allowProtected = entry.allowProtected === true;
+    if (entry.desc !== undefined && typeof entry.desc !== "string") {
+      warnings.push(`${label} contains unsupported action binding description`);
+      return undefined;
+    }
+    desc = entry.desc;
     sourceOrder = typeof entry.__sourceOrder === "number" ? entry.__sourceOrder : undefined;
     if (entry.modes !== undefined) {
       if (!Array.isArray(entry.modes)) {
@@ -877,6 +883,7 @@ function parseActionBindingEntry(
     args: normalized.transform,
     modes,
     ...(allowProtected ? { allowProtected: true } : {}),
+    ...(desc === undefined ? {} : { desc }),
     ...(sourceOrder === undefined ? {} : { __sourceOrder: sourceOrder }),
   };
 }
@@ -2808,6 +2815,8 @@ function partialFromJsOperations(operations: readonly VimJsConfigOperation[]): V
         key: mapping.key,
         inputs: mapping.inputs,
         modes: mapping.modes,
+        allowProtected: mapping.allowProtected,
+        desc: mapping.desc,
         __sourceOrder: sourceOrder,
       },
     ];

--- a/src/config.ts
+++ b/src/config.ts
@@ -1876,43 +1876,52 @@ function projectExactMappings(
   leader?: string | null,
 ): ProjectExactMapping[] {
   const mappings: ProjectExactMapping[] = [];
-  const add = (key: string, modes: readonly VimMode[]) => {
+  const add = (key: string, modes: readonly VimMappingScope[], actionId?: string) => {
     const finalKey = leader === undefined ? key : resolvedLeaderKey(key, leader ?? undefined);
-    if (finalKey) mappings.push({ key: finalKey, modes });
+    if (finalKey) mappings.push({ key: finalKey, modes, actionId });
   };
   const addRecord = (
     record: Partial<Record<string, readonly string[]>> | undefined,
-    modes: readonly VimMode[],
+    modes: readonly VimMappingScope[],
+    family: string,
   ) => {
-    for (const bindings of Object.values(record ?? {})) {
-      for (const key of bindings ?? []) add(key, modes);
+    for (const [action, bindings] of Object.entries(record ?? {})) {
+      for (const key of bindings ?? []) add(key, modes, `${family}.${action}`);
     }
   };
 
   for (const key of keymap.escape ?? []) {
     add(key, ["insert", "visual", "visualLine", "visualBlock"]);
   }
-  addRecord(keymap.operators, ACTION_BINDING_MODES);
-  addRecord(keymap.motions, ACTION_BINDING_MODES);
-  addRecord(keymap.commands, ["normal"]);
-  addRecord(keymap.macros, ["normal"]);
-  addRecord(keymap.marks, ACTION_BINDING_MODES);
-  addRecord(keymap.insert, ["insert"]);
+  addRecord(keymap.operators, ACTION_BINDING_MODES, "operator");
+  addRecord(keymap.motions, [...ACTION_BINDING_MODES, "operatorPending"], "motion");
+  addRecord(keymap.commands, ["normal"], "command");
+  addRecord(keymap.macros, ["normal"], "macro");
+  addRecord(keymap.marks, ACTION_BINDING_MODES, "mark");
+  addRecord(keymap.insert, ["insert"], "insert");
   for (const bindings of Object.values(keymap.actions ?? {})) {
     for (const binding of bindings ?? []) {
-      add(binding.key, binding.modes ?? ACTION_BINDING_MODES);
+      add(binding.key, binding.modes ?? ACTION_BINDING_MODES, binding.actionId);
     }
   }
   for (const remap of keymap.remaps?.accepted ?? []) {
     add(remap.key, remap.modes ?? ACTION_BINDING_MODES);
   }
-  for (const binding of keymap.scoped ?? []) {
-    add(
-      binding.key,
-      binding.modes.filter((mode): mode is VimMode => mode !== "operatorPending"),
-    );
-  }
+  for (const binding of keymap.scoped ?? []) add(binding.key, binding.modes, binding.actionId);
   return mappings;
+}
+
+function removeJsActionMappings(
+  keymap: PartialKeymapOptions,
+  actionId: string,
+  modes: readonly VimMappingScope[],
+): void {
+  if (!keymap.scoped) return;
+  keymap.scoped = keymap.scoped.flatMap((binding) => {
+    if (binding.actionId !== actionId) return [binding];
+    const remaining = binding.modes.filter((mode) => !modes.includes(mode));
+    return remaining.length ? [{ ...binding, modes: remaining }] : [];
+  });
 }
 
 function applyProjectExactPrecedence(
@@ -1923,6 +1932,7 @@ function applyProjectExactPrecedence(
   for (const mapping of projectExactMappings(project, leader ?? null)) {
     for (const layer of lowerLayers) {
       removeJsMappings(layer, mapping.key, mapping.modes, leader ?? null);
+      if (mapping.actionId) removeJsActionMappings(layer, mapping.actionId, mapping.modes);
     }
   }
 }
@@ -2243,7 +2253,11 @@ function mergeUi(target: ResolvedVimUi, partial: PartialUiOptions): void {
   if (partial.workbench) target.workbench = { ...target.workbench, ...partial.workbench };
 }
 
-type ProjectExactMapping = { key: string; modes: readonly VimMode[] };
+type ProjectExactMapping = {
+  key: string;
+  modes: readonly VimMappingScope[];
+  actionId?: string;
+};
 
 function actionBindingModes(binding: ResolvedVimActionBinding): readonly VimActionBindingMode[] {
   return binding.modes ?? ACTION_BINDING_MODES;
@@ -2551,7 +2565,7 @@ function mergePartialOptions(target: ResolvedVimEditorOptions, partial: PartialV
 function removeJsMappings(
   keymap: PartialKeymapOptions,
   key: string,
-  modes: readonly VimMode[],
+  modes: readonly VimMappingScope[],
   leader?: string | null,
 ): void {
   const matchesKey = (candidate: string) =>
@@ -2731,7 +2745,13 @@ function appendJsMapLayer(
   warnings.push(...parsed.warnings);
   const layer = additiveKeymapLayer(keymapLayers, parsed.partial.keymap);
   layer.unmaps = rawKeymap?.unmaps;
-  layer.scoped = rawKeymap?.scoped;
+  // Parsed insert bindings carry existing key-shape and protected-shortcut validation.
+  // Do not restore raw descriptor entries that validation rejected.
+  layer.scoped = rawKeymap?.scoped?.filter((binding) => {
+    if (!binding.actionId.startsWith("insert.")) return true;
+    const action = binding.actionId.slice("insert.".length) as keyof ResolvedVimInsertKeymap;
+    return parsed.partial.keymap?.insert?.[action]?.includes(binding.key) ?? false;
+  });
   keymapLayers.push(layer);
 }
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -1903,6 +1903,12 @@ function projectExactMappings(
   for (const remap of keymap.remaps?.accepted ?? []) {
     add(remap.key, remap.modes ?? ACTION_BINDING_MODES);
   }
+  for (const binding of keymap.scoped ?? []) {
+    add(
+      binding.key,
+      binding.modes.filter((mode): mode is VimMode => mode !== "operatorPending"),
+    );
+  }
   return mappings;
 }
 
@@ -2061,6 +2067,17 @@ function expandLeaderMappings(
     const typedActionId = actionId as BindablePromptTransformActionId;
     if (expanded.length > 0 || bindings.length === 0) overlay.actions![typedActionId] = expanded;
     else delete overlay.actions![typedActionId];
+  }
+
+  if (overlay.scoped) {
+    overlay.scoped = overlay.scoped.flatMap((binding) => {
+      const result = expandLeaderSequence(
+        binding.key,
+        `resolved settings: piVimMode.keymap.${binding.actionId}`,
+        context,
+      );
+      return result.sequence ? [{ ...binding, key: result.sequence }] : [];
+    });
   }
 
   if (overlay.remaps) {
@@ -2562,6 +2579,13 @@ function removeJsMappings(
       return remainingModes.length ? [{ ...mapping, modes: remainingModes }] : [];
     });
   }
+  if (keymap.scoped) {
+    keymap.scoped = keymap.scoped.flatMap((binding) => {
+      if (!matchesKey(binding.key)) return [binding];
+      const remainingModes = binding.modes.filter((mode) => !modes.includes(mode as VimMode));
+      return remainingModes.length ? [{ ...binding, modes: remainingModes }] : [];
+    });
+  }
 }
 
 function editorModes(modes: readonly VimMappingScope[]): VimMode[] {
@@ -2601,6 +2625,15 @@ function partialFromJsOperations(operations: readonly VimJsConfigOperation[]): V
       restoreJsUnmaps(keymap as PartialKeymapOptions, mapping.key, ["insert"]);
       const insert = (keymap.insert ??= {});
       insert[mapping.action] = [...(insert[mapping.action] ?? []), mapping.key];
+      const scoped = [...((keymap as PartialKeymapOptions).scoped ?? [])];
+      scoped.push({
+        actionId: `insert.${mapping.action}`,
+        key: mapping.key,
+        modes: ["insert"],
+        allowProtected: mapping.allowProtected,
+        desc: mapping.desc,
+      });
+      (keymap as PartialKeymapOptions).scoped = scoped;
       continue;
     }
     if (mapping.kind === "action") {
@@ -2609,7 +2642,13 @@ function partialFromJsOperations(operations: readonly VimJsConfigOperation[]): V
       const actions = (keymap.actions ??= {});
       actions[mapping.actionId] = [
         ...(actions[mapping.actionId] ?? []),
-        { key: mapping.key, args: mapping.args, modes: mapping.modes },
+        {
+          key: mapping.key,
+          args: mapping.args,
+          modes: mapping.modes,
+          allowProtected: mapping.allowProtected,
+          desc: mapping.desc,
+        },
       ];
       continue;
     }
@@ -2625,6 +2664,10 @@ function partialFromJsOperations(operations: readonly VimJsConfigOperation[]): V
     }
     if (mapping.kind === "descriptor") {
       restoreJsUnmaps(keymap as PartialKeymapOptions, mapping.key, mapping.modes);
+      if (mapping.actionId === "escape") {
+        keymap.escape = [...(keymap.escape ?? []), mapping.key];
+        continue;
+      }
       const scoped = ((keymap as PartialKeymapOptions).scoped ??= []);
       const retained = scoped.flatMap((binding) => {
         if (binding.key !== mapping.key) return [binding];
@@ -2636,6 +2679,7 @@ function partialFromJsOperations(operations: readonly VimJsConfigOperation[]): V
         key: mapping.key,
         modes: mapping.modes,
         args: mapping.args,
+        allowProtected: mapping.allowProtected,
         desc: mapping.desc,
       });
       (keymap as PartialKeymapOptions).scoped = retained;
@@ -2791,7 +2835,10 @@ function strictPrefixConflict<T>(
 }
 
 type ResolvedVimRemap = ResolvedVimKeymap["remaps"]["accepted"][number];
-type ScopedPlanSource = ResolvedVimActionBinding | ResolvedVimRemap;
+type ScopedPlanSource =
+  | ResolvedVimActionBinding
+  | ResolvedVimRemap
+  | ResolvedVimKeymap["scoped"][number];
 type VimPlanCandidate = {
   sequence: string;
   binding: VimPlanBinding;
@@ -2906,10 +2953,7 @@ export function createVimConfigPlan(
     );
   }
   for (const binding of keymap.scoped) {
-    add(binding.modes, binding.key, {
-      kind: "keymap",
-      id: binding.actionId,
-    });
+    add(binding.modes, binding.key, { kind: "keymap", id: binding.actionId }, binding);
   }
 
   const compileWarnings = [...warnings];
@@ -2930,6 +2974,7 @@ export function createVimConfigPlan(
       planOptions.keymap.remaps.accepted,
       acceptedScopes,
     );
+    planOptions.keymap.scoped = retainAcceptedScopes(planOptions.keymap.scoped, acceptedScopes);
   }
   return deepFreeze({
     options: planOptions,

--- a/src/customization.ts
+++ b/src/customization.ts
@@ -16,6 +16,7 @@ import {
   diagnosticActionMessage,
   type DiagnosticActionEntry,
 } from "./diagnostic-actions.ts";
+import { displayMappingSequence } from "./mapping-scopes.ts";
 import {
   PROMPT_TRANSFORM_ACTIONS,
   canonicalPromptTransformActionIdForShortName,
@@ -393,7 +394,10 @@ export function actionEntriesForKeymap(
     }
   }
   entries.push(...diagnosticActionEntries().map(diagnosticActionEntry));
-  return entries;
+  return entries.map((entry) => ({
+    ...entry,
+    keys: entry.keys.map(displayMappingSequence),
+  }));
 }
 
 export function searchActions(

--- a/src/mapping-scopes.ts
+++ b/src/mapping-scopes.ts
@@ -37,9 +37,39 @@ const NAMED_TERMINAL_KEYS = new Set([
   "right",
 ]);
 
+function modifiedKeyTokenLength(sequence: string): number | undefined {
+  const modifiers = /^(?:(?:shift|ctrl|alt|super)\+)+/.exec(sequence)?.[0];
+  if (!modifiers) return undefined;
+  const keyAndRest = sequence.slice(modifiers.length);
+  if (!keyAndRest) return undefined;
+  const namedKey = [...NAMED_TERMINAL_KEYS]
+    .sort((left, right) => right.length - left.length)
+    .find((key) => keyAndRest.startsWith(key));
+  const functionKey = /^f\d+/.exec(keyAndRest)?.[0];
+  const key = namedKey ?? functionKey ?? [...keyAndRest][0];
+  return key ? modifiers.length + key.length : undefined;
+}
+
+export function mappingSequencePrefixes(sequence: string): string[] {
+  const modifiedLength = modifiedKeyTokenLength(sequence);
+  if (modifiedLength === sequence.length) return [];
+  if (!modifiedLength) {
+    if (NAMED_TERMINAL_KEYS.has(sequence) || /^f\d+$/.test(sequence)) return [];
+    return Array.from({ length: Math.max(0, sequence.length - 1) }, (_, index) =>
+      sequence.slice(0, index + 1),
+    );
+  }
+  const prefixes = [sequence.slice(0, modifiedLength)];
+  for (let index = modifiedLength + 1; index < sequence.length; index += 1) {
+    prefixes.push(sequence.slice(0, index));
+  }
+  return prefixes;
+}
+
 export function isAtomicMappingSequence(sequence: string): boolean {
+  const modifiedLength = modifiedKeyTokenLength(sequence);
   return (
-    /^(?:ctrl|alt|shift|super)(?:\+(?:ctrl|alt|shift|super))*\+[^+]+$/.test(sequence) ||
+    modifiedLength === sequence.length ||
     NAMED_TERMINAL_KEYS.has(sequence) ||
     /^f\d+$/.test(sequence)
   );
@@ -47,8 +77,9 @@ export function isAtomicMappingSequence(sequence: string): boolean {
 
 export function mappingSequencesOverlap(left: string, right: string): boolean {
   if (left === right) return true;
-  if (isAtomicMappingSequence(left) || isAtomicMappingSequence(right)) return false;
-  return left.startsWith(right) || right.startsWith(left);
+  return (
+    mappingSequencePrefixes(left).includes(right) || mappingSequencePrefixes(right).includes(left)
+  );
 }
 
 const VISUAL_SCOPES = ["visual", "visualLine", "visualBlock"] as const;

--- a/src/mapping-scopes.ts
+++ b/src/mapping-scopes.ts
@@ -37,39 +37,37 @@ const NAMED_TERMINAL_KEYS = new Set([
   "right",
 ]);
 
-function modifiedKeyTokenLength(sequence: string): number | undefined {
-  const modifiers = /^(?:(?:shift|ctrl|alt|super)\+)+/.exec(sequence)?.[0];
-  if (!modifiers) return undefined;
-  const keyAndRest = sequence.slice(modifiers.length);
+const SORTED_NAMED_TERMINAL_KEYS = [...NAMED_TERMINAL_KEYS].sort(
+  (left, right) => right.length - left.length,
+);
+
+function mappingTokenLengthAt(sequence: string, offset: number): number | undefined {
+  const rest = sequence.slice(offset);
+  const modifiers = /^(?:(?:shift|ctrl|alt|super)\+)+/.exec(rest)?.[0] ?? "";
+  const keyAndRest = rest.slice(modifiers.length);
   if (!keyAndRest) return undefined;
-  const namedKey = [...NAMED_TERMINAL_KEYS]
-    .sort((left, right) => right.length - left.length)
-    .find((key) => keyAndRest.startsWith(key));
+  const namedKey = SORTED_NAMED_TERMINAL_KEYS.find((key) => keyAndRest.startsWith(key));
   const functionKey = /^f\d+/.exec(keyAndRest)?.[0];
   const key = namedKey ?? functionKey ?? [...keyAndRest][0];
   return key ? modifiers.length + key.length : undefined;
 }
 
 export function mappingSequencePrefixes(sequence: string): string[] {
-  const modifiedLength = modifiedKeyTokenLength(sequence);
-  if (modifiedLength === sequence.length) return [];
-  if (!modifiedLength) {
-    if (NAMED_TERMINAL_KEYS.has(sequence) || /^f\d+$/.test(sequence)) return [];
-    return Array.from({ length: Math.max(0, sequence.length - 1) }, (_, index) =>
-      sequence.slice(0, index + 1),
-    );
-  }
-  const prefixes = [sequence.slice(0, modifiedLength)];
-  for (let index = modifiedLength + 1; index < sequence.length; index += 1) {
-    prefixes.push(sequence.slice(0, index));
+  const prefixes: string[] = [];
+  let offset = 0;
+  while (offset < sequence.length) {
+    const tokenLength = mappingTokenLengthAt(sequence, offset);
+    if (!tokenLength) break;
+    offset += tokenLength;
+    if (offset < sequence.length) prefixes.push(sequence.slice(0, offset));
   }
   return prefixes;
 }
 
 export function isAtomicMappingSequence(sequence: string): boolean {
-  const modifiedLength = modifiedKeyTokenLength(sequence);
   return (
-    modifiedLength === sequence.length ||
+    (/^(?:(?:shift|ctrl|alt|super)\+)+/.test(sequence) &&
+      mappingTokenLengthAt(sequence, 0) === sequence.length) ||
     NAMED_TERMINAL_KEYS.has(sequence) ||
     /^f\d+$/.test(sequence)
   );

--- a/src/mapping-scopes.ts
+++ b/src/mapping-scopes.ts
@@ -40,6 +40,26 @@ const NAMED_TERMINAL_KEYS = new Set([
 const SORTED_NAMED_TERMINAL_KEYS = [...NAMED_TERMINAL_KEYS].sort(
   (left, right) => right.length - left.length,
 );
+export const MAPPING_TOKEN_SEPARATOR = "\u0000";
+
+export function displayMappingSequence(sequence: string): string {
+  return sequence.replaceAll(MAPPING_TOKEN_SEPARATOR, "");
+}
+
+export function encodeMappingTokens(tokens: readonly string[]): string {
+  if (tokens.length <= 1) return tokens[0] ?? "";
+  const raw = tokens.join("");
+  const hasAmbiguousTerminalSpelling = tokens.some((_, index) => {
+    const suffix = tokens.slice(index).join("");
+    return (
+      SORTED_NAMED_TERMINAL_KEYS.some((key) => suffix.startsWith(key)) ||
+      /^(?:(?:shift|ctrl|alt|super)\+)+/.test(suffix)
+    );
+  });
+  return tokens.some((token) => [...token].length !== 1) || hasAmbiguousTerminalSpelling
+    ? tokens.join(MAPPING_TOKEN_SEPARATOR)
+    : raw;
+}
 
 function mappingTokenLengthAt(sequence: string, offset: number): number | undefined {
   const rest = sequence.slice(offset);
@@ -53,6 +73,11 @@ function mappingTokenLengthAt(sequence: string, offset: number): number | undefi
 }
 
 export function mappingSequencePrefixes(sequence: string): string[] {
+  if (sequence.includes(MAPPING_TOKEN_SEPARATOR)) {
+    const tokens = sequence.split(MAPPING_TOKEN_SEPARATOR);
+    return tokens.slice(1).map((_, index) => encodeMappingTokens(tokens.slice(0, index + 1)));
+  }
+
   const prefixes: string[] = [];
   let offset = 0;
   while (offset < sequence.length) {

--- a/src/mapping-scopes.ts
+++ b/src/mapping-scopes.ts
@@ -66,9 +66,7 @@ export function mappingScopesForKeymapEntry(
   if (family === "operator") return NORMAL_AND_VISUAL_SCOPES;
   if (family === "command" || family === "macro") return ["normal"];
   if (family === "mark") {
-    return action === "set"
-      ? NORMAL_AND_VISUAL_SCOPES
-      : [...NORMAL_AND_VISUAL_SCOPES, "operatorPending"];
+    return action === "set" ? ["normal"] : [...NORMAL_AND_VISUAL_SCOPES, "operatorPending"];
   }
   if (family === "insert") return ["insert"];
   if (

--- a/src/mapping-scopes.ts
+++ b/src/mapping-scopes.ts
@@ -72,6 +72,21 @@ function mappingTokenLengthAt(sequence: string, offset: number): number | undefi
   return key ? modifiers.length + key.length : undefined;
 }
 
+export function appendMappingToken(
+  prefix: string,
+  key: string,
+  candidates: readonly string[],
+): string {
+  if (!prefix) return key;
+  const separated = `${prefix}${MAPPING_TOKEN_SEPARATOR}${key}`;
+  return candidates.some(
+    (candidate) =>
+      candidate === separated || mappingSequencePrefixes(candidate).includes(separated),
+  )
+    ? separated
+    : `${prefix}${key}`;
+}
+
 export function mappingSequencePrefixes(sequence: string): string[] {
   if (sequence.includes(MAPPING_TOKEN_SEPARATOR)) {
     const tokens = sequence.split(MAPPING_TOKEN_SEPARATOR);

--- a/src/mapping-scopes.ts
+++ b/src/mapping-scopes.ts
@@ -39,7 +39,7 @@ const NAMED_TERMINAL_KEYS = new Set([
 
 export function isAtomicMappingSequence(sequence: string): boolean {
   return (
-    /^(?:ctrl|alt|shift|super)\+/.test(sequence) ||
+    /^(?:ctrl|alt|shift|super)(?:\+(?:ctrl|alt|shift|super))*\+[^+]+$/.test(sequence) ||
     NAMED_TERMINAL_KEYS.has(sequence) ||
     /^f\d+$/.test(sequence)
   );
@@ -80,8 +80,12 @@ export function mappingScopesForKeymapEntry(
       : [...NORMAL_AND_VISUAL_SCOPES, "operatorPending"];
   }
   if (family === "operator") return NORMAL_AND_VISUAL_SCOPES;
-  if (family === "command")
+  if (family === "command") {
+    if (action === "insertLineStart" || action === "insertLineEnd")
+      return ["normal", "visualBlock"];
+    if (action === "pasteAfter") return ["normal", "visualLine"];
     return VISUAL_COMMANDS.has(action) ? NORMAL_AND_VISUAL_SCOPES : ["normal"];
+  }
   if (family === "macro") return ["normal"];
   if (family === "mark") {
     return action === "set" ? ["normal"] : [...NORMAL_AND_VISUAL_SCOPES, "operatorPending"];

--- a/src/mapping-scopes.ts
+++ b/src/mapping-scopes.ts
@@ -53,6 +53,22 @@ export function mappingSequencesOverlap(left: string, right: string): boolean {
 
 const VISUAL_SCOPES = ["visual", "visualLine", "visualBlock"] as const;
 const NORMAL_AND_VISUAL_SCOPES = ["normal", ...VISUAL_SCOPES] as const;
+const VISUAL_COMMANDS = new Set([
+  "insertLineStart",
+  "insertLineEnd",
+  "visualChar",
+  "visualLine",
+  "visualBlock",
+  "deleteChar",
+  "pasteAfter",
+  "toggleCase",
+  "replaceChar",
+  "startSearch",
+  "startSearchBackward",
+  "repeatSearch",
+  "repeatSearchReverse",
+  "startExCommand",
+]);
 
 export function mappingScopesForKeymapEntry(
   family: VimMappingFamily,
@@ -64,7 +80,9 @@ export function mappingScopesForKeymapEntry(
       : [...NORMAL_AND_VISUAL_SCOPES, "operatorPending"];
   }
   if (family === "operator") return NORMAL_AND_VISUAL_SCOPES;
-  if (family === "command" || family === "macro") return ["normal"];
+  if (family === "command")
+    return VISUAL_COMMANDS.has(action) ? NORMAL_AND_VISUAL_SCOPES : ["normal"];
+  if (family === "macro") return ["normal"];
   if (family === "mark") {
     return action === "set" ? ["normal"] : [...NORMAL_AND_VISUAL_SCOPES, "operatorPending"];
   }

--- a/src/modal/core.ts
+++ b/src/modal/core.ts
@@ -79,7 +79,11 @@ function hasKeyInMap(map: Record<string, readonly string[]>, key: string): boole
   return Object.values(map).some((bindings) => bindings.includes(key));
 }
 
-export function keymapHasBinding(keymap: ResolvedVimKeymap, key: string, mode?: VimMode): boolean {
+export function keymapHasBinding(
+  keymap: ResolvedVimKeymap,
+  key: string,
+  mode?: VimMode | "operatorPending",
+): boolean {
   if (keymap.escape.includes(key)) return true;
   if (hasKeyInMap(keymap.operators as Record<string, readonly string[]>, key)) return true;
   if (hasKeyInMap(keymap.motions as Record<string, readonly string[]>, key)) return true;

--- a/src/modal/core.ts
+++ b/src/modal/core.ts
@@ -104,7 +104,12 @@ export function keymapHasBinding(keymap: ResolvedVimKeymap, key: string, mode?: 
   ) {
     return true;
   }
-  return false;
+  return keymap.scoped.some(
+    (binding) =>
+      (binding.key === key || binding.key.startsWith(key)) &&
+      binding.modes.includes(mode as never) &&
+      binding.allowProtected === true,
+  );
 }
 
 export function shiftActionForOperator(

--- a/src/modal/core.ts
+++ b/src/modal/core.ts
@@ -84,6 +84,9 @@ export function keymapHasBinding(
   key: string,
   mode?: VimMode | "operatorPending",
 ): boolean {
+  if (mode && keymap.unmaps.some((unmap) => unmap.key === key && unmap.modes.includes(mode))) {
+    return false;
+  }
   if (keymap.escape.includes(key)) return true;
   if (hasKeyInMap(keymap.operators as Record<string, readonly string[]>, key)) return true;
   if (hasKeyInMap(keymap.motions as Record<string, readonly string[]>, key)) return true;

--- a/src/modal/core.ts
+++ b/src/modal/core.ts
@@ -200,6 +200,7 @@ export function clearCommandPending(state: ModalState): ModalState {
     pendingSearch: _pendingSearch,
     pendingEx: _pendingEx,
     pendingInsertEscape: _pendingInsertEscape,
+    pendingInsertEscapeInputs: _pendingInsertEscapeInputs,
     exMessage: _exMessage,
     helpPopup: _helpPopup,
     ...rest

--- a/src/modal/engine.ts
+++ b/src/modal/engine.ts
@@ -51,6 +51,7 @@ import {
   marksForOptions,
 } from "../config.ts";
 import { protectedShortcutForKey } from "../customization.ts";
+import { appendMappingToken } from "../mapping-scopes.ts";
 import { scrollHelpPopup } from "../read-only-popup.ts";
 import { applyPromptTransformAction, applyVisualPromptTransformAction } from "./actions.ts";
 import {
@@ -145,8 +146,20 @@ function isPlainFastInsertText(data: string): boolean {
 }
 
 function clearPendingInsertEscape(state: ModalState): ModalState {
-  const { pendingInsertEscape: _pendingInsertEscape, ...rest } = state;
+  const {
+    pendingInsertEscape: _pendingInsertEscape,
+    pendingInsertEscapeInputs: _pendingInsertEscapeInputs,
+    ...rest
+  } = state;
   return rest;
+}
+
+function pendingInsertEscape(state: ModalState, sequence: string, input: string): ModalState {
+  return {
+    ...state,
+    pendingInsertEscape: sequence,
+    pendingInsertEscapeInputs: [...(state.pendingInsertEscapeInputs ?? []), input],
+  };
 }
 
 function escapeKey(data: string): string | undefined {
@@ -184,7 +197,7 @@ function matchInsertEscapeInput(
   const key = escapeKey(data);
   if (!key) return state.pendingInsertEscape ? { kind: "mismatched" } : { kind: "ignored" };
 
-  const sequence = `${state.pendingInsertEscape ?? ""}${key}`;
+  const sequence = appendMappingToken(state.pendingInsertEscape ?? "", key, aliases);
   if (aliases.includes(sequence)) return { kind: "matched" };
   if (aliases.some((alias) => aliasStartsWith(alias, sequence)))
     return { kind: "pending", sequence };
@@ -192,9 +205,9 @@ function matchInsertEscapeInput(
 }
 
 function delegateBufferedInsertEscape(state: ModalState, input: string): ModalUpdate {
-  const pending = state.pendingInsertEscape;
+  const pending = state.pendingInsertEscapeInputs ?? [state.pendingInsertEscape ?? ""];
   const effects: ModalEffect[] = [
-    ...Array.from(pending ?? "", (char) => ({ type: "delegate" as const, input: char })),
+    ...pending.filter(Boolean).map((input) => ({ type: "delegate" as const, input })),
     { type: "delegate", input },
   ];
   return withEffects(clearPendingInsertEscape(state), effects);
@@ -366,7 +379,7 @@ function handleInsertInput(
   if (match.kind === "matched")
     return modeUpdate(clearPendingInsertEscape(state), "normal", options);
   if (match.kind === "pending") {
-    return withEffects({ ...state, pendingInsertEscape: match.sequence }, []);
+    return withEffects(pendingInsertEscape(state, match.sequence, data), []);
   }
   if (match.kind === "mismatched") return delegateBufferedInsertEscape(state, data);
 
@@ -544,7 +557,6 @@ function remapUpdate(
   mode: "normal" | "visual" | "visualLine" | "visualBlock",
   key: string,
 ): ModalUpdate | undefined {
-  const sequence = `${state.pending ?? ""}${key}`;
   const keymap = keymapForOptions(options);
   const actionKeys = new Set(
     keymap.actions.accepted
@@ -553,6 +565,11 @@ function remapUpdate(
   );
   const remaps = keymap.remaps.accepted.filter(
     (remap) => (!remap.modes || remap.modes.includes(mode)) && !actionKeys.has(remap.key),
+  );
+  const sequence = appendMappingToken(
+    state.pending ?? "",
+    key,
+    remaps.map((remap) => remap.key),
   );
   const exact = remaps.find((remap) => remap.key === sequence);
   if (exact) {
@@ -718,7 +735,7 @@ function handleNormalInput(
     );
     if (escapeMatch.kind === "matched") return invalidate(clearPending(state));
     if (escapeMatch.kind === "pending")
-      return withEffects({ ...state, pendingInsertEscape: escapeMatch.sequence }, []);
+      return withEffects(pendingInsertEscape(state, escapeMatch.sequence, data), []);
     if (escapeMatch.kind === "mismatched") return invalidate(clearPending(state));
   }
   if (isProtectedPiDelegateKey(data)) {
@@ -728,7 +745,13 @@ function handleNormalInput(
     }
   }
 
-  const scopedSequence = `${state.pending ?? ""}${key}`;
+  const scopedSequence = appendMappingToken(
+    state.pending ?? "",
+    key,
+    keymap.scoped
+      .filter((binding) => binding.modes.includes("normal"))
+      .map((binding) => binding.key),
+  );
   const scoped = scopedKeymapSequenceFor(keymap, scopedSequence, "normal");
   if (
     !state.pendingMacro &&
@@ -909,7 +932,7 @@ function handleVisualInput(
   if (escapeMatch.kind === "matched")
     return captureBeforeVisualExit(state, snapshot, modeUpdate(state, "normal", options));
   if (escapeMatch.kind === "pending")
-    return withEffects({ ...state, pendingInsertEscape: escapeMatch.sequence }, []);
+    return withEffects(pendingInsertEscape(state, escapeMatch.sequence, data), []);
   if (escapeMatch.kind === "mismatched") return invalidate(clearPendingInsertEscape(state));
   if (isDelegatedResetKey(data)) return resetAndDelegate(state, options, data);
   const key = keySequence(data);
@@ -922,12 +945,13 @@ function handleVisualInput(
     }
   }
 
-  const scopedSequence = `${state.pending ?? ""}${key}`;
-  const scoped = scopedKeymapSequenceFor(
-    keymap,
-    scopedSequence,
-    state.mode as VimActionBindingMode,
+  const scope = state.mode as VimActionBindingMode;
+  const scopedSequence = appendMappingToken(
+    state.pending ?? "",
+    key,
+    keymap.scoped.filter((binding) => binding.modes.includes(scope)).map((binding) => binding.key),
   );
+  const scoped = scopedKeymapSequenceFor(keymap, scopedSequence, scope);
   if (!state.pendingMark && !state.pendingRegister && (scoped.exact || scoped.isPrefix)) {
     if (!scoped.exact) return invalidate({ ...state, pending: scopedSequence });
     return applyVisualResolution(

--- a/src/modal/engine.ts
+++ b/src/modal/engine.ts
@@ -40,11 +40,16 @@ import {
   operatorActionForSequence,
   resolveMacroCommand,
   resolveNormalCommand,
-  scopedKeymapBindingFor,
+  scopedKeymapSequenceFor,
   scopedKeysForAction,
   type SemanticCommandResult,
 } from "../commands.ts";
-import { keymapForOptions, macrosForOptions, marksForOptions } from "../config.ts";
+import {
+  escapeAliasesForScope as configuredEscapeAliasesForScope,
+  keymapForOptions,
+  macrosForOptions,
+  marksForOptions,
+} from "../config.ts";
 import { protectedShortcutForKey } from "../customization.ts";
 import { scrollHelpPopup } from "../read-only-popup.ts";
 import { applyPromptTransformAction, applyVisualPromptTransformAction } from "./actions.ts";
@@ -161,13 +166,7 @@ function escapeAliasesForScope(
   options: ModalOptions,
   scope: "insert" | "visual" | "visualLine" | "visualBlock" | "operatorPending",
 ): string[] {
-  const keymap = keymapForOptions(options);
-  return [
-    ...keymap.escape,
-    ...keymap.scoped
-      .filter((binding) => binding.actionId === "escape" && binding.modes.includes(scope))
-      .map((binding) => binding.key),
-  ];
+  return configuredEscapeAliasesForScope(keymapForOptions(options), scope);
 }
 
 type InsertEscapeMatch =
@@ -728,17 +727,33 @@ function handleNormalInput(
     }
   }
 
-  // A concrete scoped descriptor owns its exact key before legacy macro/mark grammar.
-  // This prevents structural defaults (for example `q`) from shadowing configuration.
-  if (!state.pending && scopedKeymapBindingFor(keymap, key, "normal")) {
-    const resolved = resolveNormalCommand(key, undefined, keymap, "normal");
-    if (resolved.type === "pending") return invalidate({ ...state, pending: resolved.pending });
-    if (resolved.type === "motion")
-      return moveUpdate(clearPending(state), resolved.motion, snapshot, resolved.count);
-    if (resolved.type === "command")
-      return applyCommand(state, snapshot, options, resolved.command, resolved.count);
-    if (resolved.type === "action")
-      return applyPromptTransformAction(state, snapshot, options, resolved);
+  const scopedSequence = `${state.pending ?? ""}${key}`;
+  const scoped = scopedKeymapSequenceFor(keymap, scopedSequence, "normal");
+  if (
+    !state.pendingMacro &&
+    !state.pendingMark &&
+    !state.pendingRegister &&
+    (scoped.exact || scoped.isPrefix)
+  ) {
+    if (!scoped.exact) return invalidate({ ...state, pending: scopedSequence });
+    if (scoped.exact.actionId.startsWith("macro.") || scoped.exact.actionId.startsWith("mark.")) {
+      const handled = handleNormalMacroOrMark(
+        { ...state, pending: undefined },
+        snapshot,
+        options,
+        keymap,
+        scopedSequence,
+      );
+      if (handled) return handled;
+    }
+    return applyNormalResolution(
+      state,
+      snapshot,
+      options,
+      keymap,
+      scopedSequence,
+      resolveNormalCommand(scopedSequence, undefined, keymap, "normal"),
+    );
   }
 
   if (state.pendingRegister === "awaitingSlot") {
@@ -906,13 +921,20 @@ function handleVisualInput(
     }
   }
 
-  if (!state.pending && scopedKeymapBindingFor(keymap, key, state.mode as VimActionBindingMode)) {
+  const scopedSequence = `${state.pending ?? ""}${key}`;
+  const scoped = scopedKeymapSequenceFor(
+    keymap,
+    scopedSequence,
+    state.mode as VimActionBindingMode,
+  );
+  if (!state.pendingMark && !state.pendingRegister && (scoped.exact || scoped.isPrefix)) {
+    if (!scoped.exact) return invalidate({ ...state, pending: scopedSequence });
     return applyVisualResolution(
       state,
       snapshot,
       options,
       keymap,
-      resolveNormalCommand(key, undefined, keymap, state.mode as VimActionBindingMode),
+      resolveNormalCommand(scopedSequence, undefined, keymap, state.mode as VimActionBindingMode),
     );
   }
 

--- a/src/modal/engine.ts
+++ b/src/modal/engine.ts
@@ -154,7 +154,7 @@ function escapeKey(data: string): string | undefined {
 }
 
 function aliasStartsWith(alias: string, sequence: string): boolean {
-  return alias.includes("+") ? alias === sequence : alias.startsWith(sequence);
+  return alias.startsWith(sequence);
 }
 
 function isInsertEscapePrefix(data: string, sequences: readonly string[]): boolean {

--- a/src/modal/engine.ts
+++ b/src/modal/engine.ts
@@ -722,7 +722,8 @@ function handleNormalInput(
     if (escapeMatch.kind === "mismatched") return invalidate(clearPending(state));
   }
   if (isProtectedPiDelegateKey(data)) {
-    if (!keymapHasBinding(keymap, key, "normal")) {
+    const scope = pendingOperator ? "operatorPending" : "normal";
+    if (!keymapHasBinding(keymap, key, scope)) {
       return delegateProtectedShortcut(state, options, data);
     }
   }

--- a/src/modal/engine.ts
+++ b/src/modal/engine.ts
@@ -498,14 +498,24 @@ function markPendingForKey(
   options: ModalOptions,
   operator?: VimOperatorAction,
   operatorKey?: string,
+  mode: "normal" | "visual" | "visualLine" | "visualBlock" | "operatorPending" = "normal",
 ) {
   if (!marksForOptions(options).enabled) return undefined;
-  const keymap = keymapForOptions(options).marks;
-  if (!operator && keymap.set.includes(key)) return pendingMarkTarget("set");
-  if (keymap.jumpExact.includes(key)) {
+  const resolved = keymapForOptions(options);
+  const hasScopedMark = (action: "set" | "jumpExact" | "jumpLine") =>
+    resolved.scoped.some(
+      (binding) =>
+        binding.key === key &&
+        binding.actionId === `mark.${action}` &&
+        binding.modes.includes(mode),
+    );
+  if (!operator && (resolved.marks.set.includes(key) || hasScopedMark("set"))) {
+    return pendingMarkTarget("set");
+  }
+  if (resolved.marks.jumpExact.includes(key) || hasScopedMark("jumpExact")) {
     return pendingMarkTarget("jumpExact", operator, operatorKey);
   }
-  if (keymap.jumpLine.includes(key)) {
+  if (resolved.marks.jumpLine.includes(key) || hasScopedMark("jumpLine")) {
     return pendingMarkTarget("jumpLine", operator, operatorKey);
   }
   return undefined;
@@ -578,17 +588,27 @@ function handleNormalInput(
 
   if (!state.pending && !state.pendingRegister && !startsLeader) {
     const macros = macrosForOptions(options);
+    const macroKeys = (action: "record" | "play") => [
+      ...keymap.macros[action],
+      ...keymap.scoped
+        .filter(
+          (binding) => binding.actionId === `macro.${action}` && binding.modes.includes("normal"),
+        )
+        .map((binding) => binding.key),
+    ];
+    const recordKeys = macroKeys("record");
+    const playKeys = macroKeys("play");
     if (
       snapshot.isMacroReplaying &&
-      (state.pendingMacro || isMacroControlKey(key, keymap.macros.record, keymap.macros.play))
+      (state.pendingMacro || isMacroControlKey(key, recordKeys, playKeys))
     ) {
       return invalidate(clearPendingMacro(state));
     }
     const macroResult = resolveMacroCommand(key, state.pendingMacro, Boolean(state.recordingSlot), {
       enabled: macros.enabled,
       slots: macros.slots,
-      recordKeys: keymap.macros.record,
-      playKeys: keymap.macros.play,
+      recordKeys,
+      playKeys,
     });
     if (macroResult.type === "pendingMacro")
       return invalidate({ ...clearPending(state), pendingMacro: macroResult.target });
@@ -623,7 +643,13 @@ function handleNormalInput(
     if (searchCommand.type === "command" && searchCommand.command === "startSearchBackward") {
       return startSearchUpdate(state, "backward", pendingOperator);
     }
-    const markTarget = markPendingForKey(key, options, pendingOperator, state.pending);
+    const markTarget = markPendingForKey(
+      key,
+      options,
+      pendingOperator,
+      state.pending,
+      "operatorPending",
+    );
     if (markTarget) return invalidate({ ...clearRegisterTarget(state), pendingMark: markTarget });
   }
 
@@ -767,7 +793,13 @@ function handleVisualInput(
     );
   }
   if (!state.pending && !state.pendingRegister && !startsLeader) {
-    const markTarget = markPendingForKey(key, options);
+    const markTarget = markPendingForKey(
+      key,
+      options,
+      undefined,
+      undefined,
+      state.mode as "visual" | "visualLine" | "visualBlock",
+    );
     if (markTarget?.kind === "jumpExact" || markTarget?.kind === "jumpLine") {
       return invalidate({ ...clearPending(state), pendingMark: markTarget });
     }

--- a/src/modal/engine.ts
+++ b/src/modal/engine.ts
@@ -34,6 +34,7 @@ import {
   operatorActionForSequence,
   resolveMacroCommand,
   resolveNormalCommand,
+  scopedKeysForAction,
 } from "../commands.ts";
 import { keymapForOptions, macrosForOptions, marksForOptions } from "../config.ts";
 import { protectedShortcutForKey } from "../customization.ts";
@@ -503,12 +504,7 @@ function markPendingForKey(
   if (!marksForOptions(options).enabled) return undefined;
   const resolved = keymapForOptions(options);
   const hasScopedMark = (action: "set" | "jumpExact" | "jumpLine") =>
-    resolved.scoped.some(
-      (binding) =>
-        binding.key === key &&
-        binding.actionId === `mark.${action}` &&
-        binding.modes.includes(mode),
-    );
+    scopedKeysForAction(resolved, `mark.${action}`, mode).includes(key);
   if (!operator && (resolved.marks.set.includes(key) || hasScopedMark("set"))) {
     return pendingMarkTarget("set");
   }
@@ -590,11 +586,7 @@ function handleNormalInput(
     const macros = macrosForOptions(options);
     const macroKeys = (action: "record" | "play") => [
       ...keymap.macros[action],
-      ...keymap.scoped
-        .filter(
-          (binding) => binding.actionId === `macro.${action}` && binding.modes.includes("normal"),
-        )
-        .map((binding) => binding.key),
+      ...scopedKeysForAction(keymap, `macro.${action}`, "normal"),
     ];
     const recordKeys = macroKeys("record");
     const playKeys = macroKeys("play");

--- a/src/modal/engine.ts
+++ b/src/modal/engine.ts
@@ -34,6 +34,7 @@ import {
   operatorActionForSequence,
   resolveMacroCommand,
   resolveNormalCommand,
+  scopedKeymapBindingFor,
   scopedKeysForAction,
 } from "../commands.ts";
 import { keymapForOptions, macrosForOptions, marksForOptions } from "../config.ts";
@@ -567,6 +568,19 @@ function handleNormalInput(
     if (!keymapHasBinding(keymap, key, "normal")) {
       return delegateProtectedShortcut(state, options, data);
     }
+  }
+
+  // A concrete scoped descriptor owns its exact key before legacy macro/mark grammar.
+  // This prevents structural defaults (for example `q`) from shadowing configuration.
+  if (!state.pending && scopedKeymapBindingFor(keymap, key, "normal")) {
+    const resolved = resolveNormalCommand(key, undefined, keymap, "normal");
+    if (resolved.type === "pending") return invalidate({ ...state, pending: resolved.pending });
+    if (resolved.type === "motion")
+      return moveUpdate(clearPending(state), resolved.motion, snapshot, resolved.count);
+    if (resolved.type === "command")
+      return applyCommand(state, snapshot, options, resolved.command, resolved.count);
+    if (resolved.type === "action")
+      return applyPromptTransformAction(state, snapshot, options, resolved);
   }
 
   if (state.pendingRegister === "awaitingSlot") {

--- a/src/modal/engine.ts
+++ b/src/modal/engine.ts
@@ -1,6 +1,11 @@
 import { matchesKey, parseKey } from "@earendil-works/pi-tui";
 
-import type { VimDiagnostics, VimOperatorAction } from "../types.ts";
+import type {
+  ResolvedVimKeymap,
+  VimActionBindingMode,
+  VimDiagnostics,
+  VimOperatorAction,
+} from "../types.ts";
 import type {
   EditorSnapshot,
   FastInsertDelegateContext,
@@ -37,6 +42,7 @@ import {
   resolveNormalCommand,
   scopedKeymapBindingFor,
   scopedKeysForAction,
+  type SemanticCommandResult,
 } from "../commands.ts";
 import { keymapForOptions, macrosForOptions, marksForOptions } from "../config.ts";
 import { protectedShortcutForKey } from "../customization.ts";
@@ -149,6 +155,19 @@ function aliasStartsWith(alias: string, sequence: string): boolean {
 function isInsertEscapePrefix(data: string, sequences: readonly string[]): boolean {
   const key = escapeKey(data);
   return Boolean(key && sequences.some((sequence) => aliasStartsWith(sequence, key)));
+}
+
+function escapeAliasesForScope(
+  options: ModalOptions,
+  scope: "insert" | "visual" | "visualLine" | "visualBlock" | "operatorPending",
+): string[] {
+  const keymap = keymapForOptions(options);
+  return [
+    ...keymap.escape,
+    ...keymap.scoped
+      .filter((binding) => binding.actionId === "escape" && binding.modes.includes(scope))
+      .map((binding) => binding.key),
+  ];
 }
 
 type InsertEscapeMatch =
@@ -344,7 +363,7 @@ function handleInsertInput(
 
   if (snapshot.isAutocompleteOpen) return delegateBufferedInsertEscape(state, data);
 
-  const match = matchInsertEscapeInput(state, data, keymapForOptions(options).escape);
+  const match = matchInsertEscapeInput(state, data, escapeAliasesForScope(options, "insert"));
   if (match.kind === "matched")
     return modeUpdate(clearPendingInsertEscape(state), "normal", options);
   if (match.kind === "pending") {
@@ -547,6 +566,131 @@ function remapUpdate(
   return undefined;
 }
 
+function handleNormalMacroOrMark(
+  state: ModalState,
+  snapshot: EditorSnapshot,
+  options: ModalOptions,
+  keymap: ResolvedVimKeymap,
+  key: string,
+): ModalUpdate | undefined {
+  const macros = macrosForOptions(options);
+  const macroKeys = (action: "record" | "play") =>
+    [...keymap.macros[action], ...scopedKeysForAction(keymap, `macro.${action}`, "normal")].filter(
+      (binding) => !isKeyUnmapped(keymap, binding, "normal"),
+    );
+  const recordKeys = macroKeys("record");
+  const playKeys = macroKeys("play");
+  if (
+    snapshot.isMacroReplaying &&
+    (state.pendingMacro || isMacroControlKey(key, recordKeys, playKeys))
+  ) {
+    return invalidate(clearPendingMacro(state));
+  }
+  const result = resolveMacroCommand(key, state.pendingMacro, Boolean(state.recordingSlot), {
+    enabled: macros.enabled,
+    slots: macros.slots,
+    recordKeys,
+    playKeys,
+  });
+  if (result.type === "pendingMacro")
+    return invalidate({ ...clearPending(state), pendingMacro: result.target });
+  if (result.type === "startRecording") return startMacroRecording(state, result.slot);
+  if (result.type === "stopRecording") return stopMacroRecording(state);
+  if (result.type === "playMacro") {
+    if (snapshot.isMacroReplaying || state.recordingSlot)
+      return invalidate(clearPendingMacro(state));
+    return playMacroUpdate(state, result.slot, options);
+  }
+  if (result.type === "repeatMacro") {
+    if (snapshot.isMacroReplaying || state.recordingSlot || !state.lastPlayedMacro)
+      return invalidate(clearPendingMacro(state));
+    return playMacroUpdate(state, state.lastPlayedMacro, options);
+  }
+  if (result.type === "invalid") return invalidate(clearPendingMacro(state));
+
+  const markTarget = markPendingForKey(key, options);
+  return markTarget ? invalidate({ ...clearPending(state), pendingMark: markTarget }) : undefined;
+}
+
+function applyNormalResolution(
+  state: ModalState,
+  snapshot: EditorSnapshot,
+  options: ModalOptions,
+  keymap: ResolvedVimKeymap,
+  key: string,
+  result: SemanticCommandResult,
+): ModalUpdate {
+  if (result.type === "pending") {
+    const operator = operatorActionForSequence(result.pending, keymap);
+    if (state.pendingRegister && !operator) return invalidate(clearPending(state));
+    return invalidate({ ...state, pending: result.pending });
+  }
+  if (result.type === "motion") {
+    if (state.pendingRegister) return invalidate(clearPending(state));
+    return moveUpdate(clearPending(state), result.motion, snapshot, result.count);
+  }
+  if (result.type === "command") {
+    if (result.command === "easymotion") {
+      return invalidate({ ...state, pending: undefined, pendingEasymotion: { kind: "char" } });
+    }
+    return applyCommand(state, snapshot, options, result.command, result.count);
+  }
+  if (result.type === "action") {
+    if (state.pendingRegister) return invalidate(clearPending(state));
+    return applyPromptTransformAction(state, snapshot, options, result);
+  }
+  if (result.type === "charCommand")
+    return applyCommand(state, snapshot, options, result.command, result.count, result.char);
+  if (result.type === "lineCommand")
+    return applyLineCommand(state, snapshot, options, result.operator, result.count);
+  if (result.type === "operatorMotion")
+    return applyOperatorMotion(
+      state,
+      snapshot,
+      result.operator,
+      result.motion,
+      options,
+      result.count,
+    );
+  if (result.type === "operatorSearch")
+    return startSearchUpdate(state, result.direction, result.operator);
+  if (result.type === "operatorCharSearch")
+    return applyOperatorCharSearch(
+      state,
+      snapshot,
+      result.operator,
+      result.command,
+      result.char,
+      options,
+      result.count,
+    );
+  if (result.type === "operatorCharSearchRepeat")
+    return applyOperatorCharSearchRepeat(
+      state,
+      snapshot,
+      result.operator,
+      result.reverse,
+      options,
+      result.count,
+    );
+  if (result.type === "operatorTextObject")
+    return applyOperatorTextObject(
+      state,
+      snapshot,
+      result.operator,
+      result.textObject,
+      options,
+      result.count,
+    );
+  if (result.type === "invalid") {
+    if (keymap.leader && state.pending?.startsWith(keymap.leader))
+      return invalidate(clearPending(state));
+    return invalidate(withNoopFeedback(clearPending(state), options, "invalid Vim key sequence"));
+  }
+  if (state.pendingRegister) return invalidate(clearPending(state));
+  return invalidate(withNoopFeedback(state, options, `unmapped key: ${key}`));
+}
+
 function handleNormalInput(
   state: ModalState,
   snapshot: EditorSnapshot,
@@ -566,6 +710,18 @@ function handleNormalInput(
   }
 
   const keymap = keymapForOptions(options);
+  const pendingOperator = operatorActionForSequence(state.pending, keymap);
+  if (pendingOperator) {
+    const escapeMatch = matchInsertEscapeInput(
+      state,
+      data,
+      escapeAliasesForScope(options, "operatorPending"),
+    );
+    if (escapeMatch.kind === "matched") return invalidate(clearPending(state));
+    if (escapeMatch.kind === "pending")
+      return withEffects({ ...state, pendingInsertEscape: escapeMatch.sequence }, []);
+    if (escapeMatch.kind === "mismatched") return invalidate(clearPending(state));
+  }
   if (isProtectedPiDelegateKey(data)) {
     if (!keymapHasBinding(keymap, key, "normal")) {
       return delegateProtectedShortcut(state, options, data);
@@ -599,52 +755,14 @@ function handleNormalInput(
   }
 
   if (!state.pending && !state.pendingRegister && !startsLeader) {
-    const macros = macrosForOptions(options);
-    const macroKeys = (action: "record" | "play") =>
-      [
-        ...keymap.macros[action],
-        ...scopedKeysForAction(keymap, `macro.${action}`, "normal"),
-      ].filter((binding) => !isKeyUnmapped(keymap, binding, "normal"));
-    const recordKeys = macroKeys("record");
-    const playKeys = macroKeys("play");
-    if (
-      snapshot.isMacroReplaying &&
-      (state.pendingMacro || isMacroControlKey(key, recordKeys, playKeys))
-    ) {
-      return invalidate(clearPendingMacro(state));
-    }
-    const macroResult = resolveMacroCommand(key, state.pendingMacro, Boolean(state.recordingSlot), {
-      enabled: macros.enabled,
-      slots: macros.slots,
-      recordKeys,
-      playKeys,
-    });
-    if (macroResult.type === "pendingMacro")
-      return invalidate({ ...clearPending(state), pendingMacro: macroResult.target });
-    if (macroResult.type === "startRecording") return startMacroRecording(state, macroResult.slot);
-    if (macroResult.type === "stopRecording") return stopMacroRecording(state);
-    if (macroResult.type === "playMacro") {
-      if (snapshot.isMacroReplaying || state.recordingSlot)
-        return invalidate(clearPendingMacro(state));
-      return playMacroUpdate(state, macroResult.slot, options);
-    }
-    if (macroResult.type === "repeatMacro") {
-      if (snapshot.isMacroReplaying || state.recordingSlot || !state.lastPlayedMacro) {
-        return invalidate(clearPendingMacro(state));
-      }
-      return playMacroUpdate(state, state.lastPlayedMacro, options);
-    }
-    if (macroResult.type === "invalid") return invalidate(clearPendingMacro(state));
-
-    const markTarget = markPendingForKey(key, options);
-    if (markTarget) return invalidate({ ...clearPending(state), pendingMark: markTarget });
+    const macroOrMark = handleNormalMacroOrMark(state, snapshot, options, keymap, key);
+    if (macroOrMark) return macroOrMark;
   }
 
   const remapped = remapUpdate(state, options, "normal", key);
   if (remapped) return remapped;
 
-  const pendingOperator = operatorActionForSequence(state.pending, keymap);
-  if (pendingOperator) {
+  if (pendingOperator && !isKeyUnmapped(keymap, key, "operatorPending")) {
     const searchCommand = resolveNormalCommand(key, undefined, keymap, "normal");
     if (searchCommand.type === "command" && searchCommand.command === "startSearch") {
       return startSearchUpdate(state, "forward", pendingOperator);
@@ -662,92 +780,101 @@ function handleNormalInput(
     if (markTarget) return invalidate({ ...clearRegisterTarget(state), pendingMark: markTarget });
   }
 
-  const pendingResult = resolveNormalCommand(key, state.pending, keymap, "normal");
-  if (pendingResult.type === "pending") {
-    const operator = operatorActionForSequence(pendingResult.pending, keymap);
-    if (state.pendingRegister && !operator) return invalidate(clearPending(state));
-    return invalidate({ ...state, pending: pendingResult.pending });
-  }
-  if (pendingResult.type === "motion") {
-    if (state.pendingRegister) return invalidate(clearPending(state));
-    return moveUpdate(clearPending(state), pendingResult.motion, snapshot, pendingResult.count);
-  }
-  if (pendingResult.type === "command") {
-    // Intercept the configurable "easymotion" command here
-    if (pendingResult.command === "easymotion") {
-      return invalidate({ ...state, pending: undefined, pendingEasymotion: { kind: "char" } });
-    }
-    return applyCommand(state, snapshot, options, pendingResult.command, pendingResult.count);
-  }
-  if (pendingResult.type === "action") {
-    if (state.pendingRegister) return invalidate(clearPending(state));
-    return applyPromptTransformAction(state, snapshot, options, pendingResult);
-  }
-  if (pendingResult.type === "charCommand")
-    return applyCommand(
-      state,
-      snapshot,
-      options,
-      pendingResult.command,
-      pendingResult.count,
-      pendingResult.char,
-    );
-  if (pendingResult.type === "lineCommand") {
-    return applyLineCommand(state, snapshot, options, pendingResult.operator, pendingResult.count);
-  }
-  if (pendingResult.type === "operatorMotion") {
-    return applyOperatorMotion(
-      state,
-      snapshot,
-      pendingResult.operator,
-      pendingResult.motion,
-      options,
-      pendingResult.count,
-    );
-  }
-  if (pendingResult.type === "operatorSearch") {
-    return startSearchUpdate(state, pendingResult.direction, pendingResult.operator);
-  }
-  if (pendingResult.type === "operatorCharSearch") {
-    return applyOperatorCharSearch(
-      state,
-      snapshot,
-      pendingResult.operator,
-      pendingResult.command,
-      pendingResult.char,
-      options,
-      pendingResult.count,
-    );
-  }
-  if (pendingResult.type === "operatorCharSearchRepeat") {
-    return applyOperatorCharSearchRepeat(
-      state,
-      snapshot,
-      pendingResult.operator,
-      pendingResult.reverse,
-      options,
-      pendingResult.count,
-    );
-  }
-  if (pendingResult.type === "operatorTextObject") {
-    return applyOperatorTextObject(
-      state,
-      snapshot,
-      pendingResult.operator,
-      pendingResult.textObject,
-      options,
-      pendingResult.count,
-    );
-  }
-  if (pendingResult.type === "invalid") {
-    if (keymap.leader && state.pending?.startsWith(keymap.leader)) {
-      return invalidate(clearPending(state));
-    }
-    return invalidate(withNoopFeedback(clearPending(state), options, "invalid Vim key sequence"));
-  }
+  return applyNormalResolution(
+    state,
+    snapshot,
+    options,
+    keymap,
+    key,
+    resolveNormalCommand(key, state.pending, keymap, "normal"),
+  );
+}
 
-  if (state.pendingRegister) return invalidate(clearPending(state));
-  return invalidate(withNoopFeedback(state, options, `unmapped key: ${key}`));
+function applyVisualCommand(
+  state: ModalState,
+  snapshot: EditorSnapshot,
+  options: ModalOptions,
+  command: Extract<SemanticCommandResult, { type: "command" }>["command"],
+): ModalUpdate {
+  const registerAware = command === "deleteChar" || command === "pasteAfter";
+  if (state.pendingRegister && !registerAware) return invalidate(clearPending(state));
+  if (command === "startSearch") return startSearchUpdate(state);
+  if (command === "startSearchBackward") return startSearchUpdate(state, "backward");
+  if (command === "startExCommand")
+    return captureBeforeVisualExit(state, snapshot, startVisualExCommandUpdate(state, snapshot));
+  if (command === "repeatSearch") return repeatSearch(state, snapshot, options, false);
+  if (command === "repeatSearchReverse") return repeatSearch(state, snapshot, options, true);
+  if (command === "visualLine")
+    return state.mode === "visualLine"
+      ? invalidate(state)
+      : modeUpdate(state, "visualLine", options);
+  if (command === "visualChar")
+    return state.mode === "visual" ? invalidate(state) : modeUpdate(state, "visual", options);
+  if (command === "visualBlock")
+    return state.mode === "visualBlock"
+      ? invalidate(state)
+      : modeUpdate(state, "visualBlock", options);
+  if (state.mode === "visualBlock" && command === "insertLineStart")
+    return startBlockInsert(state, snapshot, options, "start");
+  if (state.mode === "visualBlock" && command === "insertLineEnd")
+    return startBlockInsert(state, snapshot, options, "end");
+  if (command === "deleteChar")
+    return deleteVisualSelection(state, snapshot, options, "normal", visualKindForMode(state.mode));
+  if (command === "toggleCase")
+    return toggleVisualSelection(state, snapshot, options, visualKindForMode(state.mode));
+  if (command === "pasteAfter" && state.mode === "visualLine")
+    return pasteVisualLineSelection(state, snapshot, options);
+  return invalidate(state.pendingRegister ? clearPending(state) : state);
+}
+
+function applyVisualResolution(
+  state: ModalState,
+  snapshot: EditorSnapshot,
+  options: ModalOptions,
+  keymap: ResolvedVimKeymap,
+  result: SemanticCommandResult,
+): ModalUpdate {
+  if (result.type === "motion") {
+    if (state.pendingRegister) return invalidate(clearPending(state));
+    return moveUpdate(state, result.motion, snapshot, result.count);
+  }
+  if (result.type === "charCommand") {
+    if (state.pendingRegister || result.command !== "replaceChar")
+      return invalidate(clearPending(state));
+    return replaceVisualSelection(
+      state,
+      snapshot,
+      options,
+      visualKindForMode(state.mode),
+      result.char,
+    );
+  }
+  if (result.type === "action") {
+    if (state.pendingRegister) return invalidate(clearPending(state));
+    return applyVisualPromptTransformAction(state, snapshot, options, result);
+  }
+  if (result.type === "command")
+    return applyVisualCommand(state, snapshot, options, result.command);
+  if (result.type === "pending") {
+    const operator = operatorActionForSequence(
+      result.pending,
+      keymap,
+      state.mode as VimActionBindingMode,
+    );
+    if (operator)
+      return applyVisualOperator(
+        state,
+        snapshot,
+        options,
+        visualKindForMode(state.mode),
+        operator,
+        countForPendingSequence(result.pending),
+      );
+    if (state.pendingRegister) return invalidate(clearPending(state));
+    return invalidate({ ...state, pending: result.pending });
+  }
+  if (result.type === "invalid") return invalidate(clearPending(state));
+  return invalidate(state.pendingRegister ? clearPending(state) : state);
 }
 
 function handleVisualInput(
@@ -758,8 +885,16 @@ function handleVisualInput(
 ): ModalUpdate {
   if (matchesKey(data, "escape"))
     return captureBeforeVisualExit(state, snapshot, modeUpdate(state, "normal", options));
-  if (matchInsertEscapeInput(state, data, keymapForOptions(options).escape).kind === "matched")
+  const escapeMatch = matchInsertEscapeInput(
+    state,
+    data,
+    escapeAliasesForScope(options, state.mode as "visual" | "visualLine" | "visualBlock"),
+  );
+  if (escapeMatch.kind === "matched")
     return captureBeforeVisualExit(state, snapshot, modeUpdate(state, "normal", options));
+  if (escapeMatch.kind === "pending")
+    return withEffects({ ...state, pendingInsertEscape: escapeMatch.sequence }, []);
+  if (escapeMatch.kind === "mismatched") return invalidate(clearPendingInsertEscape(state));
   if (isDelegatedResetKey(data)) return resetAndDelegate(state, options, data);
   const key = keySequence(data);
   if (!key) return delegate(state, data);
@@ -769,6 +904,16 @@ function handleVisualInput(
     if (!keymapHasBinding(keymap, key, state.mode)) {
       return delegateProtectedShortcut(state, options, data);
     }
+  }
+
+  if (!state.pending && scopedKeymapBindingFor(keymap, key, state.mode as VimActionBindingMode)) {
+    return applyVisualResolution(
+      state,
+      snapshot,
+      options,
+      keymap,
+      resolveNormalCommand(key, undefined, keymap, state.mode as VimActionBindingMode),
+    );
   }
 
   if (state.pendingRegister === "awaitingSlot") {
@@ -822,97 +967,18 @@ function handleVisualInput(
   );
   if (remapped) return remapped;
 
-  const result = resolveNormalCommand(
-    key,
-    state.pending,
+  return applyVisualResolution(
+    state,
+    snapshot,
+    options,
     keymap,
-    state.mode as "visual" | "visualLine" | "visualBlock",
+    resolveNormalCommand(
+      key,
+      state.pending,
+      keymap,
+      state.mode as "visual" | "visualLine" | "visualBlock",
+    ),
   );
-  if (result.type === "motion") {
-    if (state.pendingRegister) return invalidate(clearPending(state));
-    return moveUpdate(state, result.motion, snapshot, result.count);
-  }
-  if (result.type === "charCommand") {
-    if (state.pendingRegister || result.command !== "replaceChar")
-      return invalidate(clearPending(state));
-    return replaceVisualSelection(
-      state,
-      snapshot,
-      options,
-      visualKindForMode(state.mode),
-      result.char,
-    );
-  }
-  if (result.type === "action") {
-    if (state.pendingRegister) return invalidate(clearPending(state));
-    return applyVisualPromptTransformAction(state, snapshot, options, result);
-  }
-  if (result.type === "command") {
-    const registerAware = result.command === "deleteChar" || result.command === "pasteAfter";
-    if (state.pendingRegister && !registerAware) return invalidate(clearPending(state));
-
-    if (result.command === "startSearch") return startSearchUpdate(state);
-    if (result.command === "startSearchBackward") return startSearchUpdate(state, "backward");
-    if (result.command === "startExCommand") {
-      return captureBeforeVisualExit(state, snapshot, startVisualExCommandUpdate(state, snapshot));
-    }
-    if (result.command === "repeatSearch") return repeatSearch(state, snapshot, options, false);
-    if (result.command === "repeatSearchReverse")
-      return repeatSearch(state, snapshot, options, true);
-
-    if (result.command === "visualLine") {
-      return state.mode === "visualLine"
-        ? invalidate(state)
-        : modeUpdate(state, "visualLine", options);
-    }
-    if (result.command === "visualChar") {
-      return state.mode === "visual" ? invalidate(state) : modeUpdate(state, "visual", options);
-    }
-    if (result.command === "visualBlock") {
-      return state.mode === "visualBlock"
-        ? invalidate(state)
-        : modeUpdate(state, "visualBlock", options);
-    }
-    if (state.mode === "visualBlock" && result.command === "insertLineStart") {
-      return startBlockInsert(state, snapshot, options, "start");
-    }
-    if (state.mode === "visualBlock" && result.command === "insertLineEnd") {
-      return startBlockInsert(state, snapshot, options, "end");
-    }
-    if (result.command === "deleteChar") {
-      return deleteVisualSelection(
-        state,
-        snapshot,
-        options,
-        "normal",
-        visualKindForMode(state.mode),
-      );
-    }
-    if (result.command === "toggleCase") {
-      return toggleVisualSelection(state, snapshot, options, visualKindForMode(state.mode));
-    }
-    if (result.command === "pasteAfter") {
-      if (state.mode === "visualLine") return pasteVisualLineSelection(state, snapshot, options);
-      return invalidate(state.pendingRegister ? clearPending(state) : state);
-    }
-  }
-  if (result.type === "pending") {
-    const operator = operatorActionForSequence(result.pending, keymap);
-    if (operator)
-      return applyVisualOperator(
-        state,
-        snapshot,
-        options,
-        visualKindForMode(state.mode),
-        operator,
-        countForPendingSequence(result.pending),
-      );
-    if (state.pendingRegister) return invalidate(clearPending(state));
-    return invalidate({ ...state, pending: result.pending });
-  }
-  if (result.type === "invalid") return invalidate(clearPending(state));
-
-  return invalidate(state.pendingRegister ? clearPending(state) : state);
 }
 
 function handleHelpPopupInput(state: ModalState, options: ModalOptions, data: string): ModalUpdate {

--- a/src/modal/engine.ts
+++ b/src/modal/engine.ts
@@ -30,6 +30,7 @@ import {
 } from "../buffer.ts";
 import {
   countForPendingSequence,
+  isKeyUnmapped,
   isMacroControlKey,
   operatorActionForSequence,
   resolveMacroCommand,
@@ -504,6 +505,7 @@ function markPendingForKey(
 ) {
   if (!marksForOptions(options).enabled) return undefined;
   const resolved = keymapForOptions(options);
+  if (isKeyUnmapped(resolved, key, mode)) return undefined;
   const hasScopedMark = (action: "set" | "jumpExact" | "jumpLine") =>
     scopedKeysForAction(resolved, `mark.${action}`, mode).includes(key);
   if (!operator && (resolved.marks.set.includes(key) || hasScopedMark("set"))) {
@@ -598,10 +600,11 @@ function handleNormalInput(
 
   if (!state.pending && !state.pendingRegister && !startsLeader) {
     const macros = macrosForOptions(options);
-    const macroKeys = (action: "record" | "play") => [
-      ...keymap.macros[action],
-      ...scopedKeysForAction(keymap, `macro.${action}`, "normal"),
-    ];
+    const macroKeys = (action: "record" | "play") =>
+      [
+        ...keymap.macros[action],
+        ...scopedKeysForAction(keymap, `macro.${action}`, "normal"),
+      ].filter((binding) => !isKeyUnmapped(keymap, binding, "normal"));
     const recordKeys = macroKeys("record");
     const playKeys = macroKeys("play");
     if (

--- a/src/modal/types.ts
+++ b/src/modal/types.ts
@@ -175,6 +175,7 @@ export type ModalState = {
   pendingSearch?: PendingSearchTarget;
   pendingEx?: PendingExCommand;
   pendingInsertEscape?: string;
+  pendingInsertEscapeInputs?: readonly string[];
   exHistory?: string[];
   lastExSubstitution?: LastExSubstitution;
   exMessage?: ExMessage;

--- a/src/types.ts
+++ b/src/types.ts
@@ -153,6 +153,8 @@ export type VimActionKeyBindingEntry =
       key: string;
       args?: Readonly<Record<string, unknown>>;
       modes?: readonly VimActionBindingMode[];
+      allowProtected?: boolean;
+      desc?: string;
     };
 
 export type VimActionKeymapOptions = Partial<
@@ -214,6 +216,8 @@ export type ResolvedVimActionBinding = {
   actionId: BindablePromptTransformActionId;
   args: PromptTransform;
   modes?: readonly VimActionBindingMode[];
+  allowProtected?: boolean;
+  desc?: string;
 };
 
 export type ResolvedVimActionKeymap = {
@@ -233,11 +237,24 @@ export type ResolvedVimInsertKeymap = {
   moveLineEnd: readonly string[];
 };
 
+export type VimFiniteActionId =
+  | "escape"
+  | `operator.${VimOperatorAction}`
+  | `motion.${VimMotionAction}`
+  | `command.${VimCommandAction}`
+  | `macro.${keyof ResolvedVimMacroKeymap}`
+  | `mark.${keyof ResolvedVimMarkKeymap}`
+  | `insert.${keyof ResolvedVimInsertKeymap}`
+  | `textObject.kind.${VimTextObjectKind}`
+  | `textObject.target.${VimTextObjectTarget}`
+  | BindablePromptTransformActionId;
+
 export type VimScopedKeymapBinding = {
-  actionId: string;
+  actionId: VimFiniteActionId;
   key: string;
   modes: readonly VimMappingScope[];
   args?: Readonly<Record<string, unknown>>;
+  allowProtected?: boolean;
   desc?: string;
 };
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -167,6 +167,8 @@ export type VimKeySequenceRemap = {
   key: string;
   inputs: readonly string[];
   modes?: readonly VimActionBindingMode[];
+  allowProtected?: boolean;
+  desc?: string;
   /** @internal Preserves trusted JavaScript operation order across mapping kinds. */
   __sourceOrder?: number;
 };

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,3 +1,4 @@
+import type { VimMappingScope } from "./mapping-scopes.ts";
 import type { BindablePromptTransformActionId } from "./prompt-transform-actions.ts";
 
 export type VimMode = "insert" | "normal" | "visual" | "visualLine" | "visualBlock";
@@ -232,6 +233,14 @@ export type ResolvedVimInsertKeymap = {
   moveLineEnd: readonly string[];
 };
 
+export type VimScopedKeymapBinding = {
+  actionId: string;
+  key: string;
+  modes: readonly VimMappingScope[];
+  args?: Readonly<Record<string, unknown>>;
+  desc?: string;
+};
+
 export type ResolvedVimKeymap = {
   leader?: string;
   escape: readonly string[];
@@ -245,6 +254,7 @@ export type ResolvedVimKeymap = {
   insert: ResolvedVimInsertKeymap;
   actions: ResolvedVimActionKeymap;
   remaps: VimKeySequenceRemapOptions;
+  scoped: readonly VimScopedKeymapBinding[];
 };
 
 export type VimSearchOptions = {

--- a/src/types.ts
+++ b/src/types.ts
@@ -272,6 +272,8 @@ export type ResolvedVimKeymap = {
   actions: ResolvedVimActionKeymap;
   remaps: VimKeySequenceRemapOptions;
   scoped: readonly VimScopedKeymapBinding[];
+  /** Compiler tombstones. Keep scope-local unmaps from erasing sibling grammar. */
+  unmaps: readonly { key: string; modes: readonly VimMappingScope[] }[];
 };
 
 export type VimSearchOptions = {

--- a/src/types.ts
+++ b/src/types.ts
@@ -155,6 +155,8 @@ export type VimActionKeyBindingEntry =
       modes?: readonly VimActionBindingMode[];
       allowProtected?: boolean;
       desc?: string;
+      /** @internal Preserves trusted JavaScript operation order across mapping kinds. */
+      __sourceOrder?: number;
     };
 
 export type VimActionKeymapOptions = Partial<
@@ -165,6 +167,8 @@ export type VimKeySequenceRemap = {
   key: string;
   inputs: readonly string[];
   modes?: readonly VimActionBindingMode[];
+  /** @internal Preserves trusted JavaScript operation order across mapping kinds. */
+  __sourceOrder?: number;
 };
 
 export type VimKeySequenceRemapOptions = {
@@ -218,6 +222,8 @@ export type ResolvedVimActionBinding = {
   modes?: readonly VimActionBindingMode[];
   allowProtected?: boolean;
   desc?: string;
+  /** @internal Preserves trusted JavaScript operation order across mapping kinds. */
+  __sourceOrder?: number;
 };
 
 export type ResolvedVimActionKeymap = {
@@ -256,6 +262,8 @@ export type VimScopedKeymapBinding = {
   args?: Readonly<Record<string, unknown>>;
   allowProtected?: boolean;
   desc?: string;
+  /** @internal Preserves trusted JavaScript operation order across mapping kinds. */
+  __sourceOrder?: number;
 };
 
 export type ResolvedVimKeymap = {

--- a/src/vim-editor.ts
+++ b/src/vim-editor.ts
@@ -36,6 +36,7 @@ import {
   cloneResolvedVimOptions,
   cursorStyleForMode,
   DEFAULT_VIM_OPTIONS,
+  escapeAliasesForScope,
   keymapForOptions,
   promptTransformsForOptions,
   searchForOptions,
@@ -323,12 +324,7 @@ export class VimEditor extends CustomEditor {
       canFastDelegateInsertInput(this.modalState, data, {
         isAutocompleteOpen: this.isShowingAutocomplete(),
         isMacroReplaying: this.isMacroReplaying,
-        escape: [
-          ...keymap.escape,
-          ...keymap.scoped
-            .filter((binding) => binding.actionId === "escape" && binding.modes.includes("insert"))
-            .map((binding) => binding.key),
-        ],
+        escape: escapeAliasesForScope(keymap, "insert"),
       })
     ) {
       this.delegateDefaultInput(data);

--- a/src/vim-editor.ts
+++ b/src/vim-editor.ts
@@ -318,11 +318,17 @@ export class VimEditor extends CustomEditor {
   }
 
   override handleInput(data: string): void {
+    const keymap = keymapForOptions(this.options);
     if (
       canFastDelegateInsertInput(this.modalState, data, {
         isAutocompleteOpen: this.isShowingAutocomplete(),
         isMacroReplaying: this.isMacroReplaying,
-        escape: keymapForOptions(this.options).escape,
+        escape: [
+          ...keymap.escape,
+          ...keymap.scoped
+            .filter((binding) => binding.actionId === "escape" && binding.modes.includes("insert"))
+            .map((binding) => binding.key),
+        ],
       })
     ) {
       this.delegateDefaultInput(data);

--- a/test/config-js.test.ts
+++ b/test/config-js.test.ts
@@ -340,6 +340,33 @@ export default (vim) => {
     expect(result.plan.scopes.normal.exact.zq?.id).toBe("prompt.transform.quote");
   });
 
+  test("project action replaces JS descriptor across canonical scopes", () => {
+    const result = resolveVimOptions(
+      undefined,
+      { piVimMode: { keymap: { motions: { wordForward: ["L"] } } } },
+      {
+        kind: "success",
+        warnings: [],
+        operations: [
+          {
+            kind: "map",
+            mapping: {
+              kind: "descriptor",
+              actionId: "motion.wordForward",
+              key: "H",
+              modes: ["normal", "operatorPending"],
+            },
+          },
+        ],
+      },
+    );
+
+    expect(result.plan.scopes.normal.exact.H).toBeUndefined();
+    expect(result.plan.scopes.operatorPending.exact.H).toBeUndefined();
+    expect(result.plan.scopes.normal.exact.L?.id).toBe("motion.wordForward");
+    expect(result.plan.scopes.operatorPending.exact.L?.id).toBe("motion.wordForward");
+  });
+
   test("later JS remap replaces lower action in only claimed scopes", () => {
     const result = resolveVimOptions(
       {
@@ -559,6 +586,27 @@ export default (vim) => {
     }
   });
 
+  test("rejected insert descriptors do not reappear in scoped plan", () => {
+    const result = resolveVimOptions(undefined, undefined, {
+      kind: "success",
+      warnings: [],
+      operations: [
+        {
+          kind: "map",
+          mapping: {
+            kind: "descriptor",
+            actionId: "insert.deleteWordBackward",
+            key: "a",
+            modes: ["insert"],
+          },
+        },
+      ],
+    });
+
+    expect(result.options.keymap?.scoped).toEqual([]);
+    expect(result.plan.scopes.insert.exact.a).toBeUndefined();
+  });
+
   test("invalid remap modes are dropped", () => {
     const result = resolveVimOptions(undefined, undefined, {
       appendKeymap: true,
@@ -626,6 +674,24 @@ export default (vim) => {
         },
       ]);
       expect(result.warnings).toEqual([]);
+    } finally {
+      f.cleanup();
+    }
+  });
+
+  test("rejects null and empty arguments for no-argument descriptors", async () => {
+    const f = fixture();
+    try {
+      f.write(`export default (vim) => {
+  vim.keymap.set("n", "H", vim.action.motion.wordForward(null));
+  vim.keymap.set("n", "L", vim.action.motion.wordForward({}));
+};`);
+      const result = await loadVimJsConfig(f.path);
+      expect(operations(result)).toEqual([]);
+      expect(result.warnings).toEqual([
+        "global JS config: motion.wordForward does not accept these arguments",
+        "global JS config: motion.wordForward does not accept these arguments",
+      ]);
     } finally {
       f.cleanup();
     }

--- a/test/config-js.test.ts
+++ b/test/config-js.test.ts
@@ -1365,14 +1365,15 @@ export default (vim) => {
     }
   });
 
-  test("per-binding protected overrides survive prompt and insert descriptor compilation", async () => {
+  test("per-binding options survive descriptor and replay compilation", async () => {
     const f = fixture();
     try {
       f.write(`
 export default (vim) => {
-  vim.keymap.set("n", "<C-p>", vim.prompt.quote(), { allowProtected: true });
+  vim.keymap.set("n", "<C-p>", vim.prompt.quote(), { allowProtected: true, desc: "Quote" });
   vim.keymap.set("i", "<C-v>", vim.prompt.deleteWordBackward(), { allowProtected: true });
-  vim.keymap.set("n", "<C-t>", vim.prompt.reflow());
+  vim.keymap.set("n", "<C-t>", "j", { allowProtected: true, desc: "Replay down" });
+  vim.keymap.set("n", "<C-g>", vim.prompt.reflow());
 };`);
       const loaded = await loadVimJsConfig(f.path);
       const resolved = resolveVimOptions(undefined, undefined, loaded);
@@ -1383,14 +1384,23 @@ export default (vim) => {
           args: { action: "quote" },
           modes: ["normal"],
           allowProtected: true,
+          desc: "Quote",
         },
       ]);
       expect(resolved.options.keymap?.insert.deleteWordBackward).toContain("ctrl+v");
+      expect(resolved.options.keymap?.remaps.accepted).toContainEqual({
+        key: "ctrl+t",
+        inputs: ["j"],
+        modes: ["normal"],
+        allowProtected: true,
+        desc: "Replay down",
+      });
+      expect(resolved.plan.scopes.normal.exact["ctrl+t"]?.kind).toBe("remap");
       expect(resolved.warnings).toEqual(
-        expect.arrayContaining([expect.stringContaining("protected key ctrl+t")]),
+        expect.arrayContaining([expect.stringContaining("protected key ctrl+g")]),
       );
       expect(resolved.options.keymap?.actions.accepted).not.toEqual(
-        expect.arrayContaining([expect.objectContaining({ key: "ctrl+t" })]),
+        expect.arrayContaining([expect.objectContaining({ key: "ctrl+g" })]),
       );
     } finally {
       f.cleanup();

--- a/test/config-js.test.ts
+++ b/test/config-js.test.ts
@@ -778,6 +778,24 @@ export default (vim) => {
     }
   });
 
+  test("unmaps inherited grammar in only selected scopes", async () => {
+    const f = fixture();
+    try {
+      f.write(`export default (vim) => vim.keymap.set("n", "w", null);`);
+      const resolved = resolveVimOptions(undefined, undefined, await loadVimJsConfig(f.path));
+      const keymap = resolved.options.keymap;
+      expect(resolved.plan.scopes.normal.exact.w).toBeUndefined();
+      expect(resolved.plan.scopes.visual.exact.w?.id).toBe("motion.wordForward");
+      expect(resolveNormalCommand("w", undefined, keymap, "normal").type).toBe("none");
+      expect(resolveNormalCommand("w", undefined, keymap, "visual")).toMatchObject({
+        type: "motion",
+        motion: "wordForward",
+      });
+    } finally {
+      f.cleanup();
+    }
+  });
+
   test("keeps mappings declared after an unmap", async () => {
     const f = fixture();
     try {

--- a/test/config-js.test.ts
+++ b/test/config-js.test.ts
@@ -6,6 +6,7 @@ import { join } from "node:path";
 import { resolveNormalCommand } from "../src/commands.ts";
 import { loadVimJsConfig } from "../src/config-js.ts";
 import { loadVimOptions, resolveVimOptions } from "../src/config.ts";
+import { encodeMappingTokens } from "../src/mapping-scopes.ts";
 
 function fixture() {
   const dir = mkdtempSync(join(tmpdir(), "pi-vimmode-js-config-"));
@@ -422,13 +423,15 @@ export default (vim) => {
           mapping: {
             kind: "insert",
             action: "deleteWordBackward",
-            key: "alt+xalt+y",
+            key: encodeMappingTokens(["alt+x", "alt+y"]),
           },
         },
       ]);
       const resolved = resolveVimOptions(undefined, undefined, result);
-      expect(resolved.warnings).toContain(
-        "global JS config: piVimMode.keymap.insert.deleteWordBackward contains unsupported printable text sequence alt+xalt+y",
+      expect(resolved.warnings).toContainEqual(
+        expect.stringContaining(
+          "global JS config: piVimMode.keymap.insert.deleteWordBackward contains unsupported printable text sequence",
+        ),
       );
       expect(resolved.plan.scopes.insert.exact).not.toHaveProperty("alt+xalt+y");
     } finally {
@@ -494,7 +497,7 @@ export default (vim) => {
           mapping: {
             kind: "action",
             actionId: "prompt.transform.quote",
-            key: "<leader>q",
+            key: encodeMappingTokens(["<leader>", "q"]),
             args: undefined,
             modes: ["normal"],
           },
@@ -505,14 +508,19 @@ export default (vim) => {
           mapping: {
             kind: "action",
             actionId: "prompt.transform.reflow",
-            key: "<leader>r",
+            key: encodeMappingTokens(["<leader>", "r"]),
             args: {},
             modes: ["normal"],
           },
         },
         {
           kind: "map",
-          mapping: { kind: "remap", key: "<leader>x", inputs: ["leader"], modes: ["normal"] },
+          mapping: {
+            kind: "remap",
+            key: encodeMappingTokens(["<leader>", "x"]),
+            inputs: ["leader"],
+            modes: ["normal"],
+          },
         },
       ]);
 
@@ -935,7 +943,10 @@ export default (vim) => {
     );
   });
 
-  test("uses terminal-key token boundaries during prefix preflight", () => {
+  test("preserves terminal-key token boundaries during prefix preflight", () => {
+    const escapeThenA = encodeMappingTokens(["escape", "a"]);
+    const altZThenA = encodeMappingTokens(["alt+z", "a"]);
+    const altZThenCtrlY = encodeMappingTokens(["alt+z", "ctrl+y"]);
     const result = resolveVimOptions(undefined, undefined, {
       kind: "success",
       warnings: [],
@@ -954,7 +965,7 @@ export default (vim) => {
           mapping: {
             kind: "descriptor",
             actionId: "command.redo",
-            key: "escapea",
+            key: escapeThenA,
             modes: ["normal"],
           },
         },
@@ -963,7 +974,7 @@ export default (vim) => {
           mapping: {
             kind: "descriptor",
             actionId: "command.pasteAfter",
-            key: "alt+za",
+            key: altZThenA,
             modes: ["normal"],
           },
         },
@@ -972,7 +983,7 @@ export default (vim) => {
           mapping: {
             kind: "descriptor",
             actionId: "command.pasteBefore",
-            key: "alt+zctrl+y",
+            key: altZThenCtrlY,
             modes: ["normal"],
           },
         },
@@ -981,11 +992,52 @@ export default (vim) => {
 
     expect(result.warnings).toEqual([]);
     expect(result.plan.scopes.normal.exact.e?.id).toBe("command.undo");
-    expect(result.plan.scopes.normal.exact.escapea?.id).toBe("command.redo");
-    expect(result.plan.scopes.normal.exact["alt+za"]?.id).toBe("command.pasteAfter");
-    expect(result.plan.scopes.normal.exact["alt+zctrl+y"]?.id).toBe("command.pasteBefore");
-    expect(result.plan.scopes.normal.prefixes.escape).toEqual(["escapea"]);
-    expect(result.plan.scopes.normal.prefixes["alt+z"]).toEqual(["alt+za", "alt+zctrl+y"]);
+    expect(result.plan.scopes.normal.exact[escapeThenA]?.id).toBe("command.redo");
+    expect(result.plan.scopes.normal.exact[altZThenA]?.id).toBe("command.pasteAfter");
+    expect(result.plan.scopes.normal.exact[altZThenCtrlY]?.id).toBe("command.pasteBefore");
+    expect(result.plan.scopes.normal.prefixes.escape).toEqual([escapeThenA]);
+    expect(result.plan.scopes.normal.prefixes["alt+z"]).toEqual([altZThenA, altZThenCtrlY]);
+    const specialPrefix = resolveNormalCommand(
+      "escape",
+      undefined,
+      result.options.keymap!,
+      "normal",
+    );
+    expect(specialPrefix).toEqual({ type: "pending", pending: "escape" });
+    if (specialPrefix.type !== "pending") throw new Error("expected named-key prefix");
+    expect(
+      resolveNormalCommand("a", specialPrefix.pending, result.options.keymap!, "normal"),
+    ).toMatchObject({ type: "command", command: "redo" });
+
+    const literalEscapeA = encodeMappingTokens(["e", "s", "c", "a", "p", "e", "a"]);
+    const literal = resolveVimOptions(undefined, undefined, {
+      kind: "success",
+      warnings: [],
+      operations: [
+        {
+          kind: "map",
+          mapping: {
+            kind: "descriptor",
+            actionId: "command.undo",
+            key: "e",
+            modes: ["normal"],
+          },
+        },
+        {
+          kind: "map",
+          mapping: {
+            kind: "descriptor",
+            actionId: "command.redo",
+            key: literalEscapeA,
+            modes: ["normal"],
+          },
+        },
+      ],
+    });
+    expect(literal.plan.scopes.normal.exact[literalEscapeA]).toBeUndefined();
+    expect(literal.warnings).toContainEqual(
+      expect.stringContaining("strict-prefix conflict with command.undo.e"),
+    );
   });
 
   test("canonicalizes modifier order and rejects duplicate modifiers", async () => {
@@ -1084,7 +1136,9 @@ export default (vim) => {
     );
 
     expect(result.options.keymap?.remaps.accepted).toEqual([]);
-    expect(result.plan.scopes.normal.exact[",u"]?.id).toBe("prompt.transform.quote");
+    expect(result.plan.scopes.normal.exact[encodeMappingTokens([",", "u"])]?.id).toBe(
+      "prompt.transform.quote",
+    );
   });
 
   test("JS escape descriptors stay in selected scopes", () => {
@@ -1499,7 +1553,11 @@ export default (vim) => {
       expect(resolved.options.keymap?.leader).toBe(",");
       expect(resolved.options.keymap?.scoped).toEqual(
         expect.arrayContaining([
-          expect.objectContaining({ actionId: "command.undo", key: ",u", modes: ["normal"] }),
+          expect.objectContaining({
+            actionId: "command.undo",
+            key: encodeMappingTokens([",", "u"]),
+            modes: ["normal"],
+          }),
         ]),
       );
     } finally {

--- a/test/config-js.test.ts
+++ b/test/config-js.test.ts
@@ -68,6 +68,207 @@ export default (vim) => {
     }
   });
 
+  test("keeps command leaf and nested EasyMotion descriptor factories callable", async () => {
+    const f = fixture();
+    try {
+      f.write(`
+export default (vim) => {
+  vim.keymap.set("n", "e", vim.action.command.easymotion());
+  vim.keymap.set("n", "g", vim.action.command.easymotion.goToChar());
+};`);
+      const result = await loadVimJsConfig(f.path);
+      expect(result.warnings).toEqual([]);
+      expect(operations(result)).toEqual([
+        {
+          kind: "map",
+          mapping: {
+            kind: "descriptor",
+            actionId: "command.easymotion",
+            key: "e",
+            modes: ["normal"],
+          },
+        },
+        {
+          kind: "map",
+          mapping: {
+            kind: "descriptor",
+            actionId: "command.easymotion",
+            key: "g",
+            modes: ["normal"],
+          },
+        },
+      ]);
+    } finally {
+      f.cleanup();
+    }
+  });
+
+  test("runtime prefixes exclude scoped unmap tombstones and normal-only commands", () => {
+    const normalWithoutLastDescendant = resolveVimOptions(undefined, undefined, {
+      kind: "success",
+      warnings: [],
+      operations: [
+        {
+          kind: "map",
+          mapping: {
+            kind: "descriptor",
+            actionId: "motion.wordForward",
+            key: "zx",
+            modes: ["normal"],
+          },
+        },
+        { kind: "unmap", key: "zx", modes: ["normal"] },
+      ],
+    }).options.keymap!;
+    expect(resolveNormalCommand("z", undefined, normalWithoutLastDescendant, "normal")).toEqual({
+      type: "none",
+    });
+
+    const normalWithSibling = resolveVimOptions(undefined, undefined, {
+      kind: "success",
+      warnings: [],
+      operations: [
+        {
+          kind: "map",
+          mapping: {
+            kind: "descriptor",
+            actionId: "motion.wordForward",
+            key: "zx",
+            modes: ["normal"],
+          },
+        },
+        {
+          kind: "map",
+          mapping: {
+            kind: "descriptor",
+            actionId: "motion.wordBackward",
+            key: "zy",
+            modes: ["normal"],
+          },
+        },
+        { kind: "unmap", key: "zx", modes: ["normal"] },
+      ],
+    }).options.keymap!;
+    const normalPrefix = resolveNormalCommand("z", undefined, normalWithSibling, "normal");
+    expect(normalPrefix).toEqual({ type: "pending", pending: "z" });
+    if (normalPrefix.type !== "pending") throw new Error("expected normal prefix");
+    expect(
+      resolveNormalCommand("y", normalPrefix.pending, normalWithSibling, "normal"),
+    ).toMatchObject({
+      type: "motion",
+      motion: "wordBackward",
+    });
+
+    const operatorWithoutLastDescendant = resolveVimOptions(undefined, undefined, {
+      kind: "success",
+      warnings: [],
+      operations: [
+        {
+          kind: "map",
+          mapping: {
+            kind: "descriptor",
+            actionId: "motion.wordForward",
+            key: "zx",
+            modes: ["operatorPending"],
+          },
+        },
+        { kind: "unmap", key: "zx", modes: ["operatorPending"] },
+      ],
+    }).options.keymap!;
+    const deletePrefix = resolveNormalCommand(
+      "d",
+      undefined,
+      operatorWithoutLastDescendant,
+      "normal",
+    );
+    expect(deletePrefix.type).toBe("pending");
+    if (deletePrefix.type !== "pending") throw new Error("expected delete pending");
+    expect(resolveNormalCommand("z", deletePrefix.pending, operatorWithoutLastDescendant)).toEqual({
+      type: "invalid",
+    });
+
+    const operatorWithSibling = resolveVimOptions(undefined, undefined, {
+      kind: "success",
+      warnings: [],
+      operations: [
+        {
+          kind: "map",
+          mapping: {
+            kind: "descriptor",
+            actionId: "motion.wordForward",
+            key: "zx",
+            modes: ["operatorPending"],
+          },
+        },
+        {
+          kind: "map",
+          mapping: {
+            kind: "descriptor",
+            actionId: "motion.wordBackward",
+            key: "zy",
+            modes: ["operatorPending"],
+          },
+        },
+        { kind: "unmap", key: "zx", modes: ["operatorPending"] },
+      ],
+    }).options.keymap!;
+    const operatorPrefix = resolveNormalCommand("d", undefined, operatorWithSibling, "normal");
+    expect(operatorPrefix.type).toBe("pending");
+    if (operatorPrefix.type !== "pending") throw new Error("expected delete pending");
+    const motionPrefix = resolveNormalCommand("z", operatorPrefix.pending, operatorWithSibling);
+    expect(motionPrefix.type).toBe("pending");
+    if (motionPrefix.type !== "pending") throw new Error("expected motion pending");
+    expect(resolveNormalCommand("y", motionPrefix.pending, operatorWithSibling)).toMatchObject({
+      type: "operatorMotion",
+      motion: "wordBackward",
+    });
+
+    const tombstonedRepeat = resolveVimOptions(undefined, undefined, {
+      kind: "success",
+      warnings: [],
+      operations: [
+        {
+          kind: "map",
+          mapping: {
+            kind: "descriptor",
+            actionId: "operator.delete",
+            key: "z",
+            modes: ["normal"],
+          },
+        },
+        { kind: "unmap", key: "z", modes: ["operatorPending"] },
+      ],
+    }).options.keymap!;
+    const customDelete = resolveNormalCommand("z", undefined, tombstonedRepeat, "normal");
+    expect(customDelete.type).toBe("pending");
+    if (customDelete.type !== "pending") throw new Error("expected custom delete pending");
+    expect(resolveNormalCommand("z", customDelete.pending, tombstonedRepeat)).toEqual({
+      type: "invalid",
+    });
+
+    const normalOnlyCommand = resolveVimOptions(undefined, undefined, {
+      kind: "success",
+      warnings: [],
+      operations: [
+        {
+          kind: "map",
+          mapping: {
+            kind: "descriptor",
+            actionId: "command.undo",
+            key: "zx",
+            modes: ["normal"],
+          },
+        },
+      ],
+    }).options.keymap!;
+    const pendingDelete = resolveNormalCommand("d", undefined, normalOnlyCommand, "normal");
+    expect(pendingDelete.type).toBe("pending");
+    if (pendingDelete.type !== "pending") throw new Error("expected delete pending");
+    expect(resolveNormalCommand("z", pendingDelete.pending, normalOnlyCommand)).toEqual({
+      type: "invalid",
+    });
+  });
+
   test("loads opaque finite action descriptors in canonical scopes", async () => {
     const f = fixture();
     try {

--- a/test/config-js.test.ts
+++ b/test/config-js.test.ts
@@ -897,6 +897,38 @@ export default (vim) => {
     }
   });
 
+  test("per-binding protected overrides survive prompt and insert descriptor compilation", async () => {
+    const f = fixture();
+    try {
+      f.write(`
+export default (vim) => {
+  vim.keymap.set("n", "<C-p>", vim.prompt.quote(), { allowProtected: true });
+  vim.keymap.set("i", "<C-v>", vim.prompt.deleteWordBackward(), { allowProtected: true });
+  vim.keymap.set("n", "<C-t>", vim.prompt.reflow());
+};`);
+      const loaded = await loadVimJsConfig(f.path);
+      const resolved = resolveVimOptions(undefined, undefined, loaded);
+      expect(resolved.options.keymap?.actions.accepted).toEqual([
+        {
+          actionId: "prompt.transform.quote",
+          key: "ctrl+p",
+          args: { action: "quote" },
+          modes: ["normal"],
+          allowProtected: true,
+        },
+      ]);
+      expect(resolved.options.keymap?.insert.deleteWordBackward).toContain("ctrl+v");
+      expect(resolved.warnings).toEqual(
+        expect.arrayContaining([expect.stringContaining("protected key ctrl+t")]),
+      );
+      expect(resolved.options.keymap?.actions.accepted).not.toEqual(
+        expect.arrayContaining([expect.objectContaining({ key: "ctrl+t" })]),
+      );
+    } finally {
+      f.cleanup();
+    }
+  });
+
   test("protected lhs warns without registering", async () => {
     const f = fixture();
     try {
@@ -1015,6 +1047,60 @@ export default (vim) => {
     } finally {
       f.cleanup();
     }
+  });
+
+  test("leader-form unmaps suppress inherited bindings after expansion", async () => {
+    const f = fixture();
+    try {
+      f.write(`export default (vim) => {
+  vim.g.mapleader = ",";
+  vim.keymap.set("n", "<leader>x", null);
+};`);
+      const loaded = await loadVimJsConfig(f.path);
+      const resolved = resolveVimOptions(
+        {
+          piVimMode: {
+            leader: ",",
+            keymap: { commands: { undo: ["<leader>x"] } },
+          },
+        },
+        undefined,
+        loaded,
+      );
+      expect(resolved.plan.scopes.normal.exact[",x"]).toBeUndefined();
+      expect(resolved.options.keymap?.unmaps).toEqual([{ key: ",x", modes: ["normal"] }]);
+    } finally {
+      f.cleanup();
+    }
+  });
+
+  test("project text-object bindings replace matching JS descriptors", () => {
+    const resolved = resolveVimOptions(
+      undefined,
+      {
+        piVimMode: {
+          keymap: { textObjects: { kinds: { inner: ["z"] } } },
+        },
+      },
+      {
+        kind: "success",
+        warnings: [],
+        operations: [
+          {
+            kind: "map",
+            mapping: {
+              kind: "descriptor",
+              actionId: "textObject.kind.inner",
+              key: "i",
+              modes: ["operatorPending"],
+            },
+          },
+        ],
+      },
+    );
+    expect(resolved.options.keymap?.scoped).not.toEqual(
+      expect.arrayContaining([expect.objectContaining({ actionId: "textObject.kind.inner" })]),
+    );
   });
 
   test("unmaps inherited mappings in only selected scopes", async () => {

--- a/test/config-js.test.ts
+++ b/test/config-js.test.ts
@@ -267,6 +267,36 @@ export default (vim) => {
     expect(resolveNormalCommand("z", pendingDelete.pending, normalOnlyCommand)).toEqual({
       type: "invalid",
     });
+
+    const tombstonedOperatorCommands = resolveVimOptions(
+      {
+        piVimMode: {
+          keymap: {
+            commands: {
+              startSearch: ["zx"],
+              findChar: ["zy"],
+              repeatCharSearch: ["zz"],
+            },
+          },
+        },
+      },
+      undefined,
+      {
+        kind: "success",
+        warnings: [],
+        operations: [
+          { kind: "unmap", key: "zx", modes: ["operatorPending"] },
+          { kind: "unmap", key: "zy", modes: ["operatorPending"] },
+          { kind: "unmap", key: "zz", modes: ["operatorPending"] },
+        ],
+      },
+    ).options.keymap!;
+    const operatorCommand = resolveNormalCommand("d", undefined, tombstonedOperatorCommands);
+    expect(operatorCommand.type).toBe("pending");
+    if (operatorCommand.type !== "pending") throw new Error("expected operator pending");
+    expect(resolveNormalCommand("z", operatorCommand.pending, tombstonedOperatorCommands)).toEqual({
+      type: "invalid",
+    });
   });
 
   test("loads opaque finite action descriptors in canonical scopes", async () => {
@@ -841,6 +871,103 @@ export default (vim) => {
     ]);
   });
 
+  test("preserves source order across descriptor and remap mapping kinds", () => {
+    const result = resolveVimOptions(undefined, undefined, {
+      kind: "success",
+      warnings: [],
+      operations: [
+        {
+          kind: "map",
+          mapping: {
+            kind: "descriptor",
+            actionId: "command.undo",
+            key: "zz",
+            modes: ["normal"],
+          },
+        },
+        {
+          kind: "map",
+          mapping: { kind: "remap", key: "z", inputs: ["u"], modes: ["normal"] },
+        },
+      ],
+    });
+
+    expect(result.plan.scopes.normal.exact.zz?.id).toBe("command.undo");
+    expect(result.plan.scopes.normal.exact.z).toBeUndefined();
+    expect(result.warnings).toContainEqual(
+      expect.stringContaining("remap.z in normal: strict-prefix conflict with command.undo.zz"),
+    );
+  });
+
+  test("treats modified key plus trailing keys as a sequence during prefix preflight", () => {
+    const result = resolveVimOptions(undefined, undefined, {
+      kind: "success",
+      warnings: [],
+      operations: [
+        {
+          kind: "map",
+          mapping: {
+            kind: "descriptor",
+            actionId: "command.undo",
+            key: "alt+x",
+            modes: ["normal"],
+          },
+        },
+        {
+          kind: "map",
+          mapping: {
+            kind: "descriptor",
+            actionId: "command.redo",
+            key: "alt+xa",
+            modes: ["normal"],
+          },
+        },
+      ],
+    });
+
+    expect(result.plan.scopes.normal.exact["alt+x"]?.id).toBe("command.undo");
+    expect(result.plan.scopes.normal.exact["alt+xa"]).toBeUndefined();
+    expect(result.plan.scopes.normal.prefixes["alt+x"]).toBeUndefined();
+    expect(result.warnings).toContainEqual(
+      expect.stringContaining(
+        "command.redo.alt+xa in normal: strict-prefix conflict with command.undo.alt+x",
+      ),
+    );
+  });
+
+  test("canonicalizes modifier order and rejects duplicate modifiers", async () => {
+    const f = fixture();
+    try {
+      f.write(`
+export default (vim) => {
+  vim.keymap.set("n", "<C-S-x>", vim.action.command.undo());
+  vim.keymap.set("n", "<C-C-x>", vim.action.command.redo());
+};`);
+      const result = await loadVimJsConfig(f.path);
+      expect(operations(result)).toEqual([
+        {
+          kind: "map",
+          mapping: {
+            kind: "descriptor",
+            actionId: "command.undo",
+            key: "shift+ctrl+x",
+            modes: ["normal"],
+          },
+        },
+      ]);
+      expect(result.warnings).toContainEqual(
+        expect.stringContaining("keymap lhs must contain supported key syntax"),
+      );
+      const keymap = resolveVimOptions(undefined, undefined, result).options.keymap!;
+      expect(resolveNormalCommand("shift+ctrl+x", undefined, keymap, "normal")).toMatchObject({
+        type: "command",
+        command: "undo",
+      });
+    } finally {
+      f.cleanup();
+    }
+  });
+
   test("latest same-scope JS exact mapping wins", () => {
     const result = resolveVimOptions(undefined, undefined, {
       kind: "success",
@@ -984,6 +1111,39 @@ export default (vim) => {
     expect(result.options.keymap?.insert.openLineBelow).not.toContain("super+j");
     for (const scope of ["insert", "visual", "visualLine", "visualBlock"] as const) {
       expect(result.plan.scopes[scope].exact["super+j"]?.kind).toBe("escape");
+    }
+  });
+
+  test("project escape array replaces lower JS escape descriptors", () => {
+    const result = resolveVimOptions(
+      undefined,
+      { piVimMode: { keymap: { escape: ["<C-[>"] } } },
+      {
+        kind: "success",
+        warnings: [],
+        operations: [
+          {
+            kind: "map",
+            mapping: {
+              kind: "descriptor",
+              actionId: "escape",
+              key: "alt+z",
+              modes: ["insert", "visual", "visualLine", "visualBlock", "operatorPending"],
+            },
+          },
+        ],
+      },
+    );
+
+    for (const scope of [
+      "insert",
+      "visual",
+      "visualLine",
+      "visualBlock",
+      "operatorPending",
+    ] as const) {
+      expect(result.plan.scopes[scope].exact["alt+z"]).toBeUndefined();
+      expect(result.plan.scopes[scope].exact["ctrl+["]?.kind).toBe("escape");
     }
   });
 

--- a/test/config-js.test.ts
+++ b/test/config-js.test.ts
@@ -935,6 +935,59 @@ export default (vim) => {
     );
   });
 
+  test("uses terminal-key token boundaries during prefix preflight", () => {
+    const result = resolveVimOptions(undefined, undefined, {
+      kind: "success",
+      warnings: [],
+      operations: [
+        {
+          kind: "map",
+          mapping: {
+            kind: "descriptor",
+            actionId: "command.undo",
+            key: "e",
+            modes: ["normal"],
+          },
+        },
+        {
+          kind: "map",
+          mapping: {
+            kind: "descriptor",
+            actionId: "command.redo",
+            key: "escapea",
+            modes: ["normal"],
+          },
+        },
+        {
+          kind: "map",
+          mapping: {
+            kind: "descriptor",
+            actionId: "command.pasteAfter",
+            key: "alt+za",
+            modes: ["normal"],
+          },
+        },
+        {
+          kind: "map",
+          mapping: {
+            kind: "descriptor",
+            actionId: "command.pasteBefore",
+            key: "alt+zctrl+y",
+            modes: ["normal"],
+          },
+        },
+      ],
+    });
+
+    expect(result.warnings).toEqual([]);
+    expect(result.plan.scopes.normal.exact.e?.id).toBe("command.undo");
+    expect(result.plan.scopes.normal.exact.escapea?.id).toBe("command.redo");
+    expect(result.plan.scopes.normal.exact["alt+za"]?.id).toBe("command.pasteAfter");
+    expect(result.plan.scopes.normal.exact["alt+zctrl+y"]?.id).toBe("command.pasteBefore");
+    expect(result.plan.scopes.normal.prefixes.escape).toEqual(["escapea"]);
+    expect(result.plan.scopes.normal.prefixes["alt+z"]).toEqual(["alt+za", "alt+zctrl+y"]);
+  });
+
   test("canonicalizes modifier order and rejects duplicate modifiers", async () => {
     const f = fixture();
     try {

--- a/test/config-js.test.ts
+++ b/test/config-js.test.ts
@@ -1074,6 +1074,25 @@ export default (vim) => {
     }
   });
 
+  test("leader-form scoped descriptors reserve the expanded leader prefix", async () => {
+    const f = fixture();
+    try {
+      f.write(`export default (vim) => {
+  vim.g.mapleader = ",";
+  vim.keymap.set("n", "<leader>u", vim.action.command.undo());
+};`);
+      const resolved = resolveVimOptions(undefined, undefined, await loadVimJsConfig(f.path));
+      expect(resolved.options.keymap?.leader).toBe(",");
+      expect(resolved.options.keymap?.scoped).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({ actionId: "command.undo", key: ",u", modes: ["normal"] }),
+        ]),
+      );
+    } finally {
+      f.cleanup();
+    }
+  });
+
   test("project text-object bindings replace matching JS descriptors", () => {
     const resolved = resolveVimOptions(
       undefined,

--- a/test/config-js.test.ts
+++ b/test/config-js.test.ts
@@ -3,6 +3,7 @@ import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
+import { resolveNormalCommand } from "../src/commands.ts";
 import { loadVimJsConfig } from "../src/config-js.ts";
 import { loadVimOptions, resolveVimOptions } from "../src/config.ts";
 
@@ -62,6 +63,86 @@ export default (vim) => {
           },
         },
       ]);
+    } finally {
+      f.cleanup();
+    }
+  });
+
+  test("loads opaque finite action descriptors in canonical scopes", async () => {
+    const f = fixture();
+    try {
+      f.write(`
+export default (vim) => {
+  vim.keymap.set("n", "H", vim.action.motion.wordForward(), { desc: "Next word" });
+  vim.keymap.set("x", "Q", vim.action.motion.wordBackward());
+  vim.keymap.set("o", "W", vim.action.textObject.target.word());
+  vim.keymap.set("n", "undo", "undo");
+};
+`);
+      const result = await loadVimJsConfig(f.path);
+      expect(result.warnings).toEqual([]);
+      expect(operations(result)).toEqual([
+        {
+          kind: "map",
+          mapping: {
+            kind: "descriptor",
+            actionId: "motion.wordForward",
+            key: "H",
+            modes: ["normal"],
+            desc: "Next word",
+          },
+        },
+        {
+          kind: "map",
+          mapping: {
+            kind: "descriptor",
+            actionId: "motion.wordBackward",
+            key: "Q",
+            modes: ["visual", "visualLine", "visualBlock"],
+          },
+        },
+        {
+          kind: "map",
+          mapping: {
+            kind: "descriptor",
+            actionId: "textObject.target.word",
+            key: "W",
+            modes: ["operatorPending"],
+          },
+        },
+        {
+          kind: "map",
+          mapping: { kind: "remap", key: "undo", inputs: ["u", "n", "d", "o"], modes: ["normal"] },
+        },
+      ]);
+      const resolved = resolveVimOptions(undefined, undefined, result);
+      expect(resolved.plan.scopes.normal.exact.H).toEqual({
+        kind: "keymap",
+        id: "motion.wordForward",
+      });
+      expect(resolved.plan.scopes.visual.exact.Q).toEqual({
+        kind: "keymap",
+        id: "motion.wordBackward",
+      });
+      expect(resolved.plan.scopes.operatorPending.exact.W).toEqual({
+        kind: "keymap",
+        id: "textObject.target.word",
+      });
+      const keymap = resolved.options.keymap!;
+      expect(resolveNormalCommand("H", undefined, keymap, "normal")).toMatchObject({
+        type: "motion",
+        motion: "wordForward",
+      });
+      const operator = resolveNormalCommand("d", undefined, keymap, "normal");
+      expect(operator.type).toBe("pending");
+      if (operator.type !== "pending") throw new Error("expected operator pending state");
+      const kind = resolveNormalCommand("i", operator.pending, keymap, "normal");
+      expect(kind.type).toBe("pending");
+      if (kind.type !== "pending") throw new Error("expected text object pending state");
+      expect(resolveNormalCommand("W", kind.pending, keymap, "normal")).toMatchObject({
+        type: "operatorTextObject",
+        textObject: { kind: "inner", target: "word" },
+      });
     } finally {
       f.cleanup();
     }

--- a/test/config-js.test.ts
+++ b/test/config-js.test.ts
@@ -143,6 +143,100 @@ export default (vim) => {
         type: "operatorTextObject",
         textObject: { kind: "inner", target: "word" },
       });
+
+      const customOperator = resolveVimOptions(undefined, undefined, {
+        kind: "success",
+        warnings: [],
+        operations: [
+          {
+            kind: "map",
+            mapping: {
+              kind: "descriptor",
+              actionId: "operator.delete",
+              key: "Z",
+              modes: ["normal"],
+            },
+          },
+        ],
+      }).options.keymap!;
+      const pendingDelete = resolveNormalCommand("Z", undefined, customOperator, "normal");
+      expect(pendingDelete.type).toBe("pending");
+      if (pendingDelete.type !== "pending")
+        throw new Error("expected custom operator pending state");
+      expect(
+        resolveNormalCommand("w", pendingDelete.pending, customOperator, "normal"),
+      ).toMatchObject({
+        type: "operatorMotion",
+        operator: "delete",
+        motion: "wordForward",
+      });
+    } finally {
+      f.cleanup();
+    }
+  });
+
+  test("insert descriptors reject multi-key lhs", async () => {
+    const f = fixture();
+    try {
+      f.write(`
+export default (vim) => {
+  vim.keymap.set("i", "<A-x><A-y>", vim.action.insert.deleteWordBackward());
+};
+`);
+      const result = await loadVimJsConfig(f.path);
+      expect(result.warnings).toEqual([]);
+      expect(operations(result)).toEqual([
+        {
+          kind: "map",
+          mapping: {
+            kind: "insert",
+            action: "deleteWordBackward",
+            key: "alt+xalt+y",
+          },
+        },
+      ]);
+      const resolved = resolveVimOptions(undefined, undefined, result);
+      expect(resolved.warnings).toContain(
+        "global JS config: piVimMode.keymap.insert.deleteWordBackward contains unsupported printable text sequence alt+xalt+y",
+      );
+      expect(resolved.plan.scopes.insert.exact).not.toHaveProperty("alt+xalt+y");
+    } finally {
+      f.cleanup();
+    }
+  });
+
+  test("visual aliases reject commands not executable across every selected scope", async () => {
+    const f = fixture();
+    try {
+      f.write(`
+export default (vim) => {
+  vim.keymap.set("v", "I", vim.action.command.insertLineStart());
+  vim.keymap.set("visualBlock", "I", vim.action.command.insertLineStart());
+};
+`);
+      const result = await loadVimJsConfig(f.path);
+      expect(result.warnings).toEqual([
+        "global JS config: command.insertLineStart does not support selected mode",
+      ]);
+      expect(operations(result)).toHaveLength(1);
+    } finally {
+      f.cleanup();
+    }
+  });
+
+  test("operator-pending rejects mark descriptors", async () => {
+    const f = fixture();
+    try {
+      f.write(`
+export default (vim) => {
+  vim.keymap.set("o", "M", vim.action.mark.jumpExact());
+};
+`);
+      const result = await loadVimJsConfig(f.path);
+      expect(result.warnings).toEqual([
+        "global JS config: mark.jumpExact does not support selected mode",
+      ]);
+      expect(operations(result)).toEqual([]);
     } finally {
       f.cleanup();
     }
@@ -338,6 +432,64 @@ export default (vim) => {
 
     expect(result.options.keymap?.remaps.accepted).toEqual([]);
     expect(result.plan.scopes.normal.exact.zq?.id).toBe("prompt.transform.quote");
+  });
+
+  test("project empty action removes JS descriptor across canonical scopes", () => {
+    const result = resolveVimOptions(
+      undefined,
+      { piVimMode: { keymap: { motions: { wordForward: [] } } } },
+      {
+        kind: "success",
+        warnings: [],
+        operations: [
+          {
+            kind: "map",
+            mapping: {
+              kind: "descriptor",
+              actionId: "motion.wordForward",
+              key: "H",
+              modes: ["normal", "operatorPending"],
+            },
+          },
+        ],
+      },
+    );
+
+    expect(result.plan.scopes.normal.exact.H).toBeUndefined();
+    expect(result.plan.scopes.operatorPending.exact.H).toBeUndefined();
+  });
+
+  test("operator-pending unmaps suppress inherited motions and text objects", () => {
+    const result = resolveVimOptions(undefined, undefined, {
+      kind: "success",
+      warnings: [],
+      operations: [
+        { kind: "unmap", key: "w", modes: ["operatorPending"] },
+        { kind: "unmap", key: "i", modes: ["operatorPending"] },
+        { kind: "unmap", key: "/", modes: ["operatorPending"] },
+      ],
+    });
+    const keymap = result.options.keymap!;
+    const pending = resolveNormalCommand("d", undefined, keymap, "normal");
+    expect(pending.type).toBe("pending");
+    if (pending.type !== "pending") throw new Error("expected operator pending state");
+    expect(resolveNormalCommand("w", pending.pending, keymap, "normal").type).toBe("invalid");
+    expect(resolveNormalCommand("i", pending.pending, keymap, "normal").type).toBe("invalid");
+    expect(resolveNormalCommand("/", pending.pending, keymap, "normal").type).toBe("invalid");
+  });
+
+  test("project exact mappings restore lower JS unmaps", () => {
+    const result = resolveVimOptions(
+      undefined,
+      { piVimMode: { keymap: { motions: { wordForward: ["w"] } } } },
+      {
+        kind: "success",
+        warnings: [],
+        operations: [{ kind: "unmap", key: "w", modes: ["normal"] }],
+      },
+    );
+
+    expect(result.plan.scopes.normal.exact.w?.id).toBe("motion.wordForward");
   });
 
   test("project action replaces JS descriptor across canonical scopes", () => {
@@ -552,6 +704,54 @@ export default (vim) => {
 
     expect(result.options.keymap?.remaps.accepted).toEqual([]);
     expect(result.plan.scopes.normal.exact[",u"]?.id).toBe("prompt.transform.quote");
+  });
+
+  test("JS escape descriptors stay in selected scopes", () => {
+    const result = resolveVimOptions(undefined, undefined, {
+      kind: "success",
+      warnings: [],
+      operations: [
+        {
+          kind: "map",
+          mapping: {
+            kind: "descriptor",
+            actionId: "escape",
+            key: "alt+z",
+            modes: ["insert"],
+          },
+        },
+      ],
+    });
+
+    expect(result.plan.scopes.insert.exact["alt+z"]?.kind).toBe("escape");
+    for (const scope of ["visual", "visualLine", "visualBlock", "operatorPending"] as const) {
+      expect(result.plan.scopes[scope].exact["alt+z"]).toBeUndefined();
+    }
+  });
+
+  test("project command mappings replace JS descriptors in visual scopes", () => {
+    const result = resolveVimOptions(
+      undefined,
+      { piVimMode: { keymap: { commands: { toggleCase: ["Q"] } } } },
+      {
+        kind: "success",
+        warnings: [],
+        operations: [
+          {
+            kind: "map",
+            mapping: {
+              kind: "descriptor",
+              actionId: "command.toggleCase",
+              key: "X",
+              modes: ["visual", "visualLine", "visualBlock"],
+            },
+          },
+        ],
+      },
+    );
+
+    expect(result.plan.scopes.visual.exact.X).toBeUndefined();
+    expect(result.plan.scopes.visual.exact.Q?.id).toBe("command.toggleCase");
   });
 
   test("project escape mappings override lower JS mappings in escape scopes", () => {

--- a/test/config-metadata.test.ts
+++ b/test/config-metadata.test.ts
@@ -65,7 +65,7 @@ describe("canonical config metadata", () => {
     const scopesFor = (id: string) =>
       VIM_ACTION_METADATA.find((action) => action.id === id)?.scopes;
 
-    expect(scopesFor("mark.set")).toEqual(["normal", "visual", "visualLine", "visualBlock"]);
+    expect(scopesFor("mark.set")).toEqual(["normal"]);
     expect(scopesFor("mark.jumpExact")).toEqual([
       "normal",
       "visual",

--- a/test/modal.test.ts
+++ b/test/modal.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, test } from "bun:test";
 import type { ModalEffect, ModalOptions, ModalState } from "../src/modal/types.ts";
 
 import { DEFAULT_VIM_KEYMAP, resolveVimOptions } from "../src/config.ts";
+import { encodeMappingTokens } from "../src/mapping-scopes.ts";
 import { canFastDelegateInsertInput, handleModalInput } from "../src/modal/engine.ts";
 import { createModalState, resetTransientState, transitionMode } from "../src/modal/state.ts";
 import { modalModeLabel, modalStatus, modalVisualStatus } from "../src/modal/view.ts";
@@ -2251,7 +2252,7 @@ describe("Ex command-line modal behavior", () => {
           mapping: {
             kind: "descriptor",
             actionId: "escape",
-            key: "ctrl+xz",
+            key: encodeMappingTokens(["ctrl+x", "z"]),
             modes: ["visual", "visualLine", "visualBlock"],
           },
         },
@@ -2266,6 +2267,62 @@ describe("Ex command-line modal behavior", () => {
       descriptorOptions,
     );
     expect(result.state.mode).toBe("normal");
+  });
+
+  test("tokenized scoped insert escapes preserve terminal input on mismatch", () => {
+    const options = resolveVimOptions(undefined, undefined, {
+      kind: "success",
+      warnings: [],
+      operations: [
+        {
+          kind: "map",
+          mapping: {
+            kind: "descriptor",
+            actionId: "escape",
+            key: encodeMappingTokens(["ctrl+x", "z"]),
+            modes: ["insert"],
+          },
+        },
+      ],
+    }).options;
+
+    const matched = applyModalKeys(
+      { mode: "insert" },
+      "hello",
+      p(0, 5),
+      ["\u001b[120;5u", "z"],
+      options,
+    );
+    expect(matched.state.mode).toBe("normal");
+
+    const pending = handleModalInput({ mode: "insert" }, snapshot, options, "\u001b[120;5u");
+    const mismatch = handleModalInput(pending.state, snapshot, options, "a");
+    expect(mismatch.effects).toEqual([
+      { type: "delegate", input: "\u001b[120;5u" },
+      { type: "delegate", input: "a" },
+    ]);
+  });
+
+  test("tokenized scoped remaps complete at runtime", () => {
+    const options = resolveVimOptions(undefined, undefined, {
+      kind: "success",
+      warnings: [],
+      operations: [
+        {
+          kind: "map",
+          mapping: {
+            kind: "remap",
+            key: encodeMappingTokens(["ctrl+x", "z"]),
+            inputs: ["l"],
+            modes: ["normal"],
+          },
+        },
+      ],
+    }).options;
+
+    const pending = handleModalInput({ mode: "normal" }, snapshot, options, "\u001b[120;5u");
+    const replay = handleModalInput(pending.state, snapshot, options, "z");
+    expect(replay.effects).toContainEqual({ type: "playMacro", slot: "remap", inputs: ["l"] });
   });
 
   test("scoped operator aliases repeat as linewise operations", () => {

--- a/test/modal.test.ts
+++ b/test/modal.test.ts
@@ -2111,6 +2111,35 @@ describe("Ex command-line modal behavior", () => {
     expect(result.effects).toContainEqual({ type: "adapterCommand", command: "undo" });
   });
 
+  test("scoped unmap disables inherited macro key", () => {
+    const options = resolveVimOptions(undefined, undefined, {
+      kind: "success",
+      warnings: [],
+      operations: [{ kind: "unmap", key: "q", modes: ["normal"] }],
+    }).options;
+
+    const result = applyModalKeys({ mode: "normal" }, "hello", p(0, 0), ["q"], options);
+    expect(result.state.pendingMacro).toBeUndefined();
+  });
+
+  test("scoped unmap disables inherited visual command", () => {
+    const options = resolveVimOptions(undefined, undefined, {
+      kind: "success",
+      warnings: [],
+      operations: [{ kind: "unmap", key: "x", modes: ["visual", "visualLine", "visualBlock"] }],
+    }).options;
+
+    const result = applyModalKeys(
+      { mode: "visual", visualAnchor: p(0, 1) },
+      "hello",
+      p(0, 2),
+      ["x"],
+      options,
+    );
+    expect(result.text).toBe("hello");
+    expect(result.state.mode).toBe("visual");
+  });
+
   test("exact semantic actions win when a stale remap survives resolution", () => {
     const actionOptions = resolveVimOptions({
       piVimMode: {

--- a/test/modal.test.ts
+++ b/test/modal.test.ts
@@ -2196,6 +2196,104 @@ describe("Ex command-line modal behavior", () => {
     expect(visual.state.mode).toBe("visual");
   });
 
+  test("multi-key scoped text-object descriptors complete under operators", () => {
+    const descriptorOptions = resolveVimOptions(undefined, undefined, {
+      kind: "success",
+      warnings: [],
+      operations: [
+        {
+          kind: "map",
+          mapping: {
+            kind: "descriptor",
+            actionId: "textObject.kind.inner",
+            key: "zz",
+            modes: ["operatorPending"],
+          },
+        },
+        {
+          kind: "map",
+          mapping: {
+            kind: "descriptor",
+            actionId: "textObject.target.word",
+            key: "xx",
+            modes: ["operatorPending"],
+          },
+        },
+      ],
+    }).options;
+
+    const pendingKind = applyModalKeys(
+      { mode: "normal" },
+      "hello world",
+      p(0, 1),
+      ["d", "z"],
+      descriptorOptions,
+    );
+    expect(pendingKind.state.pending).toBeDefined();
+    const result = applyModalKeys(
+      { mode: "normal" },
+      "hello world",
+      p(0, 1),
+      ["d", "z", "z", "x", "x"],
+      descriptorOptions,
+    );
+    expect(result.text).toBe(" world");
+  });
+
+  test("multi-key modified scoped escape descriptors retain token prefixes", () => {
+    const descriptorOptions = resolveVimOptions(undefined, undefined, {
+      kind: "success",
+      warnings: [],
+      operations: [
+        {
+          kind: "map",
+          mapping: {
+            kind: "descriptor",
+            actionId: "escape",
+            key: "ctrl+xz",
+            modes: ["visual", "visualLine", "visualBlock"],
+          },
+        },
+      ],
+    }).options;
+
+    const result = applyModalKeys(
+      { mode: "visual", visualAnchor: p(0, 0) },
+      "hello",
+      p(0, 1),
+      ["\u001b[120;5u", "z"],
+      descriptorOptions,
+    );
+    expect(result.state.mode).toBe("normal");
+  });
+
+  test("scoped operator aliases repeat as linewise operations", () => {
+    const descriptorOptions = resolveVimOptions(undefined, undefined, {
+      kind: "success",
+      warnings: [],
+      operations: [
+        {
+          kind: "map",
+          mapping: {
+            kind: "descriptor",
+            actionId: "operator.delete",
+            key: "z",
+            modes: ["normal"],
+          },
+        },
+      ],
+    }).options;
+
+    const result = applyModalKeys(
+      { mode: "normal" },
+      "one\ntwo\nthree",
+      cursor,
+      ["z", "z"],
+      descriptorOptions,
+    );
+    expect(result.text).toBe("two\nthree");
+  });
+
   test("scoped prefixes own visual grammar, macros, marks, and easymotion", () => {
     const visualOptions = resolveVimOptions(undefined, undefined, {
       kind: "success",

--- a/test/modal.test.ts
+++ b/test/modal.test.ts
@@ -28,6 +28,7 @@ const csiAltD = "\u001b[100;3u";
 const altF = "\u001bf";
 const csiAltF = "\u001b[102;3u";
 const ctrlE = "\u001b[101;5u";
+const ctrlP = "\u001b[112;5u";
 const altV = "\u001bv";
 const ctrlAltV = "\u001b[118;7u";
 const escapeOptions = resolveVimOptions({
@@ -2371,6 +2372,29 @@ describe("Ex command-line modal behavior", () => {
     expect(
       applyModalKeys({ mode: "normal" }, "hello", p(0, 0), ["q"], descriptorOptions).state,
     ).toMatchObject({ pendingEasymotion: { kind: "char" } });
+  });
+
+  test("scoped unmaps return protected inherited keys to Pi", () => {
+    const unmappedOptions = resolveVimOptions(
+      {
+        piVimMode: {
+          keymap: {
+            allowProtectedOverrides: ["<C-p>"],
+            commands: { undo: ["<C-p>"] },
+          },
+        },
+      },
+      undefined,
+      {
+        kind: "success",
+        warnings: [],
+        operations: [{ kind: "unmap", key: "ctrl+p", modes: ["normal"] }],
+      },
+    ).options;
+
+    const update = handleModalInput({ mode: "normal" }, snapshot, unmappedOptions, ctrlP);
+    expect(update.effects).toContainEqual({ type: "delegate", input: ctrlP });
+    expect(update.state).toEqual({ mode: "normal" });
   });
 
   test("operator-pending protected descriptors keep modal ownership", () => {

--- a/test/modal.test.ts
+++ b/test/modal.test.ts
@@ -2373,6 +2373,35 @@ describe("Ex command-line modal behavior", () => {
     ).toMatchObject({ pendingEasymotion: { kind: "char" } });
   });
 
+  test("operator-pending protected descriptors keep modal ownership", () => {
+    const descriptorOptions = resolveVimOptions(undefined, undefined, {
+      kind: "success",
+      warnings: [],
+      operations: [
+        {
+          kind: "map",
+          mapping: {
+            kind: "descriptor",
+            actionId: "motion.wordForward",
+            key: "ctrl+p",
+            modes: ["operatorPending"],
+            allowProtected: true,
+          },
+        },
+      ],
+    }).options;
+
+    const result = applyModalKeys(
+      { mode: "normal" },
+      "one two",
+      p(0, 0),
+      ["d", "\x10"],
+      descriptorOptions,
+    );
+    expect(result.text).toBe("two");
+    expect(result.effects).not.toContainEqual({ type: "delegate", input: "\x10" });
+  });
+
   test("scoped unmaps remove inherited escape aliases by scope", () => {
     const options = resolveVimOptions({ piVimMode: { keymap: { escape: ["<D-j>"] } } }, undefined, {
       kind: "success",

--- a/test/modal.test.ts
+++ b/test/modal.test.ts
@@ -2096,6 +2096,21 @@ describe("Ex command-line modal behavior", () => {
     expect(visual.state.pending).toBeUndefined();
   });
 
+  test("scoped command binding overrides macro record key", () => {
+    const base = resolveVimOptions(undefined).options;
+    const options: ModalOptions = {
+      ...base,
+      keymap: {
+        ...base.keymap!,
+        scoped: [...base.keymap!.scoped, { actionId: "command.undo", key: "q", modes: ["normal"] }],
+      },
+    };
+
+    const result = applyModalKeys({ mode: "normal" }, "hello", p(0, 0), ["q"], options);
+    expect(result.state.pendingMacro).toBeUndefined();
+    expect(result.effects).toContainEqual({ type: "adapterCommand", command: "undo" });
+  });
+
   test("exact semantic actions win when a stale remap survives resolution", () => {
     const actionOptions = resolveVimOptions({
       piVimMode: {

--- a/test/modal.test.ts
+++ b/test/modal.test.ts
@@ -2196,6 +2196,103 @@ describe("Ex command-line modal behavior", () => {
     expect(visual.state.mode).toBe("visual");
   });
 
+  test("scoped prefixes own visual grammar, macros, marks, and easymotion", () => {
+    const visualOptions = resolveVimOptions(undefined, undefined, {
+      kind: "success",
+      warnings: [],
+      operations: [
+        {
+          kind: "map",
+          mapping: {
+            kind: "descriptor",
+            actionId: "operator.delete",
+            key: "uz",
+            modes: ["visual", "visualLine", "visualBlock"],
+          },
+        },
+      ],
+    }).options;
+    const pendingVisual = applyModalKeys(
+      { mode: "visual", visualAnchor: p(0, 1) },
+      "hello",
+      p(0, 2),
+      ["u"],
+      visualOptions,
+    );
+    expect(pendingVisual.text).toBe("hello");
+    expect(pendingVisual.state).toMatchObject({ mode: "visual", pending: "u" });
+    const deleted = applyModalKeys(
+      { mode: "visual", visualAnchor: p(0, 1) },
+      "hello",
+      p(0, 2),
+      ["u", "z"],
+      visualOptions,
+    );
+    expect(deleted.text).toBe("hlo");
+
+    const descriptorOptions = resolveVimOptions(undefined, undefined, {
+      kind: "success",
+      warnings: [],
+      operations: [
+        {
+          kind: "map",
+          mapping: { kind: "descriptor", actionId: "macro.record", key: "zz", modes: ["normal"] },
+        },
+        {
+          kind: "map",
+          mapping: {
+            kind: "descriptor",
+            actionId: "command.easymotion",
+            key: "q",
+            modes: ["normal"],
+          },
+        },
+      ],
+    }).options;
+    expect(
+      applyModalKeys({ mode: "normal" }, "hello", p(0, 0), ["z"], descriptorOptions).state,
+    ).toMatchObject({ pending: "z" });
+    expect(
+      applyModalKeys({ mode: "normal" }, "hello", p(0, 0), ["z", "z", "a"], descriptorOptions).state
+        .recordingSlot,
+    ).toBe("a");
+    const markOptions = resolveVimOptions(undefined, undefined, {
+      kind: "success",
+      warnings: [],
+      operations: [
+        {
+          kind: "map",
+          mapping: { kind: "descriptor", actionId: "mark.set", key: "zz", modes: ["normal"] },
+        },
+      ],
+    }).options;
+    expect(
+      applyModalKeys({ mode: "normal" }, "hello", p(0, 0), ["z", "z", "a"], markOptions).state
+        .marks,
+    ).toMatchObject({ a: p(0, 0) });
+    expect(
+      applyModalKeys({ mode: "normal" }, "hello", p(0, 0), ["q"], descriptorOptions).state,
+    ).toMatchObject({ pendingEasymotion: { kind: "char" } });
+  });
+
+  test("scoped unmaps remove inherited escape aliases by scope", () => {
+    const options = resolveVimOptions({ piVimMode: { keymap: { escape: ["<D-j>"] } } }, undefined, {
+      kind: "success",
+      warnings: [],
+      operations: [{ kind: "unmap", key: "super+j", modes: ["insert"] }],
+    }).options;
+    const insert = handleModalInput({ mode: "insert" }, snapshot, options, superJ);
+    expect(insert.state.mode).toBe("insert");
+    expect(insert.effects).toContainEqual({ type: "delegate", input: superJ });
+    const visual = handleModalInput(
+      { mode: "visual", visualAnchor: p(0, 0) },
+      snapshot,
+      options,
+      superJ,
+    );
+    expect(visual.state.mode).toBe("normal");
+  });
+
   test("scoped unmap disables inherited macro key", () => {
     const options = resolveVimOptions(undefined, undefined, {
       kind: "success",

--- a/test/modal.test.ts
+++ b/test/modal.test.ts
@@ -2111,6 +2111,91 @@ describe("Ex command-line modal behavior", () => {
     expect(result.effects).toContainEqual({ type: "adapterCommand", command: "undo" });
   });
 
+  test("visual-scoped operator descriptors execute visual operations", () => {
+    const options = resolveVimOptions(undefined, undefined, {
+      kind: "success",
+      warnings: [],
+      operations: [
+        {
+          kind: "map",
+          mapping: {
+            kind: "descriptor",
+            actionId: "operator.delete",
+            key: "u",
+            modes: ["visual", "visualLine", "visualBlock"],
+          },
+        },
+      ],
+    }).options;
+
+    const result = applyModalKeys(
+      { mode: "visual", visualAnchor: p(0, 1) },
+      "hello",
+      p(0, 2),
+      ["u"],
+      options,
+    );
+    expect(result.text).toBe("hlo");
+    expect(result.state.mode).toBe("normal");
+  });
+
+  test("multi-key scoped escape descriptors complete in visual mode", () => {
+    const options = resolveVimOptions(undefined, undefined, {
+      kind: "success",
+      warnings: [],
+      operations: [
+        {
+          kind: "map",
+          mapping: {
+            kind: "descriptor",
+            actionId: "escape",
+            key: "zz",
+            modes: ["visual", "visualLine", "visualBlock"],
+          },
+        },
+      ],
+    }).options;
+
+    const result = applyModalKeys(
+      { mode: "visual", visualAnchor: p(0, 0) },
+      "hello",
+      p(0, 1),
+      ["z", "z"],
+      options,
+    );
+    expect(result.state.mode).toBe("normal");
+  });
+
+  test("scoped escape descriptors dispatch only in selected modes", () => {
+    const insertOnly = resolveVimOptions(undefined, undefined, {
+      kind: "success",
+      warnings: [],
+      operations: [
+        {
+          kind: "map",
+          mapping: {
+            kind: "descriptor",
+            actionId: "escape",
+            key: "alt+z",
+            modes: ["insert"],
+          },
+        },
+      ],
+    }).options;
+
+    const insert = applyModalKeys({ mode: "insert" }, "hello", p(0, 5), ["\u001bz"], insertOnly);
+    expect(insert.state.mode).toBe("normal");
+
+    const visual = applyModalKeys(
+      { mode: "visual", visualAnchor: p(0, 0) },
+      "hello",
+      p(0, 1),
+      ["\u001bz"],
+      insertOnly,
+    );
+    expect(visual.state.mode).toBe("visual");
+  });
+
   test("scoped unmap disables inherited macro key", () => {
     const options = resolveVimOptions(undefined, undefined, {
       kind: "success",


### PR DESCRIPTION
## Summary

Adds trusted JavaScript action keymaps with explicit modal scopes, while retaining Pi/project override precedence and existing keymap behavior.

## Changes

- Adds finite `vim.action.*` descriptors, scoped `vim.keymap.set`, scoped `unmap`, deterministic conflict handling, and bounded literal replays.
- Preserves tokenized modified-key sequences through config compilation and runtime dispatch.
- Documents trusted JS scoped mappings in `docs/settings.md` and release notes in `RELEASE.md`.

## Testing

- [x] `bun test` passes (847 tests)
- [x] `bun run check-types` passes
- [x] `bun run lint` passes
- [ ] Manually tested in Pi

## Related Issues

Closes #39