### PR TITLE
feat: package current release notes

### DIFF
--- a/openspec/changes/ship-pi-vimmode-0-9-0/tasks.md
+++ b/openspec/changes/ship-pi-vimmode-0-9-0/tasks.md
@@ -23,7 +23,7 @@
 
 ## 5. Packaged Current-Version Changelog
 
-- [ ] 5.1 Implement [#44](https://github.com/pekochan069/pi-vimmode/issues/44): validate first `RELEASE.md` release against package version, package current-release runtime asset, and prove defensive package-relative loading outside repository cwd. **Blocked by:** #34.
+- [x] 5.1 Implement [#44](https://github.com/pekochan069/pi-vimmode/issues/44): validate first `RELEASE.md` release against package version, package current-release runtime asset, and prove defensive package-relative loading outside repository cwd. **Blocked by:** #34.
 - [ ] 5.2 Implement [#45](https://github.com/pekochan069/pi-vimmode/issues/45): add exact manual `:changelog` command and width-safe Markdown rendering through existing read-only popup while preserving all prompt-editing state. **Blocked by:** #44.
 
 ## 6. Change Validation

--- a/package.json
+++ b/package.json
@@ -25,10 +25,10 @@
     "dist",
     "README.md",
     "LICENSE",
+    "RELEASE.md",
     "docs/config.md",
     "docs/features.md",
-    "docs/settings.md",
-    "examples"
+    "docs/settings.md"
   ],
   "type": "module",
   "module": "index.ts",

--- a/rolldown.config.ts
+++ b/rolldown.config.ts
@@ -4,6 +4,7 @@ import { join } from "node:path";
 import { defineConfig } from "rolldown";
 
 import { PACKAGE_DOCS, PACKAGE_MANIFEST_FILES } from "./scripts/package-inventory.ts";
+import { currentReleaseAsset, RELEASE_ASSET_FILE } from "./src/release-notes.ts";
 
 const nodeBuiltins = new Set([...builtinModules, ...builtinModules.map((m) => `node:${m}`)]);
 const piCorePackages = [
@@ -45,6 +46,10 @@ export default defineConfig({
             encoding: "utf8",
           }),
         );
+        const releaseSource = await this.fs.readFile("RELEASE.md", { encoding: "utf8" });
+        if (typeof packageJson.version !== "string")
+          throw new Error("Root package.json has no version");
+        const releaseAsset = currentReleaseAsset(releaseSource, packageJson.version);
         delete packageJson.scripts;
         delete packageJson.devDependencies;
 
@@ -66,6 +71,8 @@ export default defineConfig({
           this.fs.copyFile("README.md", join(distDir, "README.md")),
           this.fs.copyFile("LICENSE", join(distDir, "LICENSE")),
           this.fs.copyFile("src/vim-config.d.ts", join(distDir, "config.d.ts")),
+          this.fs.copyFile("RELEASE.md", join(distDir, "RELEASE.md")),
+          this.fs.writeFile(join(distDir, RELEASE_ASSET_FILE), releaseAsset),
           ...PACKAGE_DOCS.map((doc) => this.fs.copyFile(doc, join(distDir, doc))),
         ]);
       },

--- a/scripts/package-inventory.ts
+++ b/scripts/package-inventory.ts
@@ -5,6 +5,8 @@ export const PACKAGE_MANIFEST_FILES = [
   "config.d.ts",
   "README.md",
   "LICENSE",
+  "RELEASE.md",
+  "release-notes.json",
   ...PACKAGE_DOCS,
 ] as const;
 
@@ -14,5 +16,7 @@ export const REQUIRED_PACKAGE_FILES = [
   "package.json",
   "LICENSE",
   "README.md",
+  "RELEASE.md",
+  "release-notes.json",
   ...PACKAGE_DOCS,
 ] as const;

--- a/scripts/verify-package.ts
+++ b/scripts/verify-package.ts
@@ -164,7 +164,16 @@ export async function withPackageConsumer<T>(
 
 export async function verifyPackageSmoke(packageDir: string): Promise<void> {
   await withPackageConsumer(packageDir, async ({ run }) => {
-    await run(["--no-install", "-e", "await import('pi-vimmode')"]);
+    await run([
+      "--no-install",
+      "-e",
+      `const { loadCurrentRelease } = await import("pi-vimmode");
+if (typeof loadCurrentRelease !== "function") throw new Error("Missing release loader");
+const release = loadCurrentRelease();
+if (!release.available || !release.content || release.version === "unknown") {
+  throw new Error("Packaged release asset unavailable");
+}`,
+    ]);
     try {
       await run(["--no-install", "-e", "await import('pi-vimmode/config')"]);
     } catch (error) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,6 +2,8 @@ import { type ExtensionAPI } from "@earendil-works/pi-coding-agent";
 
 import { registerVimLifecycle } from "./lifecycle.ts";
 
+export { loadCurrentRelease } from "./release-notes.ts";
+
 export default function piVimMode(pi: ExtensionAPI) {
   registerVimLifecycle(pi);
 }

--- a/src/release-notes.ts
+++ b/src/release-notes.ts
@@ -1,0 +1,158 @@
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+export const RELEASE_ASSET_FILE = "release-notes.json";
+
+const REPOSITORY_RELEASES_URL = "https://github.com/pekochan069/pi-vimmode/releases";
+
+type ReleaseAsset = {
+  version: string;
+  content: string;
+};
+
+export type CurrentRelease = {
+  available: boolean;
+  content: string;
+  releaseUrl: string;
+  version: string;
+};
+
+type Heading = {
+  index: number;
+  text: string;
+};
+
+function invalidRelease(message: string): never {
+  throw new Error(`Invalid RELEASE.md: ${message}`);
+}
+
+function fenceMarker(line: string): string | undefined {
+  return line.match(/^\s*(`{3,}|~{3,})/)?.[1];
+}
+
+function closesFence(line: string, fence: string): boolean {
+  return new RegExp(`^\\s*${fence[0]}{${fence.length},}\\s*$`).test(line);
+}
+
+function nextTopLevelHeading(lines: readonly string[], startIndex: number): Heading | undefined {
+  let fence: string | undefined;
+
+  for (let index = startIndex; index < lines.length; index++) {
+    const line = lines[index]!;
+    if (fence) {
+      if (closesFence(line, fence)) fence = undefined;
+      continue;
+    }
+
+    const marker = fenceMarker(line);
+    if (marker) {
+      fence = marker;
+      continue;
+    }
+    if (/^#(?!#)\s+/.test(line)) return { index, text: line };
+  }
+
+  if (fence) invalidRelease("contains unclosed fenced code block");
+}
+
+function validateReleaseContent(content: string): void {
+  let fence: string | undefined;
+  let hasSection = false;
+  let hasContent = false;
+
+  for (const line of content.split("\n")) {
+    if (fence) {
+      if (closesFence(line, fence)) fence = undefined;
+      else if (line.trim()) hasContent = true;
+      continue;
+    }
+
+    const marker = fenceMarker(line);
+    if (marker) {
+      fence = marker;
+      continue;
+    }
+    if (/^#(?!#)\s+/.test(line)) invalidRelease("contains an unexpected top-level heading");
+    if (/^##(?!#)\s+\S/.test(line)) hasSection = true;
+    else if (line.trim() && !/^#{1,6}\s+/.test(line)) hasContent = true;
+  }
+
+  if (fence) invalidRelease("contains unclosed fenced code block");
+  if (!hasSection) invalidRelease("must contain at least one second-level section");
+  if (!hasContent) invalidRelease("must contain non-empty content");
+}
+
+export function parseCurrentRelease(releaseSource: string, version: string): string {
+  const lines = releaseSource.replace(/\r\n?/g, "\n").split("\n");
+  if (!releaseSource.trim()) invalidRelease("is empty");
+
+  const expectedHeading = `# v${version}`;
+  const firstLine = lines[0] ?? "";
+  if (firstLine !== expectedHeading) {
+    if (firstLine.startsWith("# v")) {
+      invalidRelease(`version mismatch: expected ${expectedHeading}, found ${firstLine}`);
+    }
+    invalidRelease(`must begin with ${expectedHeading}`);
+  }
+
+  const next = nextTopLevelHeading(lines, 1);
+  if (next && !/^# v\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?(?:\+[0-9A-Za-z.-]+)?$/.test(next.text)) {
+    invalidRelease(`malformed release boundary: ${next.text}`);
+  }
+
+  const content = lines.slice(1, next?.index).join("\n").trim();
+  validateReleaseContent(content);
+  return content;
+}
+
+export function currentReleaseAsset(releaseSource: string, version: string): string {
+  const asset: ReleaseAsset = { version, content: parseCurrentRelease(releaseSource, version) };
+  return `${JSON.stringify(asset, null, 2)}\n`;
+}
+
+function releaseUrl(version: string): string {
+  return `${REPOSITORY_RELEASES_URL}/tag/v${version}`;
+}
+
+function unavailable(version?: string): CurrentRelease {
+  const url = version ? releaseUrl(version) : REPOSITORY_RELEASES_URL;
+  return {
+    available: false,
+    content: version
+      ? `Changelog unavailable for v${version}\n${url}`
+      : `Changelog unavailable\n${url}`,
+    releaseUrl: url,
+    version: version ?? "unknown",
+  };
+}
+
+function packageVersion(packageDirectory: string): string | undefined {
+  try {
+    const manifest = JSON.parse(readFileSync(join(packageDirectory, "package.json"), "utf8")) as {
+      version?: unknown;
+    };
+    return typeof manifest.version === "string" ? manifest.version : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+export function loadCurrentRelease(
+  packageDirectory = dirname(fileURLToPath(import.meta.url)),
+): CurrentRelease {
+  const version = packageVersion(packageDirectory);
+  if (!version) return unavailable();
+
+  try {
+    const asset = JSON.parse(readFileSync(join(packageDirectory, RELEASE_ASSET_FILE), "utf8")) as {
+      version?: unknown;
+      content?: unknown;
+    };
+    if (asset.version !== version || typeof asset.content !== "string") return unavailable(version);
+    validateReleaseContent(asset.content);
+    return { available: true, content: asset.content, releaseUrl: releaseUrl(version), version };
+  } catch {
+    return unavailable(version);
+  }
+}

--- a/test/package-verification.test.ts
+++ b/test/package-verification.test.ts
@@ -12,11 +12,21 @@ import {
 } from "../scripts/verify-package.ts";
 
 const requiredFiles = {
-  "index.js": "export {};\n",
+  "index.js": `export function loadCurrentRelease() {
+  return {
+    available: true,
+    content: "## Added\\n\\nText",
+    releaseUrl: "https://github.com/pekochan069/pi-vimmode/releases/tag/v0.9.0",
+    version: "0.9.0",
+  };
+}
+`,
   "config.d.ts": await Bun.file(join(import.meta.dir, "../src/vim-config.d.ts")).text(),
   "package.json": JSON.stringify({ version: "0.9.0" }),
   LICENSE: "MIT\n",
   "README.md": "README\n",
+  "RELEASE.md": "# v0.9.0\n\n## Added\n\nText\n",
+  "release-notes.json": '{"version":"0.9.0","content":"## Added\\n\\nText"}\n',
   "docs/config.md": "Config\n",
   "docs/features.md": "Features\n",
   "docs/settings.md": "Settings\n",
@@ -26,6 +36,8 @@ const requiredManifestFiles = [
   "config.d.ts",
   "README.md",
   "LICENSE",
+  "RELEASE.md",
+  "release-notes.json",
   "docs/config.md",
   "docs/features.md",
   "docs/settings.md",

--- a/test/release-notes.test.ts
+++ b/test/release-notes.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, test } from "bun:test";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { loadCurrentRelease, parseCurrentRelease } from "../src/release-notes.ts";
+
+const repositoryReleaseUrl = "https://github.com/pekochan069/pi-vimmode/releases/tag/v0.9.0";
+
+async function packageDirectory(asset?: string) {
+  const directory = await mkdtemp(join(tmpdir(), "pi-vimmode-release-notes-"));
+  await writeFile(join(directory, "package.json"), JSON.stringify({ version: "0.9.0" }));
+  if (asset !== undefined) await writeFile(join(directory, "release-notes.json"), asset);
+  return directory;
+}
+
+describe("current release parsing", () => {
+  test("extracts every current-release section through next release in source order", () => {
+    const content = parseCurrentRelease(
+      "# v0.9.0\n\n## Added\n\nFirst.\n\n## Fixed\n\n- Second\n\n# v0.8.0\n\n## Older\n",
+      "0.9.0",
+    );
+
+    expect(content).toBe("## Added\n\nFirst.\n\n## Fixed\n\n- Second");
+  });
+
+  test("rejects invalid release sources", () => {
+    expect(() => parseCurrentRelease("# v0.8.0\n\n## Added\n\nText", "0.9.0")).toThrow(
+      "version mismatch",
+    );
+    expect(() => parseCurrentRelease("# v0.9.0\n\nText", "0.9.0")).toThrow("second-level section");
+    expect(() => parseCurrentRelease("# v0.9.0\n\n## Added\n\n```ts\ntext", "0.9.0")).toThrow(
+      "unclosed fenced code block",
+    );
+    expect(() => parseCurrentRelease("# v0.9.0\n\n## Added\n\n```\n```", "0.9.0")).toThrow(
+      "non-empty content",
+    );
+  });
+
+  test("keeps fence-prefixed code inside current release", () => {
+    expect(
+      parseCurrentRelease("# v0.9.0\n\n## Added\n\n```text\n```not-a-close\n```", "0.9.0"),
+    ).toBe("## Added\n\n```text\n```not-a-close\n```");
+  });
+});
+
+describe("packaged current release", () => {
+  test("loads valid package-relative asset", async () => {
+    const directory = await packageDirectory(
+      JSON.stringify({ version: "0.9.0", content: "## Added\n\nText" }),
+    );
+    try {
+      expect(loadCurrentRelease(directory)).toEqual({
+        available: true,
+        content: "## Added\n\nText",
+        releaseUrl: repositoryReleaseUrl,
+        version: "0.9.0",
+      });
+    } finally {
+      await rm(directory, { recursive: true, force: true });
+    }
+  });
+
+  test("returns unavailable content for missing, malformed, and stale assets", async () => {
+    for (const asset of [
+      undefined,
+      "not json",
+      JSON.stringify({ version: "0.8.0", content: "## Old\n\nText" }),
+    ]) {
+      const directory = await packageDirectory(asset);
+      try {
+        expect(loadCurrentRelease(directory)).toEqual({
+          available: false,
+          content: `Changelog unavailable for v0.9.0\n${repositoryReleaseUrl}`,
+          releaseUrl: repositoryReleaseUrl,
+          version: "0.9.0",
+        });
+      } finally {
+        await rm(directory, { recursive: true, force: true });
+      }
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Installed packages now carry one validated current-release asset, so release-note consumers load only their own package files and show an explicit release link instead of stale notes when that asset is unavailable.

## Changes

- Build rejects malformed, empty, version-mismatched, or structurally incomplete release notes.
- Package output includes `RELEASE.md` and generated release asset; examples stay unpublished.
- Export package-relative release loader with unavailable-state fallback.

## Testing

- [x] `bun run verify` passes
- [ ] Manually tested in Pi (not applicable: package/runtime asset change)

## Related Issues

Closes #44
