### PR TITLE
fix(reload): preserve editor state across reloads

### DIFF
--- a/src/commands.ts
+++ b/src/commands.ts
@@ -17,7 +17,7 @@ import type {
   VimTextObjectTarget,
 } from "./types.ts";
 
-import { DEFAULT_VIM_KEYMAP } from "./config.ts";
+import { DEFAULT_VIM_KEYMAP, type VimScopeLookup } from "./config.ts";
 import {
   deriveActionsWhere,
   deriveLegacyActionToKey,
@@ -246,16 +246,17 @@ export function scopedKeymapSequenceFor(
   keymap: ResolvedVimKeymap,
   sequence: string,
   mode: VimActionBindingMode | "operatorPending",
+  lookup?: VimScopeLookup,
 ): { exact?: ResolvedVimKeymap["scoped"][number]; isPrefix: boolean } {
-  const exact = scopedKeymapBindingFor(keymap, sequence, mode);
+  const exact =
+    !lookup || lookup.exact[sequence] ? scopedKeymapBindingFor(keymap, sequence, mode) : undefined;
+  const isScopedPrefix = keymap.scoped.some(
+    (binding) =>
+      binding.modes.includes(mode) && binding.key.startsWith(sequence) && binding.key !== sequence,
+  );
   return {
     exact,
-    isPrefix: keymap.scoped.some(
-      (binding) =>
-        binding.modes.includes(mode) &&
-        binding.key.startsWith(sequence) &&
-        binding.key !== sequence,
-    ),
+    isPrefix: isScopedPrefix && (lookup ? Boolean(lookup.prefixes[sequence]) : true),
   };
 }
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -25,6 +25,7 @@ import type {
   VimCommandAction,
   VimEditorOptions,
   ResolvedVimEditorOptions,
+  VimDiagnostics,
   VimFeedbackOptions,
   VimMode,
   VimMotionAction,
@@ -407,6 +408,11 @@ export type VimConfigPlan = {
   readonly options: ResolvedVimEditorOptions;
   readonly diagnostics: { readonly warnings: readonly string[] };
   readonly scopes: Readonly<Record<VimMappingScope, VimScopeLookup>>;
+};
+
+export type VimRuntimeConfiguration = {
+  readonly plan: VimConfigPlan;
+  readonly diagnostics: VimDiagnostics;
 };
 
 export type VimConfigLoadResult = {

--- a/src/lifecycle.ts
+++ b/src/lifecycle.ts
@@ -49,6 +49,10 @@ type ConfigState = {
   refresh: (ctx: ExtensionContext) => boolean | Promise<boolean>;
 };
 
+function serializeConfig(plan: VimConfigPlan, diagnostics: VimDiagnostics): string {
+  return JSON.stringify([plan.options, plan.scopes, diagnostics]);
+}
+
 function createConfigState(
   dependencies: VimLifecycleDependencies,
   onUpdate: (plan: VimConfigPlan | undefined, diagnostics: VimDiagnostics) => void,
@@ -60,20 +64,14 @@ function createConfigState(
   const loadOptions = dependencies.loadOptions ?? loadVimOptions;
 
   const apply = (ctx: ExtensionContext, loaded: VimConfigLoadResult) => {
-    const previousConfig = JSON.stringify([
-      currentPlan.options,
-      currentPlan.scopes,
-      currentDiagnostics,
-    ]);
+    const previousConfig = serializeConfig(currentPlan, currentDiagnostics);
     const committed = !loaded.fatal || !hasCommittedLoad;
     if (committed) {
       currentPlan = loaded.plan;
       hasCommittedLoad = true;
     }
     currentDiagnostics = loaded.fatal ? loaded.plan.diagnostics : currentPlan.diagnostics;
-    const configChanged =
-      JSON.stringify([currentPlan.options, currentPlan.scopes, currentDiagnostics]) !==
-      previousConfig;
+    const configChanged = serializeConfig(currentPlan, currentDiagnostics) !== previousConfig;
     if (configChanged) onUpdate(committed ? currentPlan : undefined, currentDiagnostics);
     ctx.ui.setStatus("pi-vimmode", currentDiagnostics.warnings.length > 0 ? "vim ⚠" : "vim");
   };

--- a/src/lifecycle.ts
+++ b/src/lifecycle.ts
@@ -8,6 +8,7 @@ import {
   loadVimOptions,
   type VimConfigLoadResult,
   type VimConfigPaths,
+  type VimConfigPlan,
 } from "./config.ts";
 import { type ResetTerminalCursorStyleOptions, VimEditor } from "./vim-editor.ts";
 
@@ -21,12 +22,15 @@ type VimEditorFactory = (
 export type VimShutdownCallback = () => void;
 
 type EditorComponentFactory = ReturnType<ExtensionContext["ui"]["getEditorComponent"]>;
-type TrackedEditor = Pick<VimEditor, "reconfigure" | "resetTerminalCursorStyle" | "setAgentBusy">;
+type TrackedEditor = Pick<
+  VimEditor,
+  "reconfigure" | "resetTerminalCursorStyle" | "setAgentBusy" | "updateDiagnostics"
+>;
 type CreateEditor = (
   tui: ConstructorParameters<typeof VimEditor>[0],
   theme: ConstructorParameters<typeof VimEditor>[1],
   keybindings: ConstructorParameters<typeof VimEditor>[2],
-  options: ResolvedVimEditorOptions,
+  plan: VimConfigPlan,
   diagnostics: VimDiagnostics,
   vimOptions?: { onShutdown?: () => void },
 ) => TrackedEditor;
@@ -40,14 +44,14 @@ export type VimLifecycleDependencies = {
 };
 
 type ConfigState = {
-  options: () => ResolvedVimEditorOptions;
+  plan: () => VimConfigPlan;
   diagnostics: () => VimDiagnostics;
   refresh: (ctx: ExtensionContext) => boolean | Promise<boolean>;
 };
 
 function createConfigState(
   dependencies: VimLifecycleDependencies,
-  onCommit: (options: ResolvedVimEditorOptions, diagnostics: VimDiagnostics) => void,
+  onUpdate: (plan: VimConfigPlan | undefined, diagnostics: VimDiagnostics) => void,
 ): ConfigState {
   let currentPlan = createVimConfigPlan(dependencies.defaultOptions ?? DEFAULT_VIM_OPTIONS, []);
   let currentDiagnostics: VimDiagnostics = currentPlan.diagnostics;
@@ -65,7 +69,7 @@ function createConfigState(
     currentDiagnostics = loaded.fatal ? loaded.plan.diagnostics : currentPlan.diagnostics;
     const configChanged =
       JSON.stringify([currentPlan.options, currentDiagnostics]) !== previousConfig;
-    if (committed && configChanged) onCommit(currentPlan.options, currentDiagnostics);
+    if (configChanged) onUpdate(committed ? currentPlan : undefined, currentDiagnostics);
     ctx.ui.setStatus("pi-vimmode", currentDiagnostics.warnings.length > 0 ? "vim ⚠" : "vim");
   };
   const applyFailure = (ctx: ExtensionContext, error: unknown) => {
@@ -104,7 +108,7 @@ function createConfigState(
   };
 
   return {
-    options: () => currentPlan.options,
+    plan: () => currentPlan,
     diagnostics: () => currentDiagnostics,
     refresh,
   };
@@ -170,16 +174,19 @@ function resetKnownEditors(state: EditorState, options?: ResetTerminalCursorStyl
 
 function createEditorState(dependencies: VimLifecycleDependencies): EditorState {
   let state: EditorState;
-  const config = createConfigState(dependencies, (options, diagnostics) => {
+  const config = createConfigState(dependencies, (plan, diagnostics) => {
     if (!state?.enabled) return;
-    for (const editor of state.editors) editor.reconfigure(options, diagnostics);
+    for (const editor of state.editors) {
+      if (plan) editor.reconfigure(plan, diagnostics);
+      else editor.updateDiagnostics(diagnostics);
+    }
   });
   state = {
     config,
     createEditor:
       dependencies.createEditor ??
-      ((tui, theme, keybindings, options, diagnostics, vimOptions) =>
-        new VimEditor(tui, theme, keybindings, options, diagnostics, vimOptions)),
+      ((tui, theme, keybindings, plan, diagnostics, vimOptions) =>
+        new VimEditor(tui, theme, keybindings, plan, diagnostics, vimOptions)),
     schedule: dependencies.schedule ?? ((callback) => setTimeout(callback, 0)),
     editors: new Set<TrackedEditor>(),
     editorFactory: undefined as unknown as VimEditorFactory,
@@ -192,7 +199,7 @@ function createEditorState(dependencies: VimLifecycleDependencies): EditorState 
       tui,
       theme,
       keybindings,
-      state.config.options(),
+      state.config.plan(),
       state.config.diagnostics(),
       { onShutdown: state.currentShutdown },
     );

--- a/src/lifecycle.ts
+++ b/src/lifecycle.ts
@@ -60,7 +60,11 @@ function createConfigState(
   const loadOptions = dependencies.loadOptions ?? loadVimOptions;
 
   const apply = (ctx: ExtensionContext, loaded: VimConfigLoadResult) => {
-    const previousConfig = JSON.stringify([currentPlan.options, currentDiagnostics]);
+    const previousConfig = JSON.stringify([
+      currentPlan.options,
+      currentPlan.scopes,
+      currentDiagnostics,
+    ]);
     const committed = !loaded.fatal || !hasCommittedLoad;
     if (committed) {
       currentPlan = loaded.plan;
@@ -68,7 +72,8 @@ function createConfigState(
     }
     currentDiagnostics = loaded.fatal ? loaded.plan.diagnostics : currentPlan.diagnostics;
     const configChanged =
-      JSON.stringify([currentPlan.options, currentDiagnostics]) !== previousConfig;
+      JSON.stringify([currentPlan.options, currentPlan.scopes, currentDiagnostics]) !==
+      previousConfig;
     if (configChanged) onUpdate(committed ? currentPlan : undefined, currentDiagnostics);
     ctx.ui.setStatus("pi-vimmode", currentDiagnostics.warnings.length > 0 ? "vim ⚠" : "vim");
   };

--- a/src/lifecycle.ts
+++ b/src/lifecycle.ts
@@ -1,6 +1,6 @@
 import { type ExtensionAPI, type ExtensionContext } from "@earendil-works/pi-coding-agent";
 
-import type { ResolvedVimEditorOptions, VimDiagnostics } from "./types.ts";
+import type { ResolvedVimEditorOptions } from "./types.ts";
 
 import {
   createVimConfigPlan,
@@ -8,7 +8,7 @@ import {
   loadVimOptions,
   type VimConfigLoadResult,
   type VimConfigPaths,
-  type VimConfigPlan,
+  type VimRuntimeConfiguration,
 } from "./config.ts";
 import { type ResetTerminalCursorStyleOptions, VimEditor } from "./vim-editor.ts";
 
@@ -30,8 +30,7 @@ type CreateEditor = (
   tui: ConstructorParameters<typeof VimEditor>[0],
   theme: ConstructorParameters<typeof VimEditor>[1],
   keybindings: ConstructorParameters<typeof VimEditor>[2],
-  plan: VimConfigPlan,
-  diagnostics: VimDiagnostics,
+  configuration: VimRuntimeConfiguration,
   vimOptions?: { onShutdown?: () => void },
 ) => TrackedEditor;
 type Schedule = (callback: () => void) => void;
@@ -44,43 +43,53 @@ export type VimLifecycleDependencies = {
 };
 
 type ConfigState = {
-  plan: () => VimConfigPlan;
-  diagnostics: () => VimDiagnostics;
+  configuration: () => VimRuntimeConfiguration;
   refresh: (ctx: ExtensionContext) => boolean | Promise<boolean>;
 };
 
-function serializeConfig(plan: VimConfigPlan, diagnostics: VimDiagnostics): string {
-  return JSON.stringify([plan.options, plan.scopes, diagnostics]);
+function serializeConfig(configuration: VimRuntimeConfiguration): string {
+  return JSON.stringify([
+    configuration.plan.options,
+    configuration.plan.scopes,
+    configuration.diagnostics,
+  ]);
 }
 
 function createConfigState(
   dependencies: VimLifecycleDependencies,
-  onUpdate: (plan: VimConfigPlan | undefined, diagnostics: VimDiagnostics) => void,
+  onUpdate: (configuration: VimRuntimeConfiguration, committed: boolean) => void,
 ): ConfigState {
-  let currentPlan = createVimConfigPlan(dependencies.defaultOptions ?? DEFAULT_VIM_OPTIONS, []);
-  let currentDiagnostics: VimDiagnostics = currentPlan.diagnostics;
+  const initialPlan = createVimConfigPlan(dependencies.defaultOptions ?? DEFAULT_VIM_OPTIONS, []);
+  let currentConfiguration: VimRuntimeConfiguration = {
+    plan: initialPlan,
+    diagnostics: initialPlan.diagnostics,
+  };
   let hasCommittedLoad = false;
   let refreshGeneration = 0;
   const loadOptions = dependencies.loadOptions ?? loadVimOptions;
 
   const apply = (ctx: ExtensionContext, loaded: VimConfigLoadResult) => {
-    const previousConfig = serializeConfig(currentPlan, currentDiagnostics);
+    const previousConfig = serializeConfig(currentConfiguration);
     const committed = !loaded.fatal || !hasCommittedLoad;
-    if (committed) {
-      currentPlan = loaded.plan;
-      hasCommittedLoad = true;
-    }
-    currentDiagnostics = loaded.fatal ? loaded.plan.diagnostics : currentPlan.diagnostics;
-    const configChanged = serializeConfig(currentPlan, currentDiagnostics) !== previousConfig;
-    if (configChanged) onUpdate(committed ? currentPlan : undefined, currentDiagnostics);
-    ctx.ui.setStatus("pi-vimmode", currentDiagnostics.warnings.length > 0 ? "vim ⚠" : "vim");
+    const plan = committed ? loaded.plan : currentConfiguration.plan;
+    if (committed) hasCommittedLoad = true;
+    currentConfiguration = {
+      plan,
+      diagnostics: loaded.fatal ? loaded.plan.diagnostics : plan.diagnostics,
+    };
+    const configChanged = serializeConfig(currentConfiguration) !== previousConfig;
+    if (configChanged) onUpdate(currentConfiguration, committed);
+    ctx.ui.setStatus(
+      "pi-vimmode",
+      currentConfiguration.diagnostics.warnings.length > 0 ? "vim ⚠" : "vim",
+    );
   };
   const applyFailure = (ctx: ExtensionContext, error: unknown) => {
     const message = error instanceof Error ? error.message : String(error);
     const warnings = [`global JS config: failed to load (${message})`];
     apply(ctx, {
-      plan: createVimConfigPlan(currentPlan.options, warnings),
-      options: currentPlan.options,
+      plan: createVimConfigPlan(currentConfiguration.plan.options, warnings),
+      options: currentConfiguration.plan.options,
       warnings,
       fatal: true,
     });
@@ -111,8 +120,7 @@ function createConfigState(
   };
 
   return {
-    plan: () => currentPlan,
-    diagnostics: () => currentDiagnostics,
+    configuration: () => currentConfiguration,
     refresh,
   };
 }
@@ -177,19 +185,19 @@ function resetKnownEditors(state: EditorState, options?: ResetTerminalCursorStyl
 
 function createEditorState(dependencies: VimLifecycleDependencies): EditorState {
   let state: EditorState;
-  const config = createConfigState(dependencies, (plan, diagnostics) => {
+  const config = createConfigState(dependencies, (configuration, committed) => {
     if (!state?.enabled) return;
     for (const editor of state.editors) {
-      if (plan) editor.reconfigure(plan, diagnostics);
-      else editor.updateDiagnostics(diagnostics);
+      if (committed) editor.reconfigure(configuration);
+      else editor.updateDiagnostics(configuration.diagnostics);
     }
   });
   state = {
     config,
     createEditor:
       dependencies.createEditor ??
-      ((tui, theme, keybindings, plan, diagnostics, vimOptions) =>
-        new VimEditor(tui, theme, keybindings, plan, diagnostics, vimOptions)),
+      ((tui, theme, keybindings, configuration, vimOptions) =>
+        new VimEditor(tui, theme, keybindings, configuration, vimOptions)),
     schedule: dependencies.schedule ?? ((callback) => setTimeout(callback, 0)),
     editors: new Set<TrackedEditor>(),
     editorFactory: undefined as unknown as VimEditorFactory,
@@ -198,14 +206,9 @@ function createEditorState(dependencies: VimLifecycleDependencies): EditorState 
     hasInstalledFactory: false,
   };
   state.editorFactory = (tui, theme, keybindings) => {
-    const editor = state.createEditor(
-      tui,
-      theme,
-      keybindings,
-      state.config.plan(),
-      state.config.diagnostics(),
-      { onShutdown: state.currentShutdown },
-    );
+    const editor = state.createEditor(tui, theme, keybindings, state.config.configuration(), {
+      onShutdown: state.currentShutdown,
+    });
     state.editors.add(editor);
     if (state.agentBusy) editor.setAgentBusy(true);
     return editor as VimEditor;

--- a/src/lifecycle.ts
+++ b/src/lifecycle.ts
@@ -188,7 +188,7 @@ function createEditorState(dependencies: VimLifecycleDependencies): EditorState 
   const config = createConfigState(dependencies, (configuration, committed) => {
     if (!state?.enabled) return;
     for (const editor of state.editors) {
-      if (committed) editor.reconfigure(configuration);
+      if (committed) editor.reconfigure(configuration.plan, configuration.diagnostics);
       else editor.updateDiagnostics(configuration.diagnostics);
     }
   });

--- a/src/lifecycle.ts
+++ b/src/lifecycle.ts
@@ -45,14 +45,15 @@ export type VimLifecycleDependencies = {
 type ConfigState = {
   configuration: () => VimRuntimeConfiguration;
   refresh: (ctx: ExtensionContext) => boolean | Promise<boolean>;
+  invalidate: () => void;
 };
 
-function serializeConfig(configuration: VimRuntimeConfiguration): string {
-  return JSON.stringify([
-    configuration.plan.options,
-    configuration.plan.scopes,
-    configuration.diagnostics,
-  ]);
+function serializePlan(configuration: VimRuntimeConfiguration): string {
+  return JSON.stringify([configuration.plan.options, configuration.plan.scopes]);
+}
+
+function serializeDiagnostics(configuration: VimRuntimeConfiguration): string {
+  return JSON.stringify(configuration.diagnostics);
 }
 
 function createConfigState(
@@ -69,7 +70,8 @@ function createConfigState(
   const loadOptions = dependencies.loadOptions ?? loadVimOptions;
 
   const apply = (ctx: ExtensionContext, loaded: VimConfigLoadResult) => {
-    const previousConfig = serializeConfig(currentConfiguration);
+    const previousPlan = serializePlan(currentConfiguration);
+    const previousDiagnostics = serializeDiagnostics(currentConfiguration);
     const committed = !loaded.fatal || !hasCommittedLoad;
     const plan = committed ? loaded.plan : currentConfiguration.plan;
     if (committed) hasCommittedLoad = true;
@@ -77,8 +79,9 @@ function createConfigState(
       plan,
       diagnostics: loaded.fatal ? loaded.plan.diagnostics : plan.diagnostics,
     };
-    const configChanged = serializeConfig(currentConfiguration) !== previousConfig;
-    if (configChanged) onUpdate(currentConfiguration, committed);
+    const planChanged = serializePlan(currentConfiguration) !== previousPlan;
+    const diagnosticsChanged = serializeDiagnostics(currentConfiguration) !== previousDiagnostics;
+    if (planChanged || diagnosticsChanged) onUpdate(currentConfiguration, planChanged);
     ctx.ui.setStatus(
       "pi-vimmode",
       currentConfiguration.diagnostics.warnings.length > 0 ? "vim ⚠" : "vim",
@@ -122,6 +125,9 @@ function createConfigState(
   return {
     configuration: () => currentConfiguration,
     refresh,
+    invalidate: () => {
+      refreshGeneration += 1;
+    },
   };
 }
 
@@ -136,6 +142,7 @@ type EditorState = {
   agentBusy: boolean;
   previousEditorFactory?: EditorComponentFactory;
   hasInstalledFactory: boolean;
+  installGeneration: number;
 };
 
 function finishInstall(state: EditorState, ctx: ExtensionContext, force = false): void {
@@ -162,7 +169,9 @@ function installEditor(
   state: EditorState,
   ctx: ExtensionContext,
   force = false,
+  generation = state.installGeneration,
 ): void | Promise<void> {
+  if (generation !== state.installGeneration) return;
   if (!state.enabled) {
     ctx.ui.setStatus("pi-vimmode", "vim off");
     return;
@@ -170,7 +179,7 @@ function installEditor(
   const refreshed = state.config.refresh(ctx);
   if (refreshed instanceof Promise) {
     return refreshed.then((applied) => {
-      if (!applied) return;
+      if (!applied || generation !== state.installGeneration) return;
       if (state.enabled) finishInstall(state, ctx, force);
       else ctx.ui.setStatus("pi-vimmode", "vim off");
     });
@@ -185,10 +194,10 @@ function resetKnownEditors(state: EditorState, options?: ResetTerminalCursorStyl
 
 function createEditorState(dependencies: VimLifecycleDependencies): EditorState {
   let state: EditorState;
-  const config = createConfigState(dependencies, (configuration, committed) => {
+  const config = createConfigState(dependencies, (configuration, planChanged) => {
     if (!state?.enabled) return;
     for (const editor of state.editors) {
-      if (committed) editor.reconfigure(configuration.plan, configuration.diagnostics);
+      if (planChanged) editor.reconfigure(configuration.plan, configuration.diagnostics);
       else editor.updateDiagnostics(configuration.diagnostics);
     }
   });
@@ -204,6 +213,7 @@ function createEditorState(dependencies: VimLifecycleDependencies): EditorState 
     enabled: true,
     agentBusy: false,
     hasInstalledFactory: false,
+    installGeneration: 0,
   };
   state.editorFactory = (tui, theme, keybindings) => {
     const editor = state.createEditor(tui, theme, keybindings, state.config.configuration(), {
@@ -229,10 +239,12 @@ function observeInstall(install: void | Promise<void>, ctx: ExtensionContext): v
 }
 
 function installEditorSoon(state: EditorState, ctx: ExtensionContext): void {
-  observeInstall(installEditor(state, ctx), ctx);
+  const generation = state.installGeneration;
+  observeInstall(installEditor(state, ctx, false, generation), ctx);
   state.schedule(() => {
+    if (generation !== state.installGeneration) return;
     try {
-      observeInstall(installEditor(state, ctx), ctx);
+      observeInstall(installEditor(state, ctx, false, generation), ctx);
     } catch {
       // Context can go stale during reload/session switch. Next session_start will reinstall.
     }
@@ -302,6 +314,11 @@ export function registerVimLifecycle(
   });
   pi.on("session_shutdown", (event) => {
     state.agentBusy = false;
+    state.config.invalidate();
+    state.installGeneration += 1;
+    state.currentShutdown = undefined;
+    state.previousEditorFactory = undefined;
+    state.hasInstalledFactory = false;
     resetKnownEditors(state, {
       restoreHardwareCursorVisibility: event.reason !== "quit",
     });

--- a/src/modal/engine.ts
+++ b/src/modal/engine.ts
@@ -49,6 +49,7 @@ import {
   keymapForOptions,
   macrosForOptions,
   marksForOptions,
+  type VimConfigPlan,
 } from "../config.ts";
 import { protectedShortcutForKey } from "../customization.ts";
 import { appendMappingToken } from "../mapping-scopes.ts";
@@ -712,6 +713,7 @@ function handleNormalInput(
   snapshot: EditorSnapshot,
   options: ModalOptions,
   data: string,
+  scopes?: VimConfigPlan["scopes"],
 ): ModalUpdate {
   if (matchesKey(data, "escape")) {
     const nextState = clearPending(state);
@@ -752,7 +754,7 @@ function handleNormalInput(
       .filter((binding) => binding.modes.includes("normal"))
       .map((binding) => binding.key),
   );
-  const scoped = scopedKeymapSequenceFor(keymap, scopedSequence, "normal");
+  const scoped = scopedKeymapSequenceFor(keymap, scopedSequence, "normal", scopes?.normal);
   if (
     !state.pendingMacro &&
     !state.pendingMark &&
@@ -921,6 +923,7 @@ function handleVisualInput(
   snapshot: EditorSnapshot,
   options: ModalOptions,
   data: string,
+  scopes?: VimConfigPlan["scopes"],
 ): ModalUpdate {
   if (matchesKey(data, "escape"))
     return captureBeforeVisualExit(state, snapshot, modeUpdate(state, "normal", options));
@@ -951,7 +954,7 @@ function handleVisualInput(
     key,
     keymap.scoped.filter((binding) => binding.modes.includes(scope)).map((binding) => binding.key),
   );
-  const scoped = scopedKeymapSequenceFor(keymap, scopedSequence, scope);
+  const scoped = scopedKeymapSequenceFor(keymap, scopedSequence, scope, scopes?.[scope]);
   if (!state.pendingMark && !state.pendingRegister && (scoped.exact || scoped.isPrefix)) {
     if (!scoped.exact) return invalidate({ ...state, pending: scopedSequence });
     return applyVisualResolution(
@@ -1062,6 +1065,7 @@ function routeModalInput(
   options: ModalOptions,
   data: string,
   diagnostics: VimDiagnostics,
+  scopes?: VimConfigPlan["scopes"],
 ): ModalUpdate {
   const routedState = state.exMessage && !state.pendingEx ? clearExMessage(state) : state;
   if (routedState.helpPopup) return handleHelpPopupInput(routedState, options, data);
@@ -1080,9 +1084,9 @@ function routeModalInput(
     routedState.mode === "visualLine" ||
     routedState.mode === "visualBlock"
   ) {
-    return handleVisualInput(routedState, snapshot, options, data);
+    return handleVisualInput(routedState, snapshot, options, data, scopes);
   }
-  return handleNormalInput(routedState, snapshot, options, data);
+  return handleNormalInput(routedState, snapshot, options, data, scopes);
 }
 
 export function modalPendingDisplay(state: ModalState): string | undefined {
@@ -1107,8 +1111,9 @@ export function handleModalInput(
   options: ModalOptions,
   data: string,
   diagnostics: VimDiagnostics = { warnings: [] },
+  scopes?: VimConfigPlan["scopes"],
 ): ModalUpdate {
-  const update = routeModalInput(state, snapshot, options, data, diagnostics);
+  const update = routeModalInput(state, snapshot, options, data, diagnostics, scopes);
   if (!state.recordingSlot || !shouldRecordInput(state, snapshot, update, options, data))
     return update;
   return {

--- a/src/modal/engine.ts
+++ b/src/modal/engine.ts
@@ -760,6 +760,52 @@ function handleNormalScopedInput(
   );
 }
 
+function handleRegisterOrMarkInput(
+  state: ModalState,
+  snapshot: EditorSnapshot,
+  options: ModalOptions,
+  key: string,
+  startsLeader: boolean,
+): ModalUpdate | undefined {
+  if (state.pendingRegister === "awaitingSlot") {
+    const target = registerTargetForKey(key);
+    return invalidate(
+      target ? { ...clearCommandPending(state), pendingRegister: target } : clearPending(state),
+    );
+  }
+  if (state.pendingMark) return handlePendingMarkTarget(state, snapshot, options, key);
+  if (!state.pending && !startsLeader && isRegisterPrefixKey(key)) {
+    return invalidate({ ...clearPending(state), pendingRegister: "awaitingSlot" });
+  }
+}
+
+function handleNormalPendingOrProtectedInput(
+  state: ModalState,
+  options: ModalOptions,
+  data: string,
+  key: string,
+  keymap: ResolvedVimKeymap,
+  pendingOperator: VimOperatorAction | undefined,
+): ModalUpdate | undefined {
+  if (pendingOperator) {
+    const escapeMatch = matchInsertEscapeInput(
+      state,
+      data,
+      escapeAliasesForScope(options, "operatorPending"),
+    );
+    if (escapeMatch.kind === "matched") return invalidate(clearPending(state));
+    if (escapeMatch.kind === "pending")
+      return withEffects(pendingInsertEscape(state, escapeMatch.sequence, data), []);
+    if (escapeMatch.kind === "mismatched") return invalidate(clearPending(state));
+  }
+  if (isProtectedPiDelegateKey(data)) {
+    const scope = pendingOperator ? "operatorPending" : "normal";
+    if (!keymapHasBinding(keymap, key, scope)) {
+      return delegateProtectedShortcut(state, options, data);
+    }
+  }
+}
+
 function handleNormalInput(
   state: ModalState,
   snapshot: EditorSnapshot,
@@ -781,39 +827,29 @@ function handleNormalInput(
 
   const keymap = keymapForOptions(options);
   const pendingOperator = operatorActionForSequence(state.pending, keymap);
-  if (pendingOperator) {
-    const escapeMatch = matchInsertEscapeInput(
-      state,
-      data,
-      escapeAliasesForScope(options, "operatorPending"),
-    );
-    if (escapeMatch.kind === "matched") return invalidate(clearPending(state));
-    if (escapeMatch.kind === "pending")
-      return withEffects(pendingInsertEscape(state, escapeMatch.sequence, data), []);
-    if (escapeMatch.kind === "mismatched") return invalidate(clearPending(state));
-  }
-  if (isProtectedPiDelegateKey(data)) {
-    const scope = pendingOperator ? "operatorPending" : "normal";
-    if (!keymapHasBinding(keymap, key, scope)) {
-      return delegateProtectedShortcut(state, options, data);
-    }
-  }
+  const pendingUpdate = handleNormalPendingOrProtectedInput(
+    state,
+    options,
+    data,
+    key,
+    keymap,
+    pendingOperator,
+  );
+  if (pendingUpdate) return pendingUpdate;
 
   const scopedUpdate = handleNormalScopedInput(state, snapshot, options, key, keymap, scopes);
   if (scopedUpdate) return scopedUpdate;
 
-  if (state.pendingRegister === "awaitingSlot") {
-    const target = registerTargetForKey(key);
-    return invalidate(
-      target ? { ...clearCommandPending(state), pendingRegister: target } : clearPending(state),
-    );
-  }
-  if (state.pendingMark) return handlePendingMarkTarget(state, snapshot, options, key);
   const startsLeader =
     !state.pending && !state.pendingRegister && !state.pendingMacro && keymap.leader === key;
-  if (!state.pending && !startsLeader && isRegisterPrefixKey(key)) {
-    return invalidate({ ...clearPending(state), pendingRegister: "awaitingSlot" });
-  }
+  const registerOrMarkUpdate = handleRegisterOrMarkInput(
+    state,
+    snapshot,
+    options,
+    key,
+    startsLeader,
+  );
+  if (registerOrMarkUpdate) return registerOrMarkUpdate;
 
   if (!state.pending && !state.pendingRegister && !startsLeader) {
     const macroOrMark = handleNormalMacroOrMark(state, snapshot, options, keymap, key);
@@ -979,6 +1015,35 @@ function handleVisualEscapeInput(
   if (match.kind === "mismatched") return invalidate(clearPendingInsertEscape(state));
 }
 
+function handleVisualDirectInput(
+  state: ModalState,
+  snapshot: EditorSnapshot,
+  options: ModalOptions,
+  key: string,
+  startsLeader: boolean,
+): ModalUpdate | undefined {
+  if (state.pending || state.pendingRegister || startsLeader) return;
+  if (key === "u" || key === "U") {
+    return transformVisualSelection(
+      state,
+      snapshot,
+      options,
+      visualKindForMode(state.mode),
+      key === "u" ? "lowercase" : "uppercase",
+    );
+  }
+  const markTarget = markPendingForKey(
+    key,
+    options,
+    undefined,
+    undefined,
+    state.mode as "visual" | "visualLine" | "visualBlock",
+  );
+  if (markTarget?.kind === "jumpExact" || markTarget?.kind === "jumpLine") {
+    return invalidate({ ...clearPending(state), pendingMark: markTarget });
+  }
+}
+
 function handleVisualInput(
   state: ModalState,
   snapshot: EditorSnapshot,
@@ -1011,48 +1076,18 @@ function handleVisualInput(
   );
   if (scopedUpdate) return scopedUpdate;
 
-  if (state.pendingRegister === "awaitingSlot") {
-    const target = registerTargetForKey(key);
-    return invalidate(
-      target ? { ...clearCommandPending(state), pendingRegister: target } : clearPending(state),
-    );
-  }
-  if (state.pendingMark) return handlePendingMarkTarget(state, snapshot, options, key);
   const startsLeader =
     !state.pending && !state.pendingRegister && !state.pendingMacro && keymap.leader === key;
-  if (!state.pending && !startsLeader && isRegisterPrefixKey(key)) {
-    return invalidate({ ...clearPending(state), pendingRegister: "awaitingSlot" });
-  }
-  if (!state.pending && !state.pendingRegister && !startsLeader && key === "u") {
-    return transformVisualSelection(
-      state,
-      snapshot,
-      options,
-      visualKindForMode(state.mode),
-      "lowercase",
-    );
-  }
-  if (!state.pending && !state.pendingRegister && !startsLeader && key === "U") {
-    return transformVisualSelection(
-      state,
-      snapshot,
-      options,
-      visualKindForMode(state.mode),
-      "uppercase",
-    );
-  }
-  if (!state.pending && !state.pendingRegister && !startsLeader) {
-    const markTarget = markPendingForKey(
-      key,
-      options,
-      undefined,
-      undefined,
-      state.mode as "visual" | "visualLine" | "visualBlock",
-    );
-    if (markTarget?.kind === "jumpExact" || markTarget?.kind === "jumpLine") {
-      return invalidate({ ...clearPending(state), pendingMark: markTarget });
-    }
-  }
+  const registerOrMarkUpdate = handleRegisterOrMarkInput(
+    state,
+    snapshot,
+    options,
+    key,
+    startsLeader,
+  );
+  if (registerOrMarkUpdate) return registerOrMarkUpdate;
+  const directUpdate = handleVisualDirectInput(state, snapshot, options, key, startsLeader);
+  if (directUpdate) return directUpdate;
 
   const remapped = remapUpdate(
     state,

--- a/src/modal/engine.ts
+++ b/src/modal/engine.ts
@@ -708,6 +708,58 @@ function applyNormalResolution(
   return invalidate(withNoopFeedback(state, options, `unmapped key: ${key}`));
 }
 
+function scopedInputSequence(
+  state: ModalState,
+  key: string,
+  keymap: ResolvedVimKeymap,
+  scope: VimActionBindingMode,
+  lookup?: VimConfigPlan["scopes"][VimActionBindingMode],
+) {
+  const sequence = appendMappingToken(
+    state.pending ?? "",
+    key,
+    keymap.scoped.filter((binding) => binding.modes.includes(scope)).map((binding) => binding.key),
+  );
+  return { sequence, match: scopedKeymapSequenceFor(keymap, sequence, scope, lookup) };
+}
+
+function handleNormalScopedInput(
+  state: ModalState,
+  snapshot: EditorSnapshot,
+  options: ModalOptions,
+  key: string,
+  keymap: ResolvedVimKeymap,
+  scopes?: VimConfigPlan["scopes"],
+): ModalUpdate | undefined {
+  const { sequence, match } = scopedInputSequence(state, key, keymap, "normal", scopes?.normal);
+  if (
+    state.pendingMacro ||
+    state.pendingMark ||
+    state.pendingRegister ||
+    (!match.exact && !match.isPrefix)
+  )
+    return;
+  if (!match.exact) return invalidate({ ...state, pending: sequence });
+  if (match.exact.actionId.startsWith("macro.") || match.exact.actionId.startsWith("mark.")) {
+    const handled = handleNormalMacroOrMark(
+      { ...state, pending: undefined },
+      snapshot,
+      options,
+      keymap,
+      sequence,
+    );
+    if (handled) return handled;
+  }
+  return applyNormalResolution(
+    state,
+    snapshot,
+    options,
+    keymap,
+    sequence,
+    resolveNormalCommand(sequence, undefined, keymap, "normal"),
+  );
+}
+
 function handleNormalInput(
   state: ModalState,
   snapshot: EditorSnapshot,
@@ -747,40 +799,8 @@ function handleNormalInput(
     }
   }
 
-  const scopedSequence = appendMappingToken(
-    state.pending ?? "",
-    key,
-    keymap.scoped
-      .filter((binding) => binding.modes.includes("normal"))
-      .map((binding) => binding.key),
-  );
-  const scoped = scopedKeymapSequenceFor(keymap, scopedSequence, "normal", scopes?.normal);
-  if (
-    !state.pendingMacro &&
-    !state.pendingMark &&
-    !state.pendingRegister &&
-    (scoped.exact || scoped.isPrefix)
-  ) {
-    if (!scoped.exact) return invalidate({ ...state, pending: scopedSequence });
-    if (scoped.exact.actionId.startsWith("macro.") || scoped.exact.actionId.startsWith("mark.")) {
-      const handled = handleNormalMacroOrMark(
-        { ...state, pending: undefined },
-        snapshot,
-        options,
-        keymap,
-        scopedSequence,
-      );
-      if (handled) return handled;
-    }
-    return applyNormalResolution(
-      state,
-      snapshot,
-      options,
-      keymap,
-      scopedSequence,
-      resolveNormalCommand(scopedSequence, undefined, keymap, "normal"),
-    );
-  }
+  const scopedUpdate = handleNormalScopedInput(state, snapshot, options, key, keymap, scopes);
+  if (scopedUpdate) return scopedUpdate;
 
   if (state.pendingRegister === "awaitingSlot") {
     const target = registerTargetForKey(key);
@@ -918,6 +938,47 @@ function applyVisualResolution(
   return invalidate(state.pendingRegister ? clearPending(state) : state);
 }
 
+function handleVisualScopedInput(
+  state: ModalState,
+  snapshot: EditorSnapshot,
+  options: ModalOptions,
+  key: string,
+  keymap: ResolvedVimKeymap,
+  scope: VimActionBindingMode,
+  scopes?: VimConfigPlan["scopes"],
+): ModalUpdate | undefined {
+  const { sequence, match } = scopedInputSequence(state, key, keymap, scope, scopes?.[scope]);
+  if (state.pendingMark || state.pendingRegister || (!match.exact && !match.isPrefix)) return;
+  if (!match.exact) return invalidate({ ...state, pending: sequence });
+  return applyVisualResolution(
+    state,
+    snapshot,
+    options,
+    keymap,
+    resolveNormalCommand(sequence, undefined, keymap, scope),
+  );
+}
+
+function handleVisualEscapeInput(
+  state: ModalState,
+  snapshot: EditorSnapshot,
+  options: ModalOptions,
+  data: string,
+): ModalUpdate | undefined {
+  if (matchesKey(data, "escape"))
+    return captureBeforeVisualExit(state, snapshot, modeUpdate(state, "normal", options));
+  const match = matchInsertEscapeInput(
+    state,
+    data,
+    escapeAliasesForScope(options, state.mode as "visual" | "visualLine" | "visualBlock"),
+  );
+  if (match.kind === "matched")
+    return captureBeforeVisualExit(state, snapshot, modeUpdate(state, "normal", options));
+  if (match.kind === "pending")
+    return withEffects(pendingInsertEscape(state, match.sequence, data), []);
+  if (match.kind === "mismatched") return invalidate(clearPendingInsertEscape(state));
+}
+
 function handleVisualInput(
   state: ModalState,
   snapshot: EditorSnapshot,
@@ -925,18 +986,8 @@ function handleVisualInput(
   data: string,
   scopes?: VimConfigPlan["scopes"],
 ): ModalUpdate {
-  if (matchesKey(data, "escape"))
-    return captureBeforeVisualExit(state, snapshot, modeUpdate(state, "normal", options));
-  const escapeMatch = matchInsertEscapeInput(
-    state,
-    data,
-    escapeAliasesForScope(options, state.mode as "visual" | "visualLine" | "visualBlock"),
-  );
-  if (escapeMatch.kind === "matched")
-    return captureBeforeVisualExit(state, snapshot, modeUpdate(state, "normal", options));
-  if (escapeMatch.kind === "pending")
-    return withEffects(pendingInsertEscape(state, escapeMatch.sequence, data), []);
-  if (escapeMatch.kind === "mismatched") return invalidate(clearPendingInsertEscape(state));
+  const escapeUpdate = handleVisualEscapeInput(state, snapshot, options, data);
+  if (escapeUpdate) return escapeUpdate;
   if (isDelegatedResetKey(data)) return resetAndDelegate(state, options, data);
   const key = keySequence(data);
   if (!key) return delegate(state, data);
@@ -949,22 +1000,16 @@ function handleVisualInput(
   }
 
   const scope = state.mode as VimActionBindingMode;
-  const scopedSequence = appendMappingToken(
-    state.pending ?? "",
+  const scopedUpdate = handleVisualScopedInput(
+    state,
+    snapshot,
+    options,
     key,
-    keymap.scoped.filter((binding) => binding.modes.includes(scope)).map((binding) => binding.key),
+    keymap,
+    scope,
+    scopes,
   );
-  const scoped = scopedKeymapSequenceFor(keymap, scopedSequence, scope, scopes?.[scope]);
-  if (!state.pendingMark && !state.pendingRegister && (scoped.exact || scoped.isPrefix)) {
-    if (!scoped.exact) return invalidate({ ...state, pending: scopedSequence });
-    return applyVisualResolution(
-      state,
-      snapshot,
-      options,
-      keymap,
-      resolveNormalCommand(scopedSequence, undefined, keymap, state.mode as VimActionBindingMode),
-    );
-  }
+  if (scopedUpdate) return scopedUpdate;
 
   if (state.pendingRegister === "awaitingSlot") {
     const target = registerTargetForKey(key);

--- a/src/modal/engine.ts
+++ b/src/modal/engine.ts
@@ -760,6 +760,25 @@ function handleNormalScopedInput(
   );
 }
 
+function handlePendingTargetInput(
+  state: ModalState,
+  snapshot: EditorSnapshot,
+  options: ModalOptions,
+  key: string,
+  startsLeader: boolean,
+): ModalUpdate | undefined {
+  if (state.pendingRegister === "awaitingSlot") {
+    const target = registerTargetForKey(key);
+    return invalidate(
+      target ? { ...clearCommandPending(state), pendingRegister: target } : clearPending(state),
+    );
+  }
+  if (state.pendingMark) return handlePendingMarkTarget(state, snapshot, options, key);
+  if (!state.pending && !startsLeader && isRegisterPrefixKey(key)) {
+    return invalidate({ ...clearPending(state), pendingRegister: "awaitingSlot" });
+  }
+}
+
 function handleNormalInput(
   state: ModalState,
   snapshot: EditorSnapshot,
@@ -802,18 +821,10 @@ function handleNormalInput(
   const scopedUpdate = handleNormalScopedInput(state, snapshot, options, key, keymap, scopes);
   if (scopedUpdate) return scopedUpdate;
 
-  if (state.pendingRegister === "awaitingSlot") {
-    const target = registerTargetForKey(key);
-    return invalidate(
-      target ? { ...clearCommandPending(state), pendingRegister: target } : clearPending(state),
-    );
-  }
-  if (state.pendingMark) return handlePendingMarkTarget(state, snapshot, options, key);
   const startsLeader =
     !state.pending && !state.pendingRegister && !state.pendingMacro && keymap.leader === key;
-  if (!state.pending && !startsLeader && isRegisterPrefixKey(key)) {
-    return invalidate({ ...clearPending(state), pendingRegister: "awaitingSlot" });
-  }
+  const pendingTargetUpdate = handlePendingTargetInput(state, snapshot, options, key, startsLeader);
+  if (pendingTargetUpdate) return pendingTargetUpdate;
 
   if (!state.pending && !state.pendingRegister && !startsLeader) {
     const macroOrMark = handleNormalMacroOrMark(state, snapshot, options, keymap, key);
@@ -1011,18 +1022,10 @@ function handleVisualInput(
   );
   if (scopedUpdate) return scopedUpdate;
 
-  if (state.pendingRegister === "awaitingSlot") {
-    const target = registerTargetForKey(key);
-    return invalidate(
-      target ? { ...clearCommandPending(state), pendingRegister: target } : clearPending(state),
-    );
-  }
-  if (state.pendingMark) return handlePendingMarkTarget(state, snapshot, options, key);
   const startsLeader =
     !state.pending && !state.pendingRegister && !state.pendingMacro && keymap.leader === key;
-  if (!state.pending && !startsLeader && isRegisterPrefixKey(key)) {
-    return invalidate({ ...clearPending(state), pendingRegister: "awaitingSlot" });
-  }
+  const pendingTargetUpdate = handlePendingTargetInput(state, snapshot, options, key, startsLeader);
+  if (pendingTargetUpdate) return pendingTargetUpdate;
   if (!state.pending && !state.pendingRegister && !startsLeader && key === "u") {
     return transformVisualSelection(
       state,
@@ -1107,11 +1110,11 @@ function handleHelpPopupInput(state: ModalState, options: ModalOptions, data: st
 function routeModalInput(
   state: ModalState,
   snapshot: EditorSnapshot,
-  options: ModalOptions,
+  plan: VimConfigPlan,
   data: string,
   diagnostics: VimDiagnostics,
-  scopes?: VimConfigPlan["scopes"],
 ): ModalUpdate {
+  const { options, scopes } = plan;
   const routedState = state.exMessage && !state.pendingEx ? clearExMessage(state) : state;
   if (routedState.helpPopup) return handleHelpPopupInput(routedState, options, data);
 
@@ -1153,13 +1156,12 @@ export function modalPendingDisplay(state: ModalState): string | undefined {
 export function handleModalInput(
   state: ModalState,
   snapshot: EditorSnapshot,
-  options: ModalOptions,
+  plan: VimConfigPlan,
   data: string,
-  diagnostics: VimDiagnostics = { warnings: [] },
-  scopes?: VimConfigPlan["scopes"],
+  diagnostics: VimDiagnostics = plan.diagnostics,
 ): ModalUpdate {
-  const update = routeModalInput(state, snapshot, options, data, diagnostics, scopes);
-  if (!state.recordingSlot || !shouldRecordInput(state, snapshot, update, options, data))
+  const update = routeModalInput(state, snapshot, plan, data, diagnostics);
+  if (!state.recordingSlot || !shouldRecordInput(state, snapshot, update, plan.options, data))
     return update;
   return {
     ...update,

--- a/src/modal/engine.ts
+++ b/src/modal/engine.ts
@@ -760,6 +760,25 @@ function handleNormalScopedInput(
   );
 }
 
+function handlePendingTargetInput(
+  state: ModalState,
+  snapshot: EditorSnapshot,
+  options: ModalOptions,
+  key: string,
+  startsLeader: boolean,
+): ModalUpdate | undefined {
+  if (state.pendingRegister === "awaitingSlot") {
+    const target = registerTargetForKey(key);
+    return invalidate(
+      target ? { ...clearCommandPending(state), pendingRegister: target } : clearPending(state),
+    );
+  }
+  if (state.pendingMark) return handlePendingMarkTarget(state, snapshot, options, key);
+  if (!state.pending && !startsLeader && isRegisterPrefixKey(key)) {
+    return invalidate({ ...clearPending(state), pendingRegister: "awaitingSlot" });
+  }
+}
+
 function handleNormalInput(
   state: ModalState,
   snapshot: EditorSnapshot,
@@ -802,18 +821,10 @@ function handleNormalInput(
   const scopedUpdate = handleNormalScopedInput(state, snapshot, options, key, keymap, scopes);
   if (scopedUpdate) return scopedUpdate;
 
-  if (state.pendingRegister === "awaitingSlot") {
-    const target = registerTargetForKey(key);
-    return invalidate(
-      target ? { ...clearCommandPending(state), pendingRegister: target } : clearPending(state),
-    );
-  }
-  if (state.pendingMark) return handlePendingMarkTarget(state, snapshot, options, key);
   const startsLeader =
     !state.pending && !state.pendingRegister && !state.pendingMacro && keymap.leader === key;
-  if (!state.pending && !startsLeader && isRegisterPrefixKey(key)) {
-    return invalidate({ ...clearPending(state), pendingRegister: "awaitingSlot" });
-  }
+  const pendingTargetUpdate = handlePendingTargetInput(state, snapshot, options, key, startsLeader);
+  if (pendingTargetUpdate) return pendingTargetUpdate;
 
   if (!state.pending && !state.pendingRegister && !startsLeader) {
     const macroOrMark = handleNormalMacroOrMark(state, snapshot, options, keymap, key);
@@ -1011,18 +1022,10 @@ function handleVisualInput(
   );
   if (scopedUpdate) return scopedUpdate;
 
-  if (state.pendingRegister === "awaitingSlot") {
-    const target = registerTargetForKey(key);
-    return invalidate(
-      target ? { ...clearCommandPending(state), pendingRegister: target } : clearPending(state),
-    );
-  }
-  if (state.pendingMark) return handlePendingMarkTarget(state, snapshot, options, key);
   const startsLeader =
     !state.pending && !state.pendingRegister && !state.pendingMacro && keymap.leader === key;
-  if (!state.pending && !startsLeader && isRegisterPrefixKey(key)) {
-    return invalidate({ ...clearPending(state), pendingRegister: "awaitingSlot" });
-  }
+  const pendingTargetUpdate = handlePendingTargetInput(state, snapshot, options, key, startsLeader);
+  if (pendingTargetUpdate) return pendingTargetUpdate;
   if (!state.pending && !state.pendingRegister && !startsLeader && key === "u") {
     return transformVisualSelection(
       state,

--- a/src/modal/engine.ts
+++ b/src/modal/engine.ts
@@ -253,26 +253,13 @@ function handleEasymotionInput(
 ): ModalUpdate {
   const key = keySequence(data);
   if (!key || matchesKey(data, "escape")) {
-    const { pendingEasymotion, ...rest } = state;
-    if (pendingEasymotion?.kind === "highlight") {
-      return withEffects(rest, [
-        {
-          type: "edit",
-          result: {
-            text: pendingEasymotion.originalText,
-            cursor: snapshot.cursor,
-            changed: true,
-          },
-        },
-        { type: "invalidate" },
-      ]);
-    }
+    const { pendingEasymotion: _, ...rest } = state;
     return invalidate(rest);
   }
 
   if (state.pendingEasymotion?.kind === "char") {
     // Transition to highlight state with case-insensitive matching
-    const targets: { label: string; line: number; character: number; original: string }[] = [];
+    const targets: { label: string; line: number; character: number }[] = [];
     const lines = snapshot.text.split("\n");
     const labels = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ".split("");
     let count = 0;
@@ -286,8 +273,7 @@ function handleEasymotionInput(
       while (pos !== -1 && count < labels.length) {
         const label = labels[count];
         if (label === undefined) break;
-        const original = line[pos] ?? key;
-        targets.push({ label, line: i, character: pos, original });
+        targets.push({ label, line: i, character: pos });
         count++;
         pos = line.toLowerCase().indexOf(targetChar, pos + 1);
       }
@@ -298,46 +284,19 @@ function handleEasymotionInput(
       return invalidate(rest);
     }
 
-    // Build text with address characters replacing matched characters
-    const nextLines = [...snapshot.lines];
-    for (const target of targets) {
-      const line = nextLines[target.line];
-      if (line === undefined) continue;
-      nextLines[target.line] =
-        line.slice(0, target.character) + target.label + line.slice(target.character + 1);
-    }
-    const nextText = nextLines.join("\n");
-
-    return withEffects(
-      {
-        ...state,
-        pendingEasymotion: { kind: "highlight", targets, originalText: snapshot.text },
-      },
-      [
-        {
-          type: "edit",
-          result: { text: nextText, cursor: snapshot.cursor, changed: nextText !== snapshot.text },
-        },
-      ],
-    );
+    return invalidate({
+      ...state,
+      pendingEasymotion: { kind: "highlight", targets },
+    });
   }
 
   if (state.pendingEasymotion?.kind === "highlight") {
-    // Address character input: jump to target and restore that character
+    // Address character input: jump to target.
     const target = state.pendingEasymotion.targets.find((t) => t.label === key);
 
     if (target) {
       const { pendingEasymotion: _, ...rest } = state;
-      // Restore full original text then place cursor on the target
       return withEffects(rest, [
-        {
-          type: "edit",
-          result: {
-            text: state.pendingEasymotion.originalText,
-            cursor: snapshot.cursor,
-            changed: true,
-          },
-        },
         { type: "restoreCursor", position: { line: target.line, col: target.character } },
         { type: "invalidate" },
       ]);

--- a/src/modal/engine.ts
+++ b/src/modal/engine.ts
@@ -760,52 +760,6 @@ function handleNormalScopedInput(
   );
 }
 
-function handleRegisterOrMarkInput(
-  state: ModalState,
-  snapshot: EditorSnapshot,
-  options: ModalOptions,
-  key: string,
-  startsLeader: boolean,
-): ModalUpdate | undefined {
-  if (state.pendingRegister === "awaitingSlot") {
-    const target = registerTargetForKey(key);
-    return invalidate(
-      target ? { ...clearCommandPending(state), pendingRegister: target } : clearPending(state),
-    );
-  }
-  if (state.pendingMark) return handlePendingMarkTarget(state, snapshot, options, key);
-  if (!state.pending && !startsLeader && isRegisterPrefixKey(key)) {
-    return invalidate({ ...clearPending(state), pendingRegister: "awaitingSlot" });
-  }
-}
-
-function handleNormalPendingOrProtectedInput(
-  state: ModalState,
-  options: ModalOptions,
-  data: string,
-  key: string,
-  keymap: ResolvedVimKeymap,
-  pendingOperator: VimOperatorAction | undefined,
-): ModalUpdate | undefined {
-  if (pendingOperator) {
-    const escapeMatch = matchInsertEscapeInput(
-      state,
-      data,
-      escapeAliasesForScope(options, "operatorPending"),
-    );
-    if (escapeMatch.kind === "matched") return invalidate(clearPending(state));
-    if (escapeMatch.kind === "pending")
-      return withEffects(pendingInsertEscape(state, escapeMatch.sequence, data), []);
-    if (escapeMatch.kind === "mismatched") return invalidate(clearPending(state));
-  }
-  if (isProtectedPiDelegateKey(data)) {
-    const scope = pendingOperator ? "operatorPending" : "normal";
-    if (!keymapHasBinding(keymap, key, scope)) {
-      return delegateProtectedShortcut(state, options, data);
-    }
-  }
-}
-
 function handleNormalInput(
   state: ModalState,
   snapshot: EditorSnapshot,
@@ -827,29 +781,39 @@ function handleNormalInput(
 
   const keymap = keymapForOptions(options);
   const pendingOperator = operatorActionForSequence(state.pending, keymap);
-  const pendingUpdate = handleNormalPendingOrProtectedInput(
-    state,
-    options,
-    data,
-    key,
-    keymap,
-    pendingOperator,
-  );
-  if (pendingUpdate) return pendingUpdate;
+  if (pendingOperator) {
+    const escapeMatch = matchInsertEscapeInput(
+      state,
+      data,
+      escapeAliasesForScope(options, "operatorPending"),
+    );
+    if (escapeMatch.kind === "matched") return invalidate(clearPending(state));
+    if (escapeMatch.kind === "pending")
+      return withEffects(pendingInsertEscape(state, escapeMatch.sequence, data), []);
+    if (escapeMatch.kind === "mismatched") return invalidate(clearPending(state));
+  }
+  if (isProtectedPiDelegateKey(data)) {
+    const scope = pendingOperator ? "operatorPending" : "normal";
+    if (!keymapHasBinding(keymap, key, scope)) {
+      return delegateProtectedShortcut(state, options, data);
+    }
+  }
 
   const scopedUpdate = handleNormalScopedInput(state, snapshot, options, key, keymap, scopes);
   if (scopedUpdate) return scopedUpdate;
 
+  if (state.pendingRegister === "awaitingSlot") {
+    const target = registerTargetForKey(key);
+    return invalidate(
+      target ? { ...clearCommandPending(state), pendingRegister: target } : clearPending(state),
+    );
+  }
+  if (state.pendingMark) return handlePendingMarkTarget(state, snapshot, options, key);
   const startsLeader =
     !state.pending && !state.pendingRegister && !state.pendingMacro && keymap.leader === key;
-  const registerOrMarkUpdate = handleRegisterOrMarkInput(
-    state,
-    snapshot,
-    options,
-    key,
-    startsLeader,
-  );
-  if (registerOrMarkUpdate) return registerOrMarkUpdate;
+  if (!state.pending && !startsLeader && isRegisterPrefixKey(key)) {
+    return invalidate({ ...clearPending(state), pendingRegister: "awaitingSlot" });
+  }
 
   if (!state.pending && !state.pendingRegister && !startsLeader) {
     const macroOrMark = handleNormalMacroOrMark(state, snapshot, options, keymap, key);
@@ -1015,35 +979,6 @@ function handleVisualEscapeInput(
   if (match.kind === "mismatched") return invalidate(clearPendingInsertEscape(state));
 }
 
-function handleVisualDirectInput(
-  state: ModalState,
-  snapshot: EditorSnapshot,
-  options: ModalOptions,
-  key: string,
-  startsLeader: boolean,
-): ModalUpdate | undefined {
-  if (state.pending || state.pendingRegister || startsLeader) return;
-  if (key === "u" || key === "U") {
-    return transformVisualSelection(
-      state,
-      snapshot,
-      options,
-      visualKindForMode(state.mode),
-      key === "u" ? "lowercase" : "uppercase",
-    );
-  }
-  const markTarget = markPendingForKey(
-    key,
-    options,
-    undefined,
-    undefined,
-    state.mode as "visual" | "visualLine" | "visualBlock",
-  );
-  if (markTarget?.kind === "jumpExact" || markTarget?.kind === "jumpLine") {
-    return invalidate({ ...clearPending(state), pendingMark: markTarget });
-  }
-}
-
 function handleVisualInput(
   state: ModalState,
   snapshot: EditorSnapshot,
@@ -1076,18 +1011,48 @@ function handleVisualInput(
   );
   if (scopedUpdate) return scopedUpdate;
 
+  if (state.pendingRegister === "awaitingSlot") {
+    const target = registerTargetForKey(key);
+    return invalidate(
+      target ? { ...clearCommandPending(state), pendingRegister: target } : clearPending(state),
+    );
+  }
+  if (state.pendingMark) return handlePendingMarkTarget(state, snapshot, options, key);
   const startsLeader =
     !state.pending && !state.pendingRegister && !state.pendingMacro && keymap.leader === key;
-  const registerOrMarkUpdate = handleRegisterOrMarkInput(
-    state,
-    snapshot,
-    options,
-    key,
-    startsLeader,
-  );
-  if (registerOrMarkUpdate) return registerOrMarkUpdate;
-  const directUpdate = handleVisualDirectInput(state, snapshot, options, key, startsLeader);
-  if (directUpdate) return directUpdate;
+  if (!state.pending && !startsLeader && isRegisterPrefixKey(key)) {
+    return invalidate({ ...clearPending(state), pendingRegister: "awaitingSlot" });
+  }
+  if (!state.pending && !state.pendingRegister && !startsLeader && key === "u") {
+    return transformVisualSelection(
+      state,
+      snapshot,
+      options,
+      visualKindForMode(state.mode),
+      "lowercase",
+    );
+  }
+  if (!state.pending && !state.pendingRegister && !startsLeader && key === "U") {
+    return transformVisualSelection(
+      state,
+      snapshot,
+      options,
+      visualKindForMode(state.mode),
+      "uppercase",
+    );
+  }
+  if (!state.pending && !state.pendingRegister && !startsLeader) {
+    const markTarget = markPendingForKey(
+      key,
+      options,
+      undefined,
+      undefined,
+      state.mode as "visual" | "visualLine" | "visualBlock",
+    );
+    if (markTarget?.kind === "jumpExact" || markTarget?.kind === "jumpLine") {
+      return invalidate({ ...clearPending(state), pendingMark: markTarget });
+    }
+  }
 
   const remapped = remapUpdate(
     state,

--- a/src/modal/engine.ts
+++ b/src/modal/engine.ts
@@ -760,25 +760,6 @@ function handleNormalScopedInput(
   );
 }
 
-function handlePendingTargetInput(
-  state: ModalState,
-  snapshot: EditorSnapshot,
-  options: ModalOptions,
-  key: string,
-  startsLeader: boolean,
-): ModalUpdate | undefined {
-  if (state.pendingRegister === "awaitingSlot") {
-    const target = registerTargetForKey(key);
-    return invalidate(
-      target ? { ...clearCommandPending(state), pendingRegister: target } : clearPending(state),
-    );
-  }
-  if (state.pendingMark) return handlePendingMarkTarget(state, snapshot, options, key);
-  if (!state.pending && !startsLeader && isRegisterPrefixKey(key)) {
-    return invalidate({ ...clearPending(state), pendingRegister: "awaitingSlot" });
-  }
-}
-
 function handleNormalInput(
   state: ModalState,
   snapshot: EditorSnapshot,
@@ -821,10 +802,18 @@ function handleNormalInput(
   const scopedUpdate = handleNormalScopedInput(state, snapshot, options, key, keymap, scopes);
   if (scopedUpdate) return scopedUpdate;
 
+  if (state.pendingRegister === "awaitingSlot") {
+    const target = registerTargetForKey(key);
+    return invalidate(
+      target ? { ...clearCommandPending(state), pendingRegister: target } : clearPending(state),
+    );
+  }
+  if (state.pendingMark) return handlePendingMarkTarget(state, snapshot, options, key);
   const startsLeader =
     !state.pending && !state.pendingRegister && !state.pendingMacro && keymap.leader === key;
-  const pendingTargetUpdate = handlePendingTargetInput(state, snapshot, options, key, startsLeader);
-  if (pendingTargetUpdate) return pendingTargetUpdate;
+  if (!state.pending && !startsLeader && isRegisterPrefixKey(key)) {
+    return invalidate({ ...clearPending(state), pendingRegister: "awaitingSlot" });
+  }
 
   if (!state.pending && !state.pendingRegister && !startsLeader) {
     const macroOrMark = handleNormalMacroOrMark(state, snapshot, options, keymap, key);
@@ -1022,10 +1011,18 @@ function handleVisualInput(
   );
   if (scopedUpdate) return scopedUpdate;
 
+  if (state.pendingRegister === "awaitingSlot") {
+    const target = registerTargetForKey(key);
+    return invalidate(
+      target ? { ...clearCommandPending(state), pendingRegister: target } : clearPending(state),
+    );
+  }
+  if (state.pendingMark) return handlePendingMarkTarget(state, snapshot, options, key);
   const startsLeader =
     !state.pending && !state.pendingRegister && !state.pendingMacro && keymap.leader === key;
-  const pendingTargetUpdate = handlePendingTargetInput(state, snapshot, options, key, startsLeader);
-  if (pendingTargetUpdate) return pendingTargetUpdate;
+  if (!state.pending && !startsLeader && isRegisterPrefixKey(key)) {
+    return invalidate({ ...clearPending(state), pendingRegister: "awaitingSlot" });
+  }
   if (!state.pending && !state.pendingRegister && !startsLeader && key === "u") {
     return transformVisualSelection(
       state,

--- a/src/modal/types.ts
+++ b/src/modal/types.ts
@@ -196,8 +196,7 @@ export type ModalState = {
     | { kind: "char" }
     | {
         kind: "highlight";
-        targets: { label: string; line: number; character: number; original: string }[];
-        originalText: string;
+        targets: { label: string; line: number; character: number }[];
       }
     | { kind: "jump"; targets: { label: string; line: number; character: number }[]; char: string };
 };

--- a/src/render.ts
+++ b/src/render.ts
@@ -37,7 +37,7 @@ export type SearchHighlightRenderInput = {
 };
 
 export type EasymotionRenderInput = {
-  targets: { line: number; character: number }[];
+  targets: { line: number; character: number; label: string }[];
   labelColor: string;
 };
 
@@ -102,7 +102,6 @@ type VisualRenderView = {
   search?: SearchHighlightRenderInput;
   searchRanges: TextRange[];
   easymotion: EasymotionRenderInput | undefined;
-  easymotionTargets: Set<string>;
 };
 
 function styleSelection(text: string): string {
@@ -115,6 +114,11 @@ function styleSearch(text: string): string {
 
 function styleCurrentSearch(text: string): string {
   return `${SEARCH_CURRENT_START}${text}${ANSI_RESET}`;
+}
+
+function fitEasymotionLabel(label: string, width: number): string {
+  const truncated = truncateToWidth(label, width, "");
+  return truncated + " ".repeat(Math.max(0, width - visibleWidth(truncated)));
 }
 
 export function renderCursorCell(cell: string, style: CursorStyle): string {
@@ -273,10 +277,17 @@ function renderLayoutLine(
     const cell = Array.from(chunk.text.slice(offset))[0] ?? "";
     const cellStart = chunk.startIndex + offset;
     const cellWidth = visibleWidth(cell);
+    const easymotionTarget = options.easymotion?.targets.find(
+      (target) => target.line === chunk.lineIndex && target.character === cellStart,
+    );
+    const displayCell =
+      easymotionTarget && options.easymotion
+        ? fitEasymotionLabel(easymotionTarget.label, cellWidth)
+        : cell;
     const isCursor = options.cursor.line === chunk.lineIndex && options.cursor.col === cellStart;
 
     if (isCursor) {
-      output += marker + renderCursorCell(cell, options.cursorStyle);
+      output += marker + renderCursorCell(displayCell, options.cursorStyle);
       cursorRendered = true;
     } else if (
       isSelectedCell(
@@ -288,9 +299,9 @@ function renderLayoutLine(
         cellStart,
       )
     ) {
-      output += styleSelection(cell);
-    } else if (options.easymotionTargets?.has(`${chunk.lineIndex}:${cellStart}`)) {
-      output += options.easymotion?.labelColor + cell + ANSI_RESET;
+      output += styleSelection(displayCell);
+    } else if (easymotionTarget && options.easymotion) {
+      output += options.easymotion.labelColor + displayCell + ANSI_RESET;
     } else {
       const searchStyle = searchRangeAt(options, chunk.lineIndex, cellStart);
       if (searchStyle === "current") output += styleCurrentSearch(cell);
@@ -376,9 +387,6 @@ function createPromptRenderView(input: PromptRenderInput): VisualRenderView {
     search: input.search,
     searchRanges: createSearchRanges(input.snapshot.text, input.search),
     easymotion: input.easymotion,
-    easymotionTargets: new Set(
-      (input.easymotion?.targets ?? []).map((t) => `${t.line}:${t.character}`),
-    ),
   };
 }
 
@@ -399,9 +407,6 @@ function createVisualRenderView(input: ActiveVisualRenderInput): VisualRenderVie
     search: input.search,
     searchRanges: createSearchRanges(text, input.search),
     easymotion: input.easymotion,
-    easymotionTargets: new Set(
-      (input.easymotion?.targets ?? []).map((t) => `${t.line}:${t.character}`),
-    ),
   };
 }
 

--- a/src/vim-editor.ts
+++ b/src/vim-editor.ts
@@ -307,12 +307,9 @@ export class VimEditor extends CustomEditor {
       this.modalState,
       this.modalState.mode,
     );
+    if (this.modalState.blockInsert) reset.blockInsert = this.modalState.blockInsert;
     const currentCursor = this.getCursor();
-    const text =
-      this.modalState.pendingEasymotion?.kind === "highlight"
-        ? this.modalState.pendingEasymotion.originalText
-        : this.getText();
-    if (text !== this.getText()) super.handleInput(KEY.undo);
+    const text = this.getText();
     const cursor = clampToText(text, currentCursor);
     if (this.modalState.visualAnchor && this.modalState.mode.startsWith("visual")) {
       reset.visualAnchor = clampToText(text, this.modalState.visualAnchor);
@@ -441,7 +438,11 @@ export class VimEditor extends CustomEditor {
     const pending = this.modalState.pendingEasymotion;
     if (pending?.kind !== "highlight") return undefined;
     return {
-      targets: pending.targets.map((t) => ({ line: t.line, character: t.character })),
+      targets: pending.targets.map((t) => ({
+        line: t.line,
+        character: t.character,
+        label: t.label,
+      })),
       labelColor: easymotion.labelColor,
     };
   }
@@ -735,7 +736,11 @@ export class VimEditor extends CustomEditor {
     }
 
     super.handleInput(KEY.lineStart);
-    for (let i = 0; i < target.col; i++) super.handleInput(KEY.right);
+    while (this.getCursor().col < target.col) {
+      const before = this.getCursor().col;
+      super.handleInput(KEY.right);
+      if (this.getCursor().col <= before) break;
+    }
   }
 
   private terminalRows(): number | undefined {

--- a/src/vim-editor.ts
+++ b/src/vim-editor.ts
@@ -42,6 +42,7 @@ import {
   searchForOptions,
   uiForOptions,
   easymotionForOptions,
+  type VimConfigPlan,
   type VimRuntimeConfiguration,
 } from "./config.ts";
 import { suggestExCommands } from "./ex.ts";
@@ -297,10 +298,10 @@ export class VimEditor extends CustomEditor {
     return cursorStyleForMode(this.options, this.modalState.mode);
   }
 
-  reconfigure(configuration: VimRuntimeConfiguration): void {
+  reconfigure(plan: VimConfigPlan, diagnostics: VimDiagnostics): void {
     this.configuration = {
-      plan: configuration.plan,
-      diagnostics: { warnings: [...configuration.diagnostics.warnings] },
+      plan,
+      diagnostics: { warnings: [...diagnostics.warnings] },
     };
     const { recordingSlot: _recordingSlot, ...reset } = resetTransientState(
       this.modalState,

--- a/src/vim-editor.ts
+++ b/src/vim-editor.ts
@@ -42,7 +42,7 @@ import {
   searchForOptions,
   uiForOptions,
   easymotionForOptions,
-  type VimConfigPlan,
+  type VimRuntimeConfiguration,
 } from "./config.ts";
 import { suggestExCommands } from "./ex.ts";
 import {
@@ -230,7 +230,7 @@ export type ResetTerminalCursorStyleOptions = {
 
 export class VimEditor extends CustomEditor {
   private modalState: ModalState;
-  private configuration: { plan: VimConfigPlan; diagnostics: VimDiagnostics };
+  private configuration: VimRuntimeConfiguration;
   private readonly overlayTheme: EditorTheme;
   private readonly redoStack: RedoSnapshot[] = [];
   private readonly originalHardwareCursorVisible: boolean | undefined;
@@ -245,16 +245,15 @@ export class VimEditor extends CustomEditor {
     tui: TUI,
     theme: EditorTheme,
     keybindings: KeybindingsManager,
-    planOrOptions: VimConfigPlan | ResolvedVimEditorOptions = DEFAULT_VIM_OPTIONS,
-    diagnostics: VimDiagnostics = { warnings: [] },
+    configuration?: VimRuntimeConfiguration,
     vimOptions?: VimEditorOptions,
   ) {
     super(tui, theme, keybindings);
-    const plan =
-      "scopes" in planOrOptions
-        ? planOrOptions
-        : createVimConfigPlan(planOrOptions, diagnostics.warnings);
-    this.configuration = { plan, diagnostics: { warnings: [...diagnostics.warnings] } };
+    const plan = configuration?.plan ?? createVimConfigPlan(DEFAULT_VIM_OPTIONS, []);
+    this.configuration = {
+      plan,
+      diagnostics: { warnings: [...(configuration?.diagnostics.warnings ?? [])] },
+    };
     this.overlayTheme = theme;
     this.onShutdown = vimOptions?.onShutdown;
     this.modalState = createModalState(this.options.startMode);
@@ -298,8 +297,11 @@ export class VimEditor extends CustomEditor {
     return cursorStyleForMode(this.options, this.modalState.mode);
   }
 
-  reconfigure(plan: VimConfigPlan, diagnostics: VimDiagnostics): void {
-    this.configuration = { plan, diagnostics: { warnings: [...diagnostics.warnings] } };
+  reconfigure(configuration: VimRuntimeConfiguration): void {
+    this.configuration = {
+      plan: configuration.plan,
+      diagnostics: { warnings: [...configuration.diagnostics.warnings] },
+    };
     const { recordingSlot: _recordingSlot, ...reset } = resetTransientState(
       this.modalState,
       this.modalState.mode,
@@ -359,10 +361,9 @@ export class VimEditor extends CustomEditor {
     const update = handleModalInput(
       this.modalState,
       this.snapshot(),
-      this.options,
+      this.configuration.plan,
       data,
       this.diagnostics,
-      this.configuration.plan.scopes,
     );
     this.modalState = update.state;
     this.applyEffects(update.effects);

--- a/src/vim-editor.ts
+++ b/src/vim-editor.ts
@@ -33,7 +33,7 @@ import { normalizeBufferPosition, pasteRegister, pasteRegisterBefore } from "./b
 import { readClipboardText } from "./clipboard.ts";
 import { pendingDisplay } from "./commands.ts";
 import {
-  cloneResolvedVimOptions,
+  createVimConfigPlan,
   cursorStyleForMode,
   DEFAULT_VIM_OPTIONS,
   escapeAliasesForScope,
@@ -42,6 +42,7 @@ import {
   searchForOptions,
   uiForOptions,
   easymotionForOptions,
+  type VimConfigPlan,
 } from "./config.ts";
 import { suggestExCommands } from "./ex.ts";
 import {
@@ -204,10 +205,6 @@ export function fitStatusBorder(
   return `${border("─")}${leftText}${border("─".repeat(gapWidth))}${rightText}${border("─")}`;
 }
 
-function cloneOptions(options: ResolvedVimEditorOptions): ResolvedVimEditorOptions {
-  return cloneResolvedVimOptions(options);
-}
-
 type RedoSnapshot = {
   text: string;
   cursor: Position;
@@ -233,8 +230,7 @@ export type ResetTerminalCursorStyleOptions = {
 
 export class VimEditor extends CustomEditor {
   private modalState: ModalState;
-  private options: ResolvedVimEditorOptions;
-  private diagnostics: VimDiagnostics;
+  private configuration: { plan: VimConfigPlan; diagnostics: VimDiagnostics };
   private readonly overlayTheme: EditorTheme;
   private readonly redoStack: RedoSnapshot[] = [];
   private readonly originalHardwareCursorVisible: boolean | undefined;
@@ -249,18 +245,29 @@ export class VimEditor extends CustomEditor {
     tui: TUI,
     theme: EditorTheme,
     keybindings: KeybindingsManager,
-    options: ResolvedVimEditorOptions = DEFAULT_VIM_OPTIONS,
+    planOrOptions: VimConfigPlan | ResolvedVimEditorOptions = DEFAULT_VIM_OPTIONS,
     diagnostics: VimDiagnostics = { warnings: [] },
     vimOptions?: VimEditorOptions,
   ) {
     super(tui, theme, keybindings);
-    this.options = cloneOptions(options);
-    this.diagnostics = { warnings: [...diagnostics.warnings] };
+    const plan =
+      "scopes" in planOrOptions
+        ? planOrOptions
+        : createVimConfigPlan(planOrOptions, diagnostics.warnings);
+    this.configuration = { plan, diagnostics: { warnings: [...diagnostics.warnings] } };
     this.overlayTheme = theme;
     this.onShutdown = vimOptions?.onShutdown;
     this.modalState = createModalState(this.options.startMode);
     this.originalHardwareCursorVisible = this.getHardwareCursorVisibility();
     this.applyTerminalCursorStyle(cursorStyleForMode(this.options, this.modalState.mode));
+  }
+
+  private get options(): ResolvedVimEditorOptions {
+    return this.configuration.plan.options;
+  }
+
+  private get diagnostics(): VimDiagnostics {
+    return this.configuration.diagnostics;
   }
 
   getVimMode(): VimMode {
@@ -291,14 +298,19 @@ export class VimEditor extends CustomEditor {
     return cursorStyleForMode(this.options, this.modalState.mode);
   }
 
-  reconfigure(options: ResolvedVimEditorOptions, diagnostics: VimDiagnostics): void {
-    this.options = cloneOptions(options);
-    this.diagnostics = { warnings: [...diagnostics.warnings] };
+  reconfigure(plan: VimConfigPlan, diagnostics: VimDiagnostics): void {
+    this.configuration = { plan, diagnostics: { warnings: [...diagnostics.warnings] } };
     const { recordingSlot: _recordingSlot, ...reset } = resetTransientState(
       this.modalState,
       this.modalState.mode,
     );
-    const text = this.getText();
+    const currentCursor = this.getCursor();
+    const text =
+      this.modalState.pendingEasymotion?.kind === "highlight"
+        ? this.modalState.pendingEasymotion.originalText
+        : this.getText();
+    if (text !== this.getText()) super.handleInput(KEY.undo);
+    const cursor = clampToText(text, currentCursor);
     if (this.modalState.visualAnchor && this.modalState.mode.startsWith("visual")) {
       reset.visualAnchor = clampToText(text, this.modalState.visualAnchor);
     }
@@ -310,10 +322,19 @@ export class VimEditor extends CustomEditor {
       };
     }
     this.modalState = reset;
+    this.restoreCursor(cursor);
     this.helpOverlay?.hide();
     this.helpOverlay = undefined;
     this.applyTerminalCursorStyle(this.getCurrentCursorStyle());
     this.invalidate();
+    this.tui.requestRender();
+  }
+
+  updateDiagnostics(diagnostics: VimDiagnostics): void {
+    this.configuration = {
+      plan: this.configuration.plan,
+      diagnostics: { warnings: [...diagnostics.warnings] },
+    };
   }
 
   setAgentBusy(active: boolean): void {
@@ -341,6 +362,7 @@ export class VimEditor extends CustomEditor {
       this.options,
       data,
       this.diagnostics,
+      this.configuration.plan.scopes,
     );
     this.modalState = update.state;
     this.applyEffects(update.effects);

--- a/test/lifecycle.test.ts
+++ b/test/lifecycle.test.ts
@@ -11,6 +11,7 @@ import {
   type VimRuntimeConfiguration,
 } from "../src/config.ts";
 import { registerVimLifecycle } from "../src/lifecycle.ts";
+import { VimEditor } from "../src/vim-editor.ts";
 
 type HookName =
   | "session_start"
@@ -91,6 +92,32 @@ function createContext(cwd = "/workspace"): FakeContext {
   return ctx;
 }
 
+function createRealEditor(configuration: VimRuntimeConfiguration): VimEditor {
+  const tui = {
+    terminal: { rows: 24, columns: 80, write: () => {} },
+    requestRender: () => {},
+    getShowHardwareCursor: () => false,
+    setShowHardwareCursor: () => {},
+    showOverlay: () => ({ hide: () => {} }),
+  } as any;
+  const theme = {
+    borderColor: (text: string) => text,
+    selectList: {
+      selectedText: (text: string) => text,
+      description: (text: string) => text,
+      noMatch: (text: string) => text,
+      scrollInfo: (text: string) => text,
+    },
+  } as any;
+  const keybindings = {
+    matches: () => false,
+    getKeys: () => [],
+    getDefinition: () => ({ defaultKeys: [] }),
+    getConflicts: () => [],
+  } as any;
+  return new VimEditor(tui, theme, keybindings, configuration);
+}
+
 function createFakeEditor(configuration: VimRuntimeConfiguration): FakeEditor {
   const editor: FakeEditor = {
     plan: configuration.plan,
@@ -127,12 +154,14 @@ function createLifecycleHarness(
     DEFAULT_VIM_OPTIONS,
     { ...DEFAULT_VIM_OPTIONS, startMode: "normal" },
   ],
+  useRealEditor = false,
 ) {
   const hooks = new Map<HookName, Hook>();
   const commands = new Map<string, Command>();
   const scheduled: Array<() => void> = [];
   const loadCalls: Array<{ cwd?: string }> = [];
   const createdEditors: FakeEditor[] = [];
+  const realEditors: VimEditor[] = [];
   const shutdownCallbacks: Array<(() => void) | undefined> = [];
   const warnings: string[][] = [];
   const fatalLoads: boolean[] = [];
@@ -174,6 +203,11 @@ function createLifecycleHarness(
     },
     createEditor: (_tui, _theme, _keybindings, configuration, vimOptions) => {
       shutdownCallbacks.push(vimOptions?.onShutdown);
+      if (useRealEditor) {
+        const editor = createRealEditor(configuration);
+        realEditors.push(editor);
+        return editor;
+      }
       const editor = createFakeEditor(configuration);
       createdEditors.push(editor);
       return editor;
@@ -189,6 +223,7 @@ function createLifecycleHarness(
     scheduled,
     loadCalls,
     createdEditors,
+    realEditors,
     shutdownCallbacks,
     warnings,
     fatalLoads,
@@ -532,40 +567,44 @@ describe("vim extension lifecycle", () => {
     expect(ctx.ui.statuses.at(-1)).toEqual(["pi-vimmode", "vim"]);
   });
 
-  test("lookup-only reload reconfigures active editors", async () => {
-    const { hooks, deferredLoads, resolveDeferred, createdEditors } = createLifecycleHarness([
-      DEFAULT_VIM_OPTIONS,
-      DEFAULT_VIM_OPTIONS,
-    ]);
+  test("lookup-only reload changes live editor binding", async () => {
+    const normal = { ...DEFAULT_VIM_OPTIONS, startMode: "normal" as const };
+    const { hooks, deferredLoads, resolveDeferred, realEditors } = createLifecycleHarness(
+      [normal, normal],
+      true,
+    );
     const ctx = createContext("/repo");
 
     hooks.get("agent_end")?.({}, ctx);
     ctx.ui.component?.({}, {}, {});
-    const initialPlan = createdEditors[0]!.plan;
-    const lookupOnlyPlan: VimConfigPlan = {
-      ...initialPlan,
-      scopes: {
-        ...initialPlan.scopes,
-        normal: {
-          exact: {
-            ...initialPlan.scopes.normal.exact,
-            ",x": { kind: "command", id: "showKeybindings" },
-          },
-          prefixes: { ...initialPlan.scopes.normal.prefixes, ",": [",x"] },
-        },
+    const editor = realEditors[0]!;
+    const updatedOptions = {
+      ...normal,
+      keymap: {
+        ...normal.keymap!,
+        scoped: [
+          ...normal.keymap!.scoped,
+          { actionId: "command.openLineBelow" as const, key: "x", modes: ["normal"] as const },
+        ],
       },
     };
+    const lookupOnlyPlan = createVimConfigPlan(updatedOptions, []);
     deferredLoads.add(1);
     hooks.get("agent_end")?.({}, ctx);
     resolveDeferred.get(1)?.({
       plan: lookupOnlyPlan,
-      options: DEFAULT_VIM_OPTIONS,
+      options: updatedOptions,
       warnings: [],
       fatal: false,
     });
     await new Promise((resolve) => setTimeout(resolve, 0));
 
-    expect(createdEditors[0]!.reconfigureCalls).toEqual([[lookupOnlyPlan, { warnings: [] }]]);
+    editor.setText("one\ntwo");
+    editor.handleInput("g");
+    editor.handleInput("g");
+    editor.handleInput("x");
+    expect(editor.getText()).toBe("one\n\ntwo");
+    expect(editor.getVimMode()).toBe("insert");
   });
 
   test("stale async refresh cannot install into an older context", async () => {
@@ -594,6 +633,36 @@ describe("vim extension lifecycle", () => {
     expect(newer.shutdownCalls).toBe(1);
   });
 
+  test("shutdown invalidates pending loads and delayed installs before next session", async () => {
+    const { hooks, scheduled, deferredLoads, resolveDeferred, loadCalls } =
+      createLifecycleHarness();
+    deferredLoads.add(0);
+    const oldContext = createContext("/old");
+    const nextContext = createContext("/next");
+    const nativeFactory = (() => ({}) as FakeEditor) as unknown as FakeEditorComponent;
+
+    hooks.get("session_start")?.({}, oldContext);
+    expect(loadCalls).toEqual([{ cwd: "/old" }]);
+    hooks.get("session_shutdown")?.({ reason: "new" }, oldContext);
+    scheduled[0]!();
+    expect(loadCalls).toEqual([{ cwd: "/old" }]);
+
+    resolveDeferred.get(0)?.({
+      plan: createVimConfigPlan(DEFAULT_VIM_OPTIONS, []),
+      options: DEFAULT_VIM_OPTIONS,
+      warnings: [],
+      fatal: false,
+    });
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(oldContext.ui.component).toBeUndefined();
+
+    nextContext.ui.component = nativeFactory;
+    hooks.get("session_start")?.({}, nextContext);
+
+    expect(nextContext.ui.component).not.toBe(nativeFactory);
+    expect(nextContext.ui.setCalls).toHaveLength(1);
+  });
+
   test("async install cannot reactivate editor after vimmode off", async () => {
     const { hooks, commands, deferredLoads, resolveDeferred } = createLifecycleHarness();
     deferredLoads.add(0);
@@ -611,6 +680,33 @@ describe("vim extension lifecycle", () => {
 
     expect(ctx.ui.component).toBeUndefined();
     expect(ctx.ui.statuses.at(-1)).toEqual(["pi-vimmode", "vim off"]);
+  });
+
+  test("fatal reload recovery preserves live grammar and clears diagnostics", () => {
+    const normal = { ...DEFAULT_VIM_OPTIONS, startMode: "normal" as const };
+    const { hooks, fatalLoads, warnings, realEditors } = createLifecycleHarness(
+      [normal, normal, normal],
+      true,
+    );
+    fatalLoads.push(false, true, false);
+    warnings.push([], ["fatal JS config"], []);
+    const ctx = createContext("/repo");
+
+    hooks.get("agent_end")?.({}, ctx);
+    ctx.ui.component?.({}, {}, {});
+    const editor = realEditors[0]!;
+    editor.setText("one\ntwo");
+    editor.handleInput("d");
+    expect(editor.getPendingOperator()).toBe("d");
+
+    hooks.get("agent_end")?.({}, ctx);
+    hooks.get("agent_end")?.({}, ctx);
+
+    expect(editor.getPendingOperator()).toBe("d");
+    expect(
+      (editor as unknown as { configuration: VimRuntimeConfiguration }).configuration.diagnostics,
+    ).toEqual({ warnings: [] });
+    expect(ctx.ui.statuses.at(-1)).toEqual(["pi-vimmode", "vim"]);
   });
 
   test("fatal reload updates diagnostics but preserves last-known-good options", () => {

--- a/test/lifecycle.test.ts
+++ b/test/lifecycle.test.ts
@@ -490,6 +490,47 @@ describe("vim extension lifecycle", () => {
     expect(createdEditors[1]?.plan).toBe(newestPlan);
   });
 
+  test("older async refresh cannot commit after a newer refresh starts", async () => {
+    const initial = { ...DEFAULT_VIM_OPTIONS, startMode: "normal" as const };
+    const stale = resolveVimOptions({
+      piVimMode: { startMode: "normal", keymap: { commands: { openLineBelow: [",s"] } } },
+    }).options;
+    const newest = { ...DEFAULT_VIM_OPTIONS, startMode: "insert" as const };
+    const { hooks, deferredLoads, resolveDeferred, createdEditors } = createLifecycleHarness([
+      initial,
+      stale,
+      newest,
+    ]);
+    const ctx = createContext("/repo");
+
+    hooks.get("agent_end")?.({}, ctx);
+    ctx.ui.component?.({}, {}, {});
+    deferredLoads.add(1).add(2);
+    hooks.get("agent_end")?.({}, ctx);
+    hooks.get("agent_end")?.({}, ctx);
+    resolveDeferred.get(1)?.({
+      plan: createVimConfigPlan(stale, ["stale"]),
+      options: stale,
+      warnings: ["stale"],
+      fatal: false,
+    });
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(createdEditors[0]?.reconfigureCalls).toEqual([]);
+
+    const newestPlan = createVimConfigPlan(newest, []);
+    resolveDeferred.get(2)?.({
+      plan: newestPlan,
+      options: newest,
+      warnings: [],
+      fatal: false,
+    });
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(createdEditors[0]?.reconfigureCalls).toEqual([[newestPlan, { warnings: [] }]]);
+    expect(ctx.ui.statuses.at(-1)).toEqual(["pi-vimmode", "vim"]);
+  });
+
   test("lookup-only reload reconfigures active editors", async () => {
     const { hooks, deferredLoads, resolveDeferred, createdEditors } = createLifecycleHarness([
       DEFAULT_VIM_OPTIONS,

--- a/test/lifecycle.test.ts
+++ b/test/lifecycle.test.ts
@@ -490,6 +490,42 @@ describe("vim extension lifecycle", () => {
     expect(createdEditors[1]?.plan).toBe(newestPlan);
   });
 
+  test("lookup-only reload reconfigures active editors", async () => {
+    const { hooks, deferredLoads, resolveDeferred, createdEditors } = createLifecycleHarness([
+      DEFAULT_VIM_OPTIONS,
+      DEFAULT_VIM_OPTIONS,
+    ]);
+    const ctx = createContext("/repo");
+
+    hooks.get("agent_end")?.({}, ctx);
+    ctx.ui.component?.({}, {}, {});
+    const initialPlan = createdEditors[0]!.plan;
+    const lookupOnlyPlan: VimConfigPlan = {
+      ...initialPlan,
+      scopes: {
+        ...initialPlan.scopes,
+        normal: {
+          exact: {
+            ...initialPlan.scopes.normal.exact,
+            ",x": { kind: "command", id: "showKeybindings" },
+          },
+          prefixes: { ...initialPlan.scopes.normal.prefixes, ",": [",x"] },
+        },
+      },
+    };
+    deferredLoads.add(1);
+    hooks.get("agent_end")?.({}, ctx);
+    resolveDeferred.get(1)?.({
+      plan: lookupOnlyPlan,
+      options: DEFAULT_VIM_OPTIONS,
+      warnings: [],
+      fatal: false,
+    });
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(createdEditors[0]!.reconfigureCalls).toEqual([[lookupOnlyPlan, { warnings: [] }]]);
+  });
+
   test("stale async refresh cannot install into an older context", async () => {
     const { hooks, deferredLoads, resolveDeferred, shutdownCallbacks } = createLifecycleHarness();
     deferredLoads.add(0).add(1);

--- a/test/lifecycle.test.ts
+++ b/test/lifecycle.test.ts
@@ -8,6 +8,7 @@ import {
   resolveVimOptions,
   type VimConfigLoadResult,
   type VimConfigPlan,
+  type VimRuntimeConfiguration,
 } from "../src/config.ts";
 import { registerVimLifecycle } from "../src/lifecycle.ts";
 
@@ -48,11 +49,11 @@ type FakeEditor = {
   options: ResolvedVimEditorOptions;
   diagnostics: VimDiagnostics;
   busyCalls: boolean[];
-  reconfigureCalls: Array<[VimConfigPlan, VimDiagnostics]>;
+  reconfigureCalls: VimRuntimeConfiguration[];
   diagnosticsCalls: VimDiagnostics[];
   resetCount: number;
   resetOptions: Array<{ restoreHardwareCursorVisibility?: boolean } | undefined>;
-  reconfigure: (plan: VimConfigPlan, diagnostics: VimDiagnostics) => void;
+  reconfigure: (configuration: VimRuntimeConfiguration) => void;
   updateDiagnostics: (diagnostics: VimDiagnostics) => void;
   resetTerminalCursorStyle: (options?: { restoreHardwareCursorVisibility?: boolean }) => void;
   setAgentBusy: (active: boolean) => void;
@@ -90,21 +91,21 @@ function createContext(cwd = "/workspace"): FakeContext {
   return ctx;
 }
 
-function createFakeEditor(plan: VimConfigPlan, diagnostics: VimDiagnostics): FakeEditor {
+function createFakeEditor(configuration: VimRuntimeConfiguration): FakeEditor {
   const editor: FakeEditor = {
-    plan,
-    options: plan.options,
-    diagnostics,
+    plan: configuration.plan,
+    options: configuration.plan.options,
+    diagnostics: configuration.diagnostics,
     busyCalls: [],
     reconfigureCalls: [],
     diagnosticsCalls: [],
     resetCount: 0,
     resetOptions: [],
-    reconfigure: (nextPlan, nextDiagnostics) => {
-      editor.plan = nextPlan;
-      editor.options = nextPlan.options;
-      editor.diagnostics = nextDiagnostics;
-      editor.reconfigureCalls.push([nextPlan, nextDiagnostics]);
+    reconfigure: (nextConfiguration) => {
+      editor.plan = nextConfiguration.plan;
+      editor.options = nextConfiguration.plan.options;
+      editor.diagnostics = nextConfiguration.diagnostics;
+      editor.reconfigureCalls.push(nextConfiguration);
     },
     updateDiagnostics: (nextDiagnostics) => {
       editor.diagnostics = nextDiagnostics;
@@ -171,9 +172,9 @@ function createLifecycleHarness(
       }
       return asyncLoads.has(load) ? Promise.resolve(result) : result;
     },
-    createEditor: (_tui, _theme, _keybindings, plan, diagnostics, vimOptions) => {
+    createEditor: (_tui, _theme, _keybindings, configuration, vimOptions) => {
       shutdownCallbacks.push(vimOptions?.onShutdown);
-      const editor = createFakeEditor(plan, diagnostics);
+      const editor = createFakeEditor(configuration);
       createdEditors.push(editor);
       return editor;
     },
@@ -484,7 +485,9 @@ describe("vim extension lifecycle", () => {
     });
     await new Promise((resolve) => setTimeout(resolve, 0));
 
-    expect(createdEditors[0]?.reconfigureCalls).toEqual([[newestPlan, { warnings: [] }]]);
+    expect(createdEditors[0]?.reconfigureCalls).toEqual([
+      { plan: newestPlan, diagnostics: { warnings: [] } },
+    ]);
     expect(ctx.ui.statuses.at(-1)).toEqual(["pi-vimmode", "vim"]);
     ctx.ui.component?.({}, {}, {});
     expect(createdEditors[1]?.plan).toBe(newestPlan);
@@ -527,7 +530,9 @@ describe("vim extension lifecycle", () => {
     });
     await new Promise((resolve) => setTimeout(resolve, 0));
 
-    expect(createdEditors[0]?.reconfigureCalls).toEqual([[newestPlan, { warnings: [] }]]);
+    expect(createdEditors[0]?.reconfigureCalls).toEqual([
+      { plan: newestPlan, diagnostics: { warnings: [] } },
+    ]);
     expect(ctx.ui.statuses.at(-1)).toEqual(["pi-vimmode", "vim"]);
   });
 
@@ -564,7 +569,9 @@ describe("vim extension lifecycle", () => {
     });
     await new Promise((resolve) => setTimeout(resolve, 0));
 
-    expect(createdEditors[0]!.reconfigureCalls).toEqual([[lookupOnlyPlan, { warnings: [] }]]);
+    expect(createdEditors[0]!.reconfigureCalls).toEqual([
+      { plan: lookupOnlyPlan, diagnostics: { warnings: [] } },
+    ]);
   });
 
   test("stale async refresh cannot install into an older context", async () => {

--- a/test/lifecycle.test.ts
+++ b/test/lifecycle.test.ts
@@ -49,11 +49,11 @@ type FakeEditor = {
   options: ResolvedVimEditorOptions;
   diagnostics: VimDiagnostics;
   busyCalls: boolean[];
-  reconfigureCalls: VimRuntimeConfiguration[];
+  reconfigureCalls: Array<[VimConfigPlan, VimDiagnostics]>;
   diagnosticsCalls: VimDiagnostics[];
   resetCount: number;
   resetOptions: Array<{ restoreHardwareCursorVisibility?: boolean } | undefined>;
-  reconfigure: (configuration: VimRuntimeConfiguration) => void;
+  reconfigure: (plan: VimConfigPlan, diagnostics: VimDiagnostics) => void;
   updateDiagnostics: (diagnostics: VimDiagnostics) => void;
   resetTerminalCursorStyle: (options?: { restoreHardwareCursorVisibility?: boolean }) => void;
   setAgentBusy: (active: boolean) => void;
@@ -101,11 +101,11 @@ function createFakeEditor(configuration: VimRuntimeConfiguration): FakeEditor {
     diagnosticsCalls: [],
     resetCount: 0,
     resetOptions: [],
-    reconfigure: (nextConfiguration) => {
-      editor.plan = nextConfiguration.plan;
-      editor.options = nextConfiguration.plan.options;
-      editor.diagnostics = nextConfiguration.diagnostics;
-      editor.reconfigureCalls.push(nextConfiguration);
+    reconfigure: (nextPlan, nextDiagnostics) => {
+      editor.plan = nextPlan;
+      editor.options = nextPlan.options;
+      editor.diagnostics = nextDiagnostics;
+      editor.reconfigureCalls.push([nextPlan, nextDiagnostics]);
     },
     updateDiagnostics: (nextDiagnostics) => {
       editor.diagnostics = nextDiagnostics;
@@ -485,9 +485,7 @@ describe("vim extension lifecycle", () => {
     });
     await new Promise((resolve) => setTimeout(resolve, 0));
 
-    expect(createdEditors[0]?.reconfigureCalls).toEqual([
-      { plan: newestPlan, diagnostics: { warnings: [] } },
-    ]);
+    expect(createdEditors[0]?.reconfigureCalls).toEqual([[newestPlan, { warnings: [] }]]);
     expect(ctx.ui.statuses.at(-1)).toEqual(["pi-vimmode", "vim"]);
     ctx.ui.component?.({}, {}, {});
     expect(createdEditors[1]?.plan).toBe(newestPlan);
@@ -530,9 +528,7 @@ describe("vim extension lifecycle", () => {
     });
     await new Promise((resolve) => setTimeout(resolve, 0));
 
-    expect(createdEditors[0]?.reconfigureCalls).toEqual([
-      { plan: newestPlan, diagnostics: { warnings: [] } },
-    ]);
+    expect(createdEditors[0]?.reconfigureCalls).toEqual([[newestPlan, { warnings: [] }]]);
     expect(ctx.ui.statuses.at(-1)).toEqual(["pi-vimmode", "vim"]);
   });
 
@@ -569,9 +565,7 @@ describe("vim extension lifecycle", () => {
     });
     await new Promise((resolve) => setTimeout(resolve, 0));
 
-    expect(createdEditors[0]!.reconfigureCalls).toEqual([
-      { plan: lookupOnlyPlan, diagnostics: { warnings: [] } },
-    ]);
+    expect(createdEditors[0]!.reconfigureCalls).toEqual([[lookupOnlyPlan, { warnings: [] }]]);
   });
 
   test("stale async refresh cannot install into an older context", async () => {

--- a/test/lifecycle.test.ts
+++ b/test/lifecycle.test.ts
@@ -5,7 +5,9 @@ import type { ResolvedVimEditorOptions, VimDiagnostics } from "../src/types.ts";
 import {
   createVimConfigPlan,
   DEFAULT_VIM_OPTIONS,
+  resolveVimOptions,
   type VimConfigLoadResult,
+  type VimConfigPlan,
 } from "../src/config.ts";
 import { registerVimLifecycle } from "../src/lifecycle.ts";
 
@@ -42,13 +44,16 @@ type FakeContext = {
 };
 
 type FakeEditor = {
+  plan: VimConfigPlan;
   options: ResolvedVimEditorOptions;
   diagnostics: VimDiagnostics;
   busyCalls: boolean[];
-  reconfigureCalls: Array<[ResolvedVimEditorOptions, VimDiagnostics]>;
+  reconfigureCalls: Array<[VimConfigPlan, VimDiagnostics]>;
+  diagnosticsCalls: VimDiagnostics[];
   resetCount: number;
   resetOptions: Array<{ restoreHardwareCursorVisibility?: boolean } | undefined>;
-  reconfigure: (options: ResolvedVimEditorOptions, diagnostics: VimDiagnostics) => void;
+  reconfigure: (plan: VimConfigPlan, diagnostics: VimDiagnostics) => void;
+  updateDiagnostics: (diagnostics: VimDiagnostics) => void;
   resetTerminalCursorStyle: (options?: { restoreHardwareCursorVisibility?: boolean }) => void;
   setAgentBusy: (active: boolean) => void;
 };
@@ -83,6 +88,37 @@ function createContext(cwd = "/workspace"): FakeContext {
     },
   };
   return ctx;
+}
+
+function createFakeEditor(plan: VimConfigPlan, diagnostics: VimDiagnostics): FakeEditor {
+  const editor: FakeEditor = {
+    plan,
+    options: plan.options,
+    diagnostics,
+    busyCalls: [],
+    reconfigureCalls: [],
+    diagnosticsCalls: [],
+    resetCount: 0,
+    resetOptions: [],
+    reconfigure: (nextPlan, nextDiagnostics) => {
+      editor.plan = nextPlan;
+      editor.options = nextPlan.options;
+      editor.diagnostics = nextDiagnostics;
+      editor.reconfigureCalls.push([nextPlan, nextDiagnostics]);
+    },
+    updateDiagnostics: (nextDiagnostics) => {
+      editor.diagnostics = nextDiagnostics;
+      editor.diagnosticsCalls.push(nextDiagnostics);
+    },
+    resetTerminalCursorStyle: (options) => {
+      editor.resetCount += 1;
+      editor.resetOptions.push(options);
+    },
+    setAgentBusy: (active) => {
+      editor.busyCalls.push(active);
+    },
+  };
+  return editor;
 }
 
 function createLifecycleHarness(
@@ -135,28 +171,9 @@ function createLifecycleHarness(
       }
       return asyncLoads.has(load) ? Promise.resolve(result) : result;
     },
-    createEditor: (_tui, _theme, _keybindings, editorOptions, diagnostics, vimOptions) => {
+    createEditor: (_tui, _theme, _keybindings, plan, diagnostics, vimOptions) => {
       shutdownCallbacks.push(vimOptions?.onShutdown);
-      const editor: FakeEditor = {
-        options: editorOptions,
-        diagnostics,
-        busyCalls: [],
-        reconfigureCalls: [],
-        resetCount: 0,
-        resetOptions: [],
-        reconfigure: (options, nextDiagnostics) => {
-          editor.options = options;
-          editor.diagnostics = nextDiagnostics;
-          editor.reconfigureCalls.push([options, nextDiagnostics]);
-        },
-        resetTerminalCursorStyle: (options) => {
-          editor.resetCount += 1;
-          editor.resetOptions.push(options);
-        },
-        setAgentBusy: (active) => {
-          editor.busyCalls.push(active);
-        },
-      };
+      const editor = createFakeEditor(plan, diagnostics);
       createdEditors.push(editor);
       return editor;
     },
@@ -431,35 +448,46 @@ describe("vim extension lifecycle", () => {
     expect(ctx.ui.statuses.at(-1)).toEqual(["pi-vimmode", "vim ⚠"]);
   });
 
-  test("newer async refresh stays authoritative when loads resolve out of order", async () => {
-    const normal = { ...DEFAULT_VIM_OPTIONS, startMode: "normal" as const };
-    const insert = { ...DEFAULT_VIM_OPTIONS, startMode: "insert" as const };
+  test("newer async refresh alone reconfigures active editors", async () => {
+    const initial = { ...DEFAULT_VIM_OPTIONS, startMode: "normal" as const };
+    const stale = resolveVimOptions({
+      piVimMode: { startMode: "normal", keymap: { commands: { openLineBelow: [",s"] } } },
+    }).options;
+    const newest = resolveVimOptions({
+      piVimMode: { startMode: "insert", keymap: { commands: { openLineBelow: [",n"] } } },
+    }).options;
     const { hooks, deferredLoads, resolveDeferred, createdEditors } = createLifecycleHarness([
-      normal,
-      insert,
+      initial,
+      stale,
+      newest,
     ]);
-    deferredLoads.add(0).add(1);
     const ctx = createContext("/repo");
 
     hooks.get("agent_end")?.({}, ctx);
+    ctx.ui.component?.({}, {}, {});
+    deferredLoads.add(1).add(2);
     hooks.get("agent_end")?.({}, ctx);
-    resolveDeferred.get(1)?.({
-      plan: createVimConfigPlan(insert, []),
-      options: insert,
+    hooks.get("agent_end")?.({}, ctx);
+    const newestPlan = createVimConfigPlan(newest, []);
+    resolveDeferred.get(2)?.({
+      plan: newestPlan,
+      options: newest,
       warnings: [],
       fatal: false,
     });
     await new Promise((resolve) => setTimeout(resolve, 0));
-    resolveDeferred.get(0)?.({
-      plan: createVimConfigPlan(normal, []),
-      options: normal,
-      warnings: [],
+    resolveDeferred.get(1)?.({
+      plan: createVimConfigPlan(stale, ["stale"]),
+      options: stale,
+      warnings: ["stale"],
       fatal: false,
     });
     await new Promise((resolve) => setTimeout(resolve, 0));
 
+    expect(createdEditors[0]?.reconfigureCalls).toEqual([[newestPlan, { warnings: [] }]]);
+    expect(ctx.ui.statuses.at(-1)).toEqual(["pi-vimmode", "vim"]);
     ctx.ui.component?.({}, {}, {});
-    expect(createdEditors[0]?.options.startMode).toBe("insert");
+    expect(createdEditors[1]?.plan).toBe(newestPlan);
   });
 
   test("stale async refresh cannot install into an older context", async () => {
@@ -521,10 +549,11 @@ describe("vim extension lifecycle", () => {
 
     expect(createdEditors.map((editor) => editor.options.startMode)).toEqual(["insert", "insert"]);
     expect(createdEditors.map((editor) => editor.diagnostics.warnings)).toEqual([
-      [],
+      ["fatal JS config"],
       ["fatal JS config"],
     ]);
     expect(createdEditors[0]!.reconfigureCalls).toHaveLength(0);
+    expect(createdEditors[0]!.diagnosticsCalls).toEqual([{ warnings: ["fatal JS config"] }]);
     expect(ctx.ui.statuses.at(-1)).toEqual(["pi-vimmode", "vim ⚠"]);
   });
 

--- a/test/modal-effects.test.ts
+++ b/test/modal-effects.test.ts
@@ -1,10 +1,9 @@
 import { describe, expect, test } from "bun:test";
 
-import type { EditorSnapshot, ModalEffect, ModalOptions, ModalState } from "../src/modal/types.ts";
-import type { ResolvedVimEditorOptions } from "../src/types.ts";
+import type { ModalEffect, ModalOptions, ModalState } from "../src/modal/types.ts";
 
-import { createVimConfigPlan, DEFAULT_VIM_KEYMAP, DEFAULT_VIM_OPTIONS } from "../src/config.ts";
-import { handleModalInput as handleModalInputWithPlan } from "../src/modal/engine.ts";
+import { DEFAULT_VIM_KEYMAP, DEFAULT_VIM_OPTIONS } from "../src/config.ts";
+import { handleModalInputWithOptions as handleModalInput } from "./modal-test-helper.ts";
 
 const p = (line: number, col: number) => ({ line, col });
 const options: ModalOptions = {
@@ -18,19 +17,6 @@ const options: ModalOptions = {
   },
   search: DEFAULT_VIM_OPTIONS.search,
 };
-
-function handleModalInput(
-  state: ModalState,
-  snapshot: EditorSnapshot,
-  modalOptions: ModalOptions,
-  data: string,
-) {
-  const plan = createVimConfigPlan(
-    { ...DEFAULT_VIM_OPTIONS, ...modalOptions } as ResolvedVimEditorOptions,
-    [],
-  );
-  return handleModalInputWithPlan(state, snapshot, plan, data);
-}
 
 type GoldenResult = {
   state: Record<string, unknown>;
@@ -52,7 +38,7 @@ function runGolden(
   const effects: unknown[] = [];
 
   for (const key of keys) {
-    const snapshot: EditorSnapshot = {
+    const snapshot = {
       text: currentText,
       lines: currentText.split("\n"),
       cursor: currentCursor,

--- a/test/modal-effects.test.ts
+++ b/test/modal-effects.test.ts
@@ -1,9 +1,10 @@
 import { describe, expect, test } from "bun:test";
 
 import type { EditorSnapshot, ModalEffect, ModalOptions, ModalState } from "../src/modal/types.ts";
+import type { ResolvedVimEditorOptions } from "../src/types.ts";
 
-import { DEFAULT_VIM_KEYMAP, DEFAULT_VIM_OPTIONS } from "../src/config.ts";
-import { handleModalInput } from "../src/modal/engine.ts";
+import { createVimConfigPlan, DEFAULT_VIM_KEYMAP, DEFAULT_VIM_OPTIONS } from "../src/config.ts";
+import { handleModalInput as handleModalInputWithPlan } from "../src/modal/engine.ts";
 
 const p = (line: number, col: number) => ({ line, col });
 const options: ModalOptions = {
@@ -17,6 +18,19 @@ const options: ModalOptions = {
   },
   search: DEFAULT_VIM_OPTIONS.search,
 };
+
+function handleModalInput(
+  state: ModalState,
+  snapshot: EditorSnapshot,
+  modalOptions: ModalOptions,
+  data: string,
+) {
+  const plan = createVimConfigPlan(
+    { ...DEFAULT_VIM_OPTIONS, ...modalOptions } as ResolvedVimEditorOptions,
+    [],
+  );
+  return handleModalInputWithPlan(state, snapshot, plan, data);
+}
 
 type GoldenResult = {
   state: Record<string, unknown>;

--- a/test/modal-test-helper.ts
+++ b/test/modal-test-helper.ts
@@ -1,0 +1,19 @@
+import type { EditorSnapshot, ModalOptions, ModalState } from "../src/modal/types.ts";
+import type { ResolvedVimEditorOptions, VimDiagnostics } from "../src/types.ts";
+
+import { createVimConfigPlan, DEFAULT_VIM_OPTIONS } from "../src/config.ts";
+import { handleModalInput } from "../src/modal/engine.ts";
+
+export function handleModalInputWithOptions(
+  state: ModalState,
+  snapshot: EditorSnapshot,
+  options: ModalOptions,
+  data: string,
+  diagnostics: VimDiagnostics = { warnings: [] },
+) {
+  const plan = createVimConfigPlan(
+    { ...DEFAULT_VIM_OPTIONS, ...options } as ResolvedVimEditorOptions,
+    diagnostics.warnings,
+  );
+  return handleModalInput(state, snapshot, plan, data, diagnostics);
+}

--- a/test/modal.test.ts
+++ b/test/modal.test.ts
@@ -1,12 +1,11 @@
 import { describe, expect, test } from "bun:test";
 
-import type { EditorSnapshot, ModalEffect, ModalOptions, ModalState } from "../src/modal/types.ts";
-import type { ResolvedVimEditorOptions, VimDiagnostics } from "../src/types.ts";
+import type { ModalEffect, ModalOptions, ModalState } from "../src/modal/types.ts";
+import type { ResolvedVimEditorOptions } from "../src/types.ts";
 
 import {
   createVimConfigPlan,
   DEFAULT_VIM_KEYMAP,
-  DEFAULT_VIM_OPTIONS,
   resolveVimOptions,
   type VimConfigPlan,
 } from "../src/config.ts";
@@ -17,6 +16,7 @@ import {
 } from "../src/modal/engine.ts";
 import { createModalState, resetTransientState, transitionMode } from "../src/modal/state.ts";
 import { modalModeLabel, modalStatus, modalVisualStatus } from "../src/modal/view.ts";
+import { handleModalInputWithOptions as handleModalInput } from "./modal-test-helper.ts";
 
 const p = (line: number, col: number) => ({ line, col });
 const cursor = { line: 0, col: 0 };
@@ -45,20 +45,6 @@ const ctrlAltV = "\u001b[118;7u";
 const escapeOptions = resolveVimOptions({
   piVimMode: { keymap: { escape: ["<D-j>"] } },
 }).options;
-
-function handleModalInput(
-  state: ModalState,
-  editorSnapshot: EditorSnapshot,
-  modalOptions: ModalOptions,
-  data: string,
-  diagnostics: VimDiagnostics = { warnings: [] },
-) {
-  const plan = createVimConfigPlan(
-    { ...DEFAULT_VIM_OPTIONS, ...modalOptions } as ResolvedVimEditorOptions,
-    diagnostics.warnings,
-  );
-  return handleModalInputWithPlan(state, editorSnapshot, plan, data, diagnostics);
-}
 
 function applyModalKeys(
   initialState: ModalState,

--- a/test/modal.test.ts
+++ b/test/modal.test.ts
@@ -1,10 +1,20 @@
 import { describe, expect, test } from "bun:test";
 
-import type { ModalEffect, ModalOptions, ModalState } from "../src/modal/types.ts";
+import type { EditorSnapshot, ModalEffect, ModalOptions, ModalState } from "../src/modal/types.ts";
+import type { ResolvedVimEditorOptions, VimDiagnostics } from "../src/types.ts";
 
-import { DEFAULT_VIM_KEYMAP, resolveVimOptions } from "../src/config.ts";
+import {
+  createVimConfigPlan,
+  DEFAULT_VIM_KEYMAP,
+  DEFAULT_VIM_OPTIONS,
+  resolveVimOptions,
+  type VimConfigPlan,
+} from "../src/config.ts";
 import { encodeMappingTokens } from "../src/mapping-scopes.ts";
-import { canFastDelegateInsertInput, handleModalInput } from "../src/modal/engine.ts";
+import {
+  canFastDelegateInsertInput,
+  handleModalInput as handleModalInputWithPlan,
+} from "../src/modal/engine.ts";
 import { createModalState, resetTransientState, transitionMode } from "../src/modal/state.ts";
 import { modalModeLabel, modalStatus, modalVisualStatus } from "../src/modal/view.ts";
 
@@ -36,27 +46,41 @@ const escapeOptions = resolveVimOptions({
   piVimMode: { keymap: { escape: ["<D-j>"] } },
 }).options;
 
+function handleModalInput(
+  state: ModalState,
+  editorSnapshot: EditorSnapshot,
+  modalOptions: ModalOptions,
+  data: string,
+  diagnostics: VimDiagnostics = { warnings: [] },
+) {
+  const plan = createVimConfigPlan(
+    { ...DEFAULT_VIM_OPTIONS, ...modalOptions } as ResolvedVimEditorOptions,
+    diagnostics.warnings,
+  );
+  return handleModalInputWithPlan(state, editorSnapshot, plan, data, diagnostics);
+}
+
 function applyModalKeys(
   initialState: ModalState,
   initialText: string,
   initialCursor: { line: number; col: number },
   keys: readonly string[],
-  modalOptions: ModalOptions = options,
+  configuration: ModalOptions | VimConfigPlan = options,
   terminalRows?: number,
 ) {
   let state = initialState;
   let text = initialText;
   let cursor = initialCursor;
+  const plan = "scopes" in configuration ? configuration : undefined;
+  const modalOptions = "scopes" in configuration ? configuration.options : configuration;
 
   const effects: ModalEffect[] = [];
 
   for (const key of keys) {
-    const update = handleModalInput(
-      state,
-      { text, lines: text.split("\n"), cursor, terminalRows },
-      modalOptions,
-      key,
-    );
+    const editorSnapshot = { text, lines: text.split("\n"), cursor, terminalRows };
+    const update = plan
+      ? handleModalInputWithPlan(state, editorSnapshot, plan, key)
+      : handleModalInput(state, editorSnapshot, modalOptions, key);
     state = update.state;
     effects.push(...update.effects);
     for (const effect of update.effects) {
@@ -2549,13 +2573,11 @@ describe("Ex command-line modal behavior", () => {
       },
     };
 
-    const result = applyModalKeys(
-      { mode: "normal" },
-      "hello",
-      p(0, 0),
-      [",", "u"],
-      conflictingOptions,
-    );
+    const actionPlan = createVimConfigPlan(actionOptions, []);
+    const result = applyModalKeys({ mode: "normal" }, "hello", p(0, 0), [",", "u"], {
+      ...actionPlan,
+      options: conflictingOptions as ResolvedVimEditorOptions,
+    });
 
     expect(result.text).toBe("> hello");
     expect(result.effects.some((effect) => effect.type === "playMacro")).toBe(false);

--- a/test/render.test.ts
+++ b/test/render.test.ts
@@ -265,6 +265,32 @@ describe("visual render helper", () => {
   });
 });
 
+describe("EasyMotion rendering", () => {
+  test("renders target label under cursor", () => {
+    const lines = renderPromptEditor({
+      snapshot: { text: "one", lines: ["one"], cursor: p(0, 0) },
+      cursorStyle: "block",
+      viewport: { width: 10, focused: true },
+      easymotion: { targets: [{ line: 0, character: 0, label: "a" }], labelColor: "red" },
+    });
+
+    expect(lines.join("\n")).toContain(`${CURSOR_BLOCK_START}a${ANSI_RESET}`);
+    expect(lines.join("\n")).not.toContain(`${CURSOR_BLOCK_START}o${ANSI_RESET}`);
+  });
+
+  test("preserves wide target cell width", () => {
+    const lines = renderPromptEditor({
+      snapshot: { text: "界x", lines: ["界x"], cursor: p(0, 2) },
+      cursorStyle: "block",
+      viewport: { width: 10, focused: false },
+      easymotion: { targets: [{ line: 0, character: 0, label: "a" }], labelColor: "red" },
+    });
+
+    expect(visibleWidth(lines[1]!)).toBe(10);
+    expect(lines.join("\n")).toContain("a ");
+  });
+});
+
 describe("cursor rendering", () => {
   test("renders distinct cursor style markers", () => {
     expect(renderCursorCell("x", "block")).toContain(CURSOR_BLOCK_START);

--- a/test/vim-editor.test.ts
+++ b/test/vim-editor.test.ts
@@ -335,9 +335,7 @@ describe("vim editor integration", () => {
     editor.handleInput("d");
     expect(editor.getPendingOperator()).toBe("d");
 
-    editor.reconfigure(
-      runtimeConfiguration(createVimConfigPlan(options, []), { warnings: ["reloaded"] }),
-    );
+    editor.reconfigure(createVimConfigPlan(options, []), { warnings: ["reloaded"] });
     expectEditorState(editor, { text: "one\ntwo", mode: "normal", pending: undefined });
     typeKeys(editor, ["g", "g", ",", "k"]);
 
@@ -402,7 +400,7 @@ describe("vim editor integration", () => {
       [],
     );
 
-    editor.reconfigure(runtimeConfiguration(plan, { warnings: ["reloaded"] }));
+    editor.reconfigure(plan, { warnings: ["reloaded"] });
 
     expectEditorState(editor, { text: "one\ntwo", cursor: beforeCursor, mode: "visual" });
     expect(internal.modalState).toMatchObject({
@@ -446,7 +444,7 @@ describe("vim editor integration", () => {
     typeKeys(editor, ["G", "$"]);
     editor.setText("x");
 
-    editor.reconfigure(runtimeConfiguration());
+    editor.reconfigure(createVimConfigPlan(DEFAULT_VIM_OPTIONS, []), { warnings: [] });
 
     expect(editor.getCursor()).toEqual({ line: 0, col: 1 });
   });
@@ -463,7 +461,7 @@ describe("vim editor integration", () => {
     };
     editor.setText("Xane");
 
-    editor.reconfigure(runtimeConfiguration());
+    editor.reconfigure(createVimConfigPlan(DEFAULT_VIM_OPTIONS, []), { warnings: [] });
     expect(editor.getText()).toBe("Xone");
     editor.handleInput("u");
 
@@ -476,7 +474,7 @@ describe("vim editor integration", () => {
     typeKeys(editor, ["g", "g", "i", "x", "\x1b", "u"]);
     expect(editor.getText()).toBe("draft");
 
-    editor.reconfigure(runtimeConfiguration());
+    editor.reconfigure(createVimConfigPlan(DEFAULT_VIM_OPTIONS, []), { warnings: [] });
     editor.handleInput("\x12");
 
     expect(editor.getText()).toBe("xdraft");

--- a/test/vim-editor.test.ts
+++ b/test/vim-editor.test.ts
@@ -168,88 +168,6 @@ function expectEditorState(
   if (expected.pending !== undefined) expect(editor.getPendingOperator()).toBe(expected.pending);
 }
 
-type ReconfigureTestInternal = {
-  modalState: ModalState;
-  redoStack: Array<{ text: string; cursor: { line: number; col: number } }>;
-};
-
-const RECONFIGURE_TRANSIENT_FIELDS = [
-  "recordingSlot",
-  "pending",
-  "pendingMacro",
-  "pendingRegister",
-  "pendingMark",
-  "pendingSearch",
-  "pendingEx",
-  "pendingInsertEscape",
-  "pendingInsertEscapeInputs",
-  "pendingWorkbench",
-  "pendingEasymotion",
-] as const;
-
-function seedReconfigureState(editor: VimEditor): ReconfigureTestInternal {
-  editor.setText("one\ntwo");
-  typeKeys(editor, ["g", "g", "v", "j"]);
-  const internal = editor as unknown as ReconfigureTestInternal;
-  internal.modalState = {
-    ...internal.modalState,
-    register: { type: "char", text: "unnamed" },
-    namedRegisters: { a: { type: "line", text: "named\n" } },
-    clipboardRegisters: { "+": { type: "char", text: "clipboard" } },
-    macros: { q: ["i", "x", "escape"] },
-    recordingSlot: "q",
-    lastPlayedMacro: "q",
-    marks: { a: { line: 1, col: 2 } },
-    searchHistory: [{ query: "two", matcherMode: "literal" }],
-    exHistory: ["messages"],
-    lastVisualSelection: {
-      mode: "visual",
-      anchor: { line: 99, col: 99 },
-      cursor: { line: 0, col: 99 },
-      text: "one\ntwo",
-    },
-    pending: "2d",
-    pendingMacro: "play",
-    pendingRegister: "awaitingSlot",
-    pendingMark: { kind: "set" },
-    pendingSearch: { query: "stale", direction: "forward" },
-    pendingEx: { command: "stale", sourceMode: "visual" },
-    pendingInsertEscape: "j",
-    pendingInsertEscapeInputs: ["j"],
-    pendingWorkbench: { kind: "ex", prefix: ":", text: "stale", sourceMode: "visual" },
-    pendingEasymotion: {
-      kind: "highlight",
-      targets: [{ label: "a", line: 0, character: 0, original: "o" }],
-      originalText: "one\ntwo",
-    },
-  };
-  editor.setText("ane\ntwo");
-  internal.redoStack.push({ text: "redo", cursor: { line: 0, col: 4 } });
-  return internal;
-}
-
-function expectReconfiguredDurableState(internal: ReconfigureTestInternal) {
-  expect(internal.modalState).toMatchObject({
-    register: { type: "char", text: "unnamed" },
-    namedRegisters: { a: { type: "line", text: "named\n" } },
-    clipboardRegisters: { "+": { type: "char", text: "clipboard" } },
-    macros: { q: ["i", "x", "escape"] },
-    lastPlayedMacro: "q",
-    marks: { a: { line: 1, col: 2 } },
-    searchHistory: [{ query: "two", matcherMode: "literal" }],
-    exHistory: ["messages"],
-    visualAnchor: { line: 0, col: 0 },
-    lastVisualSelection: {
-      anchor: { line: 1, col: 3 },
-      cursor: { line: 0, col: 3 },
-    },
-  });
-  for (const field of RECONFIGURE_TRANSIENT_FIELDS) {
-    expect(internal.modalState[field]).toBeUndefined();
-  }
-  expect(internal.redoStack).toEqual([{ text: "redo", cursor: { line: 0, col: 4 } }]);
-}
-
 describe("vim editor integration", () => {
   test("starts insert, inserts text, and escape enters normal", () => {
     const { editor } = createEditor();
@@ -405,7 +323,46 @@ describe("vim editor integration", () => {
       ...DEFAULT_VIM_OPTIONS,
       startMode: "normal",
     });
-    const internal = seedReconfigureState(editor);
+    editor.setText("one\ntwo");
+    typeKeys(editor, ["g", "g", "v", "j"]);
+    const internal = editor as unknown as {
+      modalState: ModalState;
+      redoStack: Array<{ text: string; cursor: { line: number; col: number } }>;
+    };
+    internal.modalState = {
+      ...internal.modalState,
+      register: { type: "char", text: "unnamed" },
+      namedRegisters: { a: { type: "line", text: "named\n" } },
+      clipboardRegisters: { "+": { type: "char", text: "clipboard" } },
+      macros: { q: ["i", "x", "escape"] },
+      recordingSlot: "q",
+      lastPlayedMacro: "q",
+      marks: { a: { line: 1, col: 2 } },
+      searchHistory: [{ query: "two", matcherMode: "literal" }],
+      exHistory: ["messages"],
+      lastVisualSelection: {
+        mode: "visual",
+        anchor: { line: 99, col: 99 },
+        cursor: { line: 0, col: 99 },
+        text: "one\ntwo",
+      },
+      pending: "2d",
+      pendingMacro: "play",
+      pendingRegister: "awaitingSlot",
+      pendingMark: { kind: "set" },
+      pendingSearch: { query: "stale", direction: "forward" },
+      pendingEx: { command: "stale", sourceMode: "visual" },
+      pendingInsertEscape: "j",
+      pendingInsertEscapeInputs: ["j"],
+      pendingWorkbench: { kind: "ex", prefix: ":", text: "stale", sourceMode: "visual" },
+      pendingEasymotion: {
+        kind: "highlight",
+        targets: [{ label: "a", line: 0, character: 0, original: "o" }],
+        originalText: "one\ntwo",
+      },
+    };
+    editor.setText("ane\ntwo");
+    internal.redoStack.push({ text: "redo", cursor: { line: 0, col: 4 } });
     const beforeCursor = editor.getCursor();
     const renderRequests = getRenderRequests();
     const plan = createVimConfigPlan(
@@ -421,9 +378,50 @@ describe("vim editor integration", () => {
     editor.reconfigure(plan, { warnings: ["reloaded"] });
 
     expectEditorState(editor, { text: "one\ntwo", cursor: beforeCursor, mode: "visual" });
-    expectReconfiguredDurableState(internal);
+    expect(internal.modalState).toMatchObject({
+      register: { type: "char", text: "unnamed" },
+      namedRegisters: { a: { type: "line", text: "named\n" } },
+      clipboardRegisters: { "+": { type: "char", text: "clipboard" } },
+      macros: { q: ["i", "x", "escape"] },
+      lastPlayedMacro: "q",
+      marks: { a: { line: 1, col: 2 } },
+      searchHistory: [{ query: "two", matcherMode: "literal" }],
+      exHistory: ["messages"],
+      visualAnchor: { line: 0, col: 0 },
+      lastVisualSelection: {
+        anchor: { line: 1, col: 3 },
+        cursor: { line: 0, col: 3 },
+      },
+    });
+    for (const field of [
+      "recordingSlot",
+      "pending",
+      "pendingMacro",
+      "pendingRegister",
+      "pendingMark",
+      "pendingSearch",
+      "pendingEx",
+      "pendingInsertEscape",
+      "pendingInsertEscapeInputs",
+      "pendingWorkbench",
+      "pendingEasymotion",
+    ] as const) {
+      expect(internal.modalState[field]).toBeUndefined();
+    }
+    expect(internal.redoStack).toEqual([{ text: "redo", cursor: { line: 0, col: 4 } }]);
     expect(writes.at(-1)).toBe("\x1b[4 q");
     expect(getRenderRequests()).toBeGreaterThan(renderRequests);
+  });
+
+  test("reconfigure clamps an out-of-bounds active cursor", () => {
+    const { editor } = createEditor({ ...DEFAULT_VIM_OPTIONS, startMode: "normal" });
+    editor.setText("one\ntwo");
+    typeKeys(editor, ["G", "$"]);
+    editor.setText("x");
+
+    editor.reconfigure(createVimConfigPlan(DEFAULT_VIM_OPTIONS, []), { warnings: [] });
+
+    expect(editor.getCursor()).toEqual({ line: 0, col: 1 });
   });
 
   test("reconfigure removes EasyMotion labels without adding undo history", () => {

--- a/test/vim-editor.test.ts
+++ b/test/vim-editor.test.ts
@@ -5,7 +5,13 @@ import type { ModalState } from "../src/modal/types.ts";
 import type { ResolvedVimEditorOptions, VimDiagnostics, VimMode } from "../src/types.ts";
 
 import { setClipboardTextReaderForTesting } from "../src/clipboard.ts";
-import { createVimConfigPlan, DEFAULT_VIM_OPTIONS, resolveVimOptions } from "../src/config.ts";
+import {
+  createVimConfigPlan,
+  DEFAULT_VIM_OPTIONS,
+  resolveVimOptions,
+  type VimConfigPlan,
+  type VimRuntimeConfiguration,
+} from "../src/config.ts";
 import { SEARCH_CURRENT_START, SEARCH_START } from "../src/render.ts";
 import { fitStatusBorder, VimEditor } from "../src/vim-editor.ts";
 
@@ -19,6 +25,19 @@ function ctrlVVisualBlockOptions(startMode: "insert" | "normal" = "insert") {
       },
     },
   }).options;
+}
+
+function runtimeConfiguration(
+  planOrOptions: VimConfigPlan | ResolvedVimEditorOptions = DEFAULT_VIM_OPTIONS,
+  diagnostics: VimDiagnostics = { warnings: [] },
+): VimRuntimeConfiguration {
+  return {
+    plan:
+      "scopes" in planOrOptions
+        ? planOrOptions
+        : createVimConfigPlan(planOrOptions, diagnostics.warnings),
+    diagnostics,
+  };
 }
 
 function createEditor(
@@ -94,7 +113,13 @@ function createEditor(
     },
   } as any;
   return {
-    editor: new VimEditor(tui, theme, keybindings, options, diagnostics, vimOptions),
+    editor: new VimEditor(
+      tui,
+      theme,
+      keybindings,
+      runtimeConfiguration(options, diagnostics),
+      vimOptions,
+    ),
     writes,
     hardwareCursorChanges,
     overlays,
@@ -310,7 +335,9 @@ describe("vim editor integration", () => {
     editor.handleInput("d");
     expect(editor.getPendingOperator()).toBe("d");
 
-    editor.reconfigure(createVimConfigPlan(options, []), { warnings: ["reloaded"] });
+    editor.reconfigure(
+      runtimeConfiguration(createVimConfigPlan(options, []), { warnings: ["reloaded"] }),
+    );
     expectEditorState(editor, { text: "one\ntwo", mode: "normal", pending: undefined });
     typeKeys(editor, ["g", "g", ",", "k"]);
 
@@ -375,7 +402,7 @@ describe("vim editor integration", () => {
       [],
     );
 
-    editor.reconfigure(plan, { warnings: ["reloaded"] });
+    editor.reconfigure(runtimeConfiguration(plan, { warnings: ["reloaded"] }));
 
     expectEditorState(editor, { text: "one\ntwo", cursor: beforeCursor, mode: "visual" });
     expect(internal.modalState).toMatchObject({
@@ -419,7 +446,7 @@ describe("vim editor integration", () => {
     typeKeys(editor, ["G", "$"]);
     editor.setText("x");
 
-    editor.reconfigure(createVimConfigPlan(DEFAULT_VIM_OPTIONS, []), { warnings: [] });
+    editor.reconfigure(runtimeConfiguration());
 
     expect(editor.getCursor()).toEqual({ line: 0, col: 1 });
   });
@@ -436,7 +463,7 @@ describe("vim editor integration", () => {
     };
     editor.setText("Xane");
 
-    editor.reconfigure(createVimConfigPlan(DEFAULT_VIM_OPTIONS, []), { warnings: [] });
+    editor.reconfigure(runtimeConfiguration());
     expect(editor.getText()).toBe("Xone");
     editor.handleInput("u");
 
@@ -449,7 +476,7 @@ describe("vim editor integration", () => {
     typeKeys(editor, ["g", "g", "i", "x", "\x1b", "u"]);
     expect(editor.getText()).toBe("draft");
 
-    editor.reconfigure(createVimConfigPlan(DEFAULT_VIM_OPTIONS, []), { warnings: [] });
+    editor.reconfigure(runtimeConfiguration());
     editor.handleInput("\x12");
 
     expect(editor.getText()).toBe("xdraft");

--- a/test/vim-editor.test.ts
+++ b/test/vim-editor.test.ts
@@ -5,7 +5,7 @@ import type { ModalState } from "../src/modal/types.ts";
 import type { ResolvedVimEditorOptions, VimDiagnostics, VimMode } from "../src/types.ts";
 
 import { setClipboardTextReaderForTesting } from "../src/clipboard.ts";
-import { DEFAULT_VIM_OPTIONS, resolveVimOptions } from "../src/config.ts";
+import { createVimConfigPlan, DEFAULT_VIM_OPTIONS, resolveVimOptions } from "../src/config.ts";
 import { SEARCH_CURRENT_START, SEARCH_START } from "../src/render.ts";
 import { fitStatusBorder, VimEditor } from "../src/vim-editor.ts";
 
@@ -32,13 +32,16 @@ function createEditor(
   const hardwareCursorChanges: boolean[] = [];
   const overlays: Array<{ component: any; options: any; hidden: boolean }> = [];
   let hardwareCursorVisible = initialHardwareCursorVisible;
+  let renderRequests = 0;
   const tui = {
     terminal: {
       rows: terminalSize.rows ?? 24,
       columns: terminalSize.columns,
       write: (data: string) => writes.push(data),
     },
-    requestRender() {},
+    requestRender() {
+      renderRequests += 1;
+    },
     showOverlay(component: any, options: any) {
       const entry = { component, options, hidden: false };
       overlays.push(entry);
@@ -96,6 +99,7 @@ function createEditor(
     hardwareCursorChanges,
     overlays,
     getHardwareCursorVisible: () => hardwareCursorVisible,
+    getRenderRequests: () => renderRequests,
   };
 }
 
@@ -306,12 +310,157 @@ describe("vim editor integration", () => {
     editor.handleInput("d");
     expect(editor.getPendingOperator()).toBe("d");
 
-    editor.reconfigure(options, { warnings: ["reloaded"] });
+    editor.reconfigure(createVimConfigPlan(options, []), { warnings: ["reloaded"] });
     expectEditorState(editor, { text: "one\ntwo", mode: "normal", pending: undefined });
     typeKeys(editor, ["g", "g", ",", "k"]);
 
     expect(editor.getText()).toBe("one\n\ntwo");
     expect(editor.getVimMode()).toBe("insert");
+  });
+
+  test("reconfigure preserves durable state and clears transient grammar", () => {
+    const { editor, writes, getRenderRequests } = createEditor({
+      ...DEFAULT_VIM_OPTIONS,
+      startMode: "normal",
+    });
+    editor.setText("one\ntwo");
+    typeKeys(editor, ["g", "g", "v", "j"]);
+    const internal = editor as unknown as {
+      modalState: ModalState;
+      redoStack: Array<{ text: string; cursor: { line: number; col: number } }>;
+    };
+    internal.modalState = {
+      ...internal.modalState,
+      register: { type: "char", text: "unnamed" },
+      namedRegisters: { a: { type: "line", text: "named\n" } },
+      clipboardRegisters: { "+": { type: "char", text: "clipboard" } },
+      macros: { q: ["i", "x", "escape"] },
+      recordingSlot: "q",
+      lastPlayedMacro: "q",
+      marks: { a: { line: 1, col: 2 } },
+      searchHistory: [{ query: "two", matcherMode: "literal" }],
+      exHistory: ["messages"],
+      lastVisualSelection: {
+        mode: "visual",
+        anchor: { line: 99, col: 99 },
+        cursor: { line: 0, col: 99 },
+        text: "one\ntwo",
+      },
+      pending: "2d",
+      pendingMacro: "play",
+      pendingRegister: "awaitingSlot",
+      pendingMark: { kind: "set" },
+      pendingSearch: { query: "stale", direction: "forward" },
+      pendingEx: { command: "stale", sourceMode: "visual" },
+      pendingInsertEscape: "j",
+      pendingInsertEscapeInputs: ["j"],
+      pendingWorkbench: { kind: "ex", prefix: ":", text: "stale", sourceMode: "visual" },
+      pendingEasymotion: {
+        kind: "highlight",
+        targets: [{ label: "a", line: 0, character: 0, original: "o" }],
+        originalText: "one\ntwo",
+      },
+    };
+    editor.setText("ane\ntwo");
+    internal.redoStack.push({ text: "redo", cursor: { line: 0, col: 4 } });
+    const beforeCursor = editor.getCursor();
+    const renderRequests = getRenderRequests();
+    const plan = createVimConfigPlan(
+      resolveVimOptions({
+        piVimMode: {
+          cursor: { visual: "underline" },
+          keymap: { commands: { openLineBelow: [",k"] } },
+        },
+      }).options,
+      [],
+    );
+
+    editor.reconfigure(plan, { warnings: ["reloaded"] });
+
+    expectEditorState(editor, { text: "one\ntwo", cursor: beforeCursor, mode: "visual" });
+    expect(internal.modalState).toMatchObject({
+      register: { type: "char", text: "unnamed" },
+      namedRegisters: { a: { type: "line", text: "named\n" } },
+      clipboardRegisters: { "+": { type: "char", text: "clipboard" } },
+      macros: { q: ["i", "x", "escape"] },
+      lastPlayedMacro: "q",
+      marks: { a: { line: 1, col: 2 } },
+      searchHistory: [{ query: "two", matcherMode: "literal" }],
+      exHistory: ["messages"],
+      visualAnchor: { line: 0, col: 0 },
+      lastVisualSelection: {
+        anchor: { line: 1, col: 3 },
+        cursor: { line: 0, col: 3 },
+      },
+    });
+    for (const field of [
+      "recordingSlot",
+      "pending",
+      "pendingMacro",
+      "pendingRegister",
+      "pendingMark",
+      "pendingSearch",
+      "pendingEx",
+      "pendingInsertEscape",
+      "pendingInsertEscapeInputs",
+      "pendingWorkbench",
+      "pendingEasymotion",
+    ] as const) {
+      expect(internal.modalState[field]).toBeUndefined();
+    }
+    expect(internal.redoStack).toEqual([{ text: "redo", cursor: { line: 0, col: 4 } }]);
+    expect(writes.at(-1)).toBe("\x1b[4 q");
+    expect(getRenderRequests()).toBeGreaterThan(renderRequests);
+  });
+
+  test("reconfigure removes EasyMotion labels without adding undo history", () => {
+    const { editor } = createEditor({ ...DEFAULT_VIM_OPTIONS, startMode: "normal" });
+    editor.setText("one");
+    typeKeys(editor, ["g", "g", "i", "X", "\x1b"]);
+    const internal = editor as unknown as { modalState: ModalState };
+    internal.modalState.pendingEasymotion = {
+      kind: "highlight",
+      targets: [{ label: "a", line: 0, character: 1, original: "o" }],
+      originalText: "Xone",
+    };
+    editor.setText("Xane");
+
+    editor.reconfigure(createVimConfigPlan(DEFAULT_VIM_OPTIONS, []), { warnings: [] });
+    expect(editor.getText()).toBe("Xone");
+    editor.handleInput("u");
+
+    expect(editor.getText()).toBe("one");
+  });
+
+  test("reconfigure preserves undo and redo behavior", () => {
+    const { editor } = createEditor({ ...DEFAULT_VIM_OPTIONS, startMode: "normal" });
+    editor.setText("draft");
+    typeKeys(editor, ["g", "g", "i", "x", "\x1b", "u"]);
+    expect(editor.getText()).toBe("draft");
+
+    editor.reconfigure(createVimConfigPlan(DEFAULT_VIM_OPTIONS, []), { warnings: [] });
+    editor.handleInput("\x12");
+
+    expect(editor.getText()).toBe("xdraft");
+    editor.handleInput("u");
+    expect(editor.getText()).toBe("draft");
+  });
+
+  test("diagnostics-only update preserves editor state", () => {
+    const { editor, overlays } = createEditor({ ...DEFAULT_VIM_OPTIONS, startMode: "normal" });
+    editor.setText("draft");
+    typeKeys(editor, ["g", "g", "l"]);
+    const before = {
+      text: editor.getText(),
+      cursor: editor.getCursor(),
+      mode: editor.getVimMode(),
+    };
+
+    editor.updateDiagnostics({ warnings: ["fatal reload"] });
+
+    expectEditorState(editor, before);
+    runEx(editor, "vimdoctor");
+    expect(overlays.at(-1)?.component.render(64).join("\n")).toContain("fatal reload");
   });
 
   test("plain insert text uses fast path without full snapshot", () => {

--- a/test/vim-editor.test.ts
+++ b/test/vim-editor.test.ts
@@ -168,6 +168,88 @@ function expectEditorState(
   if (expected.pending !== undefined) expect(editor.getPendingOperator()).toBe(expected.pending);
 }
 
+type ReconfigureTestInternal = {
+  modalState: ModalState;
+  redoStack: Array<{ text: string; cursor: { line: number; col: number } }>;
+};
+
+const RECONFIGURE_TRANSIENT_FIELDS = [
+  "recordingSlot",
+  "pending",
+  "pendingMacro",
+  "pendingRegister",
+  "pendingMark",
+  "pendingSearch",
+  "pendingEx",
+  "pendingInsertEscape",
+  "pendingInsertEscapeInputs",
+  "pendingWorkbench",
+  "pendingEasymotion",
+] as const;
+
+function seedReconfigureState(editor: VimEditor): ReconfigureTestInternal {
+  editor.setText("one\ntwo");
+  typeKeys(editor, ["g", "g", "v", "j"]);
+  const internal = editor as unknown as ReconfigureTestInternal;
+  internal.modalState = {
+    ...internal.modalState,
+    register: { type: "char", text: "unnamed" },
+    namedRegisters: { a: { type: "line", text: "named\n" } },
+    clipboardRegisters: { "+": { type: "char", text: "clipboard" } },
+    macros: { q: ["i", "x", "escape"] },
+    recordingSlot: "q",
+    lastPlayedMacro: "q",
+    marks: { a: { line: 1, col: 2 } },
+    searchHistory: [{ query: "two", matcherMode: "literal" }],
+    exHistory: ["messages"],
+    lastVisualSelection: {
+      mode: "visual",
+      anchor: { line: 99, col: 99 },
+      cursor: { line: 0, col: 99 },
+      text: "one\ntwo",
+    },
+    pending: "2d",
+    pendingMacro: "play",
+    pendingRegister: "awaitingSlot",
+    pendingMark: { kind: "set" },
+    pendingSearch: { query: "stale", direction: "forward" },
+    pendingEx: { command: "stale", sourceMode: "visual" },
+    pendingInsertEscape: "j",
+    pendingInsertEscapeInputs: ["j"],
+    pendingWorkbench: { kind: "ex", prefix: ":", text: "stale", sourceMode: "visual" },
+    pendingEasymotion: {
+      kind: "highlight",
+      targets: [{ label: "a", line: 0, character: 0, original: "o" }],
+      originalText: "one\ntwo",
+    },
+  };
+  editor.setText("ane\ntwo");
+  internal.redoStack.push({ text: "redo", cursor: { line: 0, col: 4 } });
+  return internal;
+}
+
+function expectReconfiguredDurableState(internal: ReconfigureTestInternal) {
+  expect(internal.modalState).toMatchObject({
+    register: { type: "char", text: "unnamed" },
+    namedRegisters: { a: { type: "line", text: "named\n" } },
+    clipboardRegisters: { "+": { type: "char", text: "clipboard" } },
+    macros: { q: ["i", "x", "escape"] },
+    lastPlayedMacro: "q",
+    marks: { a: { line: 1, col: 2 } },
+    searchHistory: [{ query: "two", matcherMode: "literal" }],
+    exHistory: ["messages"],
+    visualAnchor: { line: 0, col: 0 },
+    lastVisualSelection: {
+      anchor: { line: 1, col: 3 },
+      cursor: { line: 0, col: 3 },
+    },
+  });
+  for (const field of RECONFIGURE_TRANSIENT_FIELDS) {
+    expect(internal.modalState[field]).toBeUndefined();
+  }
+  expect(internal.redoStack).toEqual([{ text: "redo", cursor: { line: 0, col: 4 } }]);
+}
+
 describe("vim editor integration", () => {
   test("starts insert, inserts text, and escape enters normal", () => {
     const { editor } = createEditor();
@@ -323,46 +405,7 @@ describe("vim editor integration", () => {
       ...DEFAULT_VIM_OPTIONS,
       startMode: "normal",
     });
-    editor.setText("one\ntwo");
-    typeKeys(editor, ["g", "g", "v", "j"]);
-    const internal = editor as unknown as {
-      modalState: ModalState;
-      redoStack: Array<{ text: string; cursor: { line: number; col: number } }>;
-    };
-    internal.modalState = {
-      ...internal.modalState,
-      register: { type: "char", text: "unnamed" },
-      namedRegisters: { a: { type: "line", text: "named\n" } },
-      clipboardRegisters: { "+": { type: "char", text: "clipboard" } },
-      macros: { q: ["i", "x", "escape"] },
-      recordingSlot: "q",
-      lastPlayedMacro: "q",
-      marks: { a: { line: 1, col: 2 } },
-      searchHistory: [{ query: "two", matcherMode: "literal" }],
-      exHistory: ["messages"],
-      lastVisualSelection: {
-        mode: "visual",
-        anchor: { line: 99, col: 99 },
-        cursor: { line: 0, col: 99 },
-        text: "one\ntwo",
-      },
-      pending: "2d",
-      pendingMacro: "play",
-      pendingRegister: "awaitingSlot",
-      pendingMark: { kind: "set" },
-      pendingSearch: { query: "stale", direction: "forward" },
-      pendingEx: { command: "stale", sourceMode: "visual" },
-      pendingInsertEscape: "j",
-      pendingInsertEscapeInputs: ["j"],
-      pendingWorkbench: { kind: "ex", prefix: ":", text: "stale", sourceMode: "visual" },
-      pendingEasymotion: {
-        kind: "highlight",
-        targets: [{ label: "a", line: 0, character: 0, original: "o" }],
-        originalText: "one\ntwo",
-      },
-    };
-    editor.setText("ane\ntwo");
-    internal.redoStack.push({ text: "redo", cursor: { line: 0, col: 4 } });
+    const internal = seedReconfigureState(editor);
     const beforeCursor = editor.getCursor();
     const renderRequests = getRenderRequests();
     const plan = createVimConfigPlan(
@@ -378,37 +421,7 @@ describe("vim editor integration", () => {
     editor.reconfigure(plan, { warnings: ["reloaded"] });
 
     expectEditorState(editor, { text: "one\ntwo", cursor: beforeCursor, mode: "visual" });
-    expect(internal.modalState).toMatchObject({
-      register: { type: "char", text: "unnamed" },
-      namedRegisters: { a: { type: "line", text: "named\n" } },
-      clipboardRegisters: { "+": { type: "char", text: "clipboard" } },
-      macros: { q: ["i", "x", "escape"] },
-      lastPlayedMacro: "q",
-      marks: { a: { line: 1, col: 2 } },
-      searchHistory: [{ query: "two", matcherMode: "literal" }],
-      exHistory: ["messages"],
-      visualAnchor: { line: 0, col: 0 },
-      lastVisualSelection: {
-        anchor: { line: 1, col: 3 },
-        cursor: { line: 0, col: 3 },
-      },
-    });
-    for (const field of [
-      "recordingSlot",
-      "pending",
-      "pendingMacro",
-      "pendingRegister",
-      "pendingMark",
-      "pendingSearch",
-      "pendingEx",
-      "pendingInsertEscape",
-      "pendingInsertEscapeInputs",
-      "pendingWorkbench",
-      "pendingEasymotion",
-    ] as const) {
-      expect(internal.modalState[field]).toBeUndefined();
-    }
-    expect(internal.redoStack).toEqual([{ text: "redo", cursor: { line: 0, col: 4 } }]);
+    expectReconfiguredDurableState(internal);
     expect(writes.at(-1)).toBe("\x1b[4 q");
     expect(getRenderRequests()).toBeGreaterThan(renderRequests);
   });

--- a/test/vim-editor.test.ts
+++ b/test/vim-editor.test.ts
@@ -384,8 +384,7 @@ describe("vim editor integration", () => {
       pendingWorkbench: { kind: "ex", prefix: ":", text: "stale", sourceMode: "visual" },
       pendingEasymotion: {
         kind: "highlight",
-        targets: [{ label: "a", line: 0, character: 0, original: "o" }],
-        originalText: "one\ntwo",
+        targets: [{ label: "a", line: 0, character: 0 }],
       },
     };
     editor.setText("ane\ntwo");
@@ -404,7 +403,7 @@ describe("vim editor integration", () => {
 
     editor.reconfigure(plan, { warnings: ["reloaded"] });
 
-    expectEditorState(editor, { text: "one\ntwo", cursor: beforeCursor, mode: "visual" });
+    expectEditorState(editor, { text: "ane\ntwo", cursor: beforeCursor, mode: "visual" });
     expect(internal.modalState).toMatchObject({
       register: { type: "char", text: "unnamed" },
       namedRegisters: { a: { type: "line", text: "named\n" } },
@@ -451,23 +450,39 @@ describe("vim editor integration", () => {
     expect(editor.getCursor()).toEqual({ line: 0, col: 1 });
   });
 
-  test("reconfigure removes EasyMotion labels without adding undo history", () => {
+  test("reconfigure clears EasyMotion labels without changing prompt text or undo history", () => {
     const { editor } = createEditor({ ...DEFAULT_VIM_OPTIONS, startMode: "normal" });
-    editor.setText("one");
-    typeKeys(editor, ["g", "g", "i", "X", "\x1b"]);
+    editor.setText("Xone");
     const internal = editor as unknown as { modalState: ModalState };
     internal.modalState.pendingEasymotion = {
       kind: "highlight",
-      targets: [{ label: "a", line: 0, character: 1, original: "o" }],
-      originalText: "Xone",
+      targets: [{ label: "a", line: 0, character: 1 }],
     };
-    editor.setText("Xane");
+
+    expect(editor.render(20).join("\n")).toContain("\x1b[31ma\x1b[0m");
+    editor.setText("XoHOSTne");
 
     editor.reconfigure(DEFAULT_PLAN, { warnings: [] });
-    expect(editor.getText()).toBe("Xone");
+    expect(editor.getText()).toBe("XoHOSTne");
     editor.handleInput("u");
 
+    expect(editor.getText()).toBe("Xone");
+  });
+
+  test("EasyMotion labels render without editing prompt text", () => {
+    const options = resolveVimOptions({
+      piVimMode: { startMode: "normal", keymap: { commands: { easymotion: ["e"] } } },
+    }).options;
+    const { editor } = createEditor(options);
+    editor.setText("one");
+    typeKeys(editor, ["e", "o"]);
+
     expect(editor.getText()).toBe("one");
+    expect(editor.render(20).join("\n")).toContain("\x1b[31ma\x1b[0m");
+    editor.handleInput("a");
+
+    expect(editor.getText()).toBe("one");
+    expect(editor.getCursor()).toEqual({ line: 0, col: 0 });
   });
 
   test("reconfigure preserves undo and redo behavior", () => {
@@ -2218,6 +2233,31 @@ describe("vim editor integration", () => {
     expect(editor.getText()).toBe("aXbcd\neXfgh");
   });
 
+  test("visual block insert survives reload before escape", () => {
+    const { editor } = createEditor(ctrlVVisualBlockOptions("normal"));
+    editor.setText("abcd\nefgh");
+    typeKeys(editor, ["g", "g", "l", "\x16", "j", "l", "I", "X"]);
+
+    expect(editor.getText()).toBe("aXbcd\nefgh");
+    editor.reconfigure(DEFAULT_PLAN, { warnings: [] });
+    editor.handleInput("\x1b");
+
+    expect(editor.getText()).toBe("aXbcd\neXfgh");
+    expect(editor.getVimMode()).toBe("normal");
+  });
+
+  test("reconfigure restores cursor across emoji graphemes", () => {
+    const { editor } = createEditor({ ...DEFAULT_VIM_OPTIONS, startMode: "normal" });
+    editor.setText("😀x");
+    typeKeys(editor, ["g", "g", "l"]);
+    const before = editor.getCursor();
+
+    editor.reconfigure(DEFAULT_PLAN, { warnings: [] });
+
+    expect(before).toEqual({ line: 0, col: 2 });
+    expect(editor.getCursor()).toEqual(before);
+  });
+
   test("visual line change removes full lines and enters insert", () => {
     const { editor } = createEditor();
     editor.setText("one\ntwo");
@@ -2412,6 +2452,36 @@ describe("vim editor clipboard register integration", () => {
 
     expect(editor.getText()).toBe("onehost");
     expect(editor.getClipboardRegister("+")).toEqual({ type: "char", text: "host" });
+  });
+
+  test("reload does not undo clipboard paste after EasyMotion labels", async () => {
+    let resolveClipboard!: (text: string) => void;
+    setClipboardTextReaderForTesting(
+      () =>
+        new Promise<string>((resolve) => {
+          resolveClipboard = resolve;
+        }),
+    );
+    const { editor } = createEditor({ ...DEFAULT_VIM_OPTIONS, startMode: "normal" });
+    editor.setText("one");
+    const internal = editor as unknown as {
+      modalState: ModalState;
+      readClipboardAndPaste: (slot: "+" | "*", placement: "after" | "before") => void;
+    };
+    internal.modalState.pendingEasymotion = {
+      kind: "highlight",
+      targets: [{ label: "a", line: 0, character: 1 }],
+    };
+    internal.readClipboardAndPaste("+", "after");
+    resolveClipboard("HOST");
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    const pastedText = editor.getText();
+    expect(pastedText).not.toBe("one");
+    editor.reconfigure(DEFAULT_PLAN, { warnings: [] });
+    expect(editor.getText()).toBe(pastedText);
+    editor.handleInput("u");
+    expect(editor.getText()).toBe("one");
   });
 
   test("clipboard paste falls back to prompt-local mirror on host read failure", async () => {

--- a/test/vim-editor.test.ts
+++ b/test/vim-editor.test.ts
@@ -40,6 +40,8 @@ function runtimeConfiguration(
   };
 }
 
+const DEFAULT_PLAN = createVimConfigPlan(DEFAULT_VIM_OPTIONS, []);
+
 function createEditor(
   options: ResolvedVimEditorOptions = DEFAULT_VIM_OPTIONS,
   diagnostics: VimDiagnostics = { warnings: [] },
@@ -444,7 +446,7 @@ describe("vim editor integration", () => {
     typeKeys(editor, ["G", "$"]);
     editor.setText("x");
 
-    editor.reconfigure(createVimConfigPlan(DEFAULT_VIM_OPTIONS, []), { warnings: [] });
+    editor.reconfigure(DEFAULT_PLAN, { warnings: [] });
 
     expect(editor.getCursor()).toEqual({ line: 0, col: 1 });
   });
@@ -461,7 +463,7 @@ describe("vim editor integration", () => {
     };
     editor.setText("Xane");
 
-    editor.reconfigure(createVimConfigPlan(DEFAULT_VIM_OPTIONS, []), { warnings: [] });
+    editor.reconfigure(DEFAULT_PLAN, { warnings: [] });
     expect(editor.getText()).toBe("Xone");
     editor.handleInput("u");
 
@@ -474,7 +476,7 @@ describe("vim editor integration", () => {
     typeKeys(editor, ["g", "g", "i", "x", "\x1b", "u"]);
     expect(editor.getText()).toBe("draft");
 
-    editor.reconfigure(createVimConfigPlan(DEFAULT_VIM_OPTIONS, []), { warnings: [] });
+    editor.reconfigure(DEFAULT_PLAN, { warnings: [] });
     editor.handleInput("\x12");
 
     expect(editor.getText()).toBe("xdraft");


### PR DESCRIPTION
## Summary

Reloads preserve active editor state during asynchronous configuration changes. This fixes visual-block inserts, delayed clipboard paste ordering, cursor restoration around graphemes, diagnostics-only updates, and stale shutdown work.

## Changes

- Preserve durable Vim state while applying reload plans.
- Keep EasyMotion labels render-only.
- Restore cursors by grapheme boundaries.
- Separate diagnostics-only updates from editor reconfiguration.
- Invalidate stale loads and installs after shutdown.
- Known limitation: foreign editor-factory takeover can still update tracked hidden Vim editors.

## Testing

- [x] `bun test` passes (862 tests)
- [x] `bun run check-types` passes
- [x] `bun run lint` passes
- [ ] Manually tested in Pi

## Related Issues

Closes #40