### PR TITLE
fix(easymotion): render labels without prompt edits

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,7 +150,7 @@ Example keymap/UI override:
 
 ### EasyMotion
 
-When you trigger character search (e.g. `f`, `t`, `F`, `T`), matching characters on the current line are replaced with colored label characters. Press the label to jump to that character, which restores the original. The label color is configurable under `piVimMode.easymotion.labelColor`:
+EasyMotion has no default binding. Bind `command.easymotion`, type a target character, then press its label to move the cursor. Matching is case-insensitive and prompt-wide, with up to 52 labels (lowercase, then uppercase). Labels are render-only substitutions, so prompt text and undo/redo history stay unchanged. Configure label color with `piVimMode.easymotion.labelColor`:
 
 ```json
 {

--- a/docs/features.md
+++ b/docs/features.md
@@ -343,6 +343,12 @@ Limitations:
 - XML-ish tags support matching `<name ...>` / `</name>` pairs and ignore self-closing tags.
 - Error block detection is heuristic and stops at blank or unrelated prose lines.
 
+## EasyMotion
+
+EasyMotion is opt-in; it has no default binding. Bind `command.easymotion`, type a target character, then press its label to move the cursor. Matching is case-insensitive and prompt-wide. Up to 52 targets receive deterministic labels: `a` through `z`, then `A` through `Z`.
+
+Labels are render-only substitutions over unchanged prompt cells. Escape, invalid labels, and missing matches leave prompt text and undo/redo history unchanged. Valid labels move the cursor without creating an edit. Configure label color with `piVimMode.easymotion.labelColor`.
+
 ## Character search
 
 `f`, `F`, `t`, and `T` search within the current line only. They work as normal-mode motions and as targets after `d`, `c`, or `y`.

--- a/openspec/changes/render-only-easymotion-labels/.openspec.yaml
+++ b/openspec/changes/render-only-easymotion-labels/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-22

--- a/openspec/changes/render-only-easymotion-labels/design.md
+++ b/openspec/changes/render-only-easymotion-labels/design.md
@@ -1,0 +1,106 @@
+## Context
+
+EasyMotion is opt-in and has no default binding. Its current command flow collects case-insensitive character matches, assigns up to 52 labels, displays those labels, and moves the cursor after label selection.
+
+At commit `e1544e2`, display labels were written into the Pi prompt through modal `edit` effects and later restored from a full prompt snapshot. Every changed edit clears adapter redo history, so presentation could alter undo/redo semantics and any missed cleanup path could leak labels into prompt content.
+
+This change starts from a later branch that already contains partial render-only mechanics introduced in unrelated reload work: label metadata reaches `src/render.ts`, and common highlight paths no longer emit edits. Dedicated effect/history regressions are still missing, and the unreachable `jump` state remains. Implementation must characterize current behavior first, keep valid partial work, and complete only remaining gaps.
+
+Constraints:
+
+- Preserve existing opt-in command and `piVimMode.easymotion.labelColor` contract.
+- Preserve existing case-insensitive prompt-wide targeting and 52-label limit.
+- Keep `src/modal/engine.ts` responsible for modal transitions, `src/vim-editor.ts` as thin adapter, and `src/render.ts` responsible for presentation.
+- Treat automated and manual verification as release gates.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Make EasyMotion labels presentation-only for every entry and exit path.
+- Preserve prompt text and undo/redo history on highlight, cancellation, invalid input, and successful selection.
+- Keep valid selection limited to cursor movement plus rerendering.
+- Preserve render width, ANSI reset behavior, configured label color, and existing cursor/selection precedence.
+- Remove restoration-only state and unreachable EasyMotion state.
+- Add focused modal, render, and live-adapter regression coverage.
+
+**Non-Goals:**
+
+- Fix repeated `,` character-search direction behavior.
+- Add or change default bindings, action descriptors, or settings.
+- Add more than 52 labels, multi-character labels, ranking, viewport filtering, or full Vim/Neovim EasyMotion parity.
+- Refactor unrelated modal, render, reload, undo, or redo architecture.
+- Add dependencies.
+
+## Decisions
+
+### 1. Modal state stores target metadata, never prompt restoration data
+
+**Seams:** `src/modal/engine.ts`, `src/modal/types.ts`
+
+Highlight state contains only `{ label, line, character }` targets. Entering highlight state invalidates rendering without emitting a text edit. `Escape` clears pending EasyMotion state. A valid label clears pending state and emits cursor restoration plus invalidation. An invalid label leaves highlight state active and invalidates without changing text. The unused `jump` variant and its handler/display branches are removed when repository search confirms no constructor.
+
+Alternative: retain `originalText` and compensating edits. Rejected because it keeps presentation coupled to prompt ownership, creates undo/redo side effects, and relies on every exit path restoring correctly.
+
+Alternative: keep unreachable `jump` state for future work. Rejected because no current behavior constructs it and speculative state increases cleanup paths.
+
+### 2. Renderer substitutes target labels over immutable prompt cells
+
+**Seam:** `src/render.ts`
+
+Renderer resolves target metadata by prompt coordinate and uses target label as displayed cell content without changing snapshot text. Existing bounded target data may be looked up directly; no second restoration model is needed. Wide target cells keep original display width by padding a shorter label. Configured label color is followed by ANSI reset.
+
+Cursor and active visual-selection styling retain precedence over EasyMotion color, while displayed glyph remains target label. EasyMotion labels retain precedence over search highlighting at target coordinates. This matches existing composition order and avoids unrelated visual changes.
+
+Alternative: pre-edit copied render lines before normal rendering. Rejected because it duplicates text transformation and risks coordinate drift across wrapping and wide cells.
+
+Alternative: continue rendering underlying character with only EasyMotion color. Rejected because label selection requires visible target labels, not merely highlighted matches.
+
+### 3. Adapter forwards complete render metadata and performs no EasyMotion text recovery
+
+**Seam:** `src/vim-editor.ts`
+
+`VimEditor` passes each target label and coordinate into render input. It does not inspect `originalText`, undo a temporary edit, or special-case text restoration during reconfiguration. Cursor movement remains adapter-owned through existing `restoreCursor` handling.
+
+Alternative: have adapter overlay labels or restore text. Rejected because renderer already owns cell presentation and adapter-owned recovery would preserve original ownership error.
+
+### 4. Tests lock ownership and history boundaries
+
+**Seams:** `test/modal.test.ts`, `test/render.test.ts`, `test/vim-editor.test.ts`
+
+Modal tests assert highlight transitions and exit paths never produce `edit` effects. Renderer tests assert label substitution, color/reset, multiline/wide-cell behavior, and composition precedence. Live editor tests prove text remains unchanged, valid labels move cursor, invalid labels do not edit, undo immediately reaches prior real edit, and redo survives open/cancel.
+
+Tests also cover no match, case-insensitive matching, uppercase/lowercase label selection, and the 52-target ceiling. Manual terminal checks cover realistic invocation, multiple selections, history preservation, multiline input, invalid labels, and custom color.
+
+Alternative: rely on full-suite green status. Rejected because existing tests passed while EasyMotion still mutated prompt content.
+
+### 5. Keep configuration stable and correct user-facing docs
+
+**Seams:** `src/config.ts`, `src/types.ts`, `docs/features.md`, `docs/settings.md`, `README.md`
+
+No setting, default, keymap surface, or public option changes. Therefore config parsing, `VimEditor` option cloning, and settings docs require no changes. Add canonical behavior wording to `docs/features.md` and keep README concise while correcting its stale claims that `f`/`t`/`F`/`T` trigger EasyMotion, matching is line-local, and labels require text restoration.
+
+Alternative: leave docs unchanged because visible labels look similar. Rejected because current trigger, match scope, and prompt-ownership claims are materially false.
+
+Alternative: add a render-only setting or new default binding. Rejected as unrelated scope and unnecessary configuration.
+
+## Risks / Trade-offs
+
+- **Partial implementation arrived in unrelated commit:** tests may pass before all intended cleanup is owned by this change. **Mitigation:** inspect current diff/state, add dedicated regressions first, then delete only remaining dead/restoration code.
+- **Render precedence regression:** labels could hide cursor/selection or lose color/reset. **Mitigation:** focused tests for target under cursor, selected target, search overlap, configured color, and ANSI reset.
+- **Coordinate/width mismatch:** multiline, wrapped, Unicode, or wide cells could misplace labels or change terminal width. **Mitigation:** preserve existing logical coordinates and add multiline plus wide-cell width tests.
+- **History regression hidden by unchanged final text:** temporary edits could still clear redo after compensation. **Mitigation:** assert no modal `edit` effect and test live redo after EasyMotion open/cancel.
+- **Bounded label set leaves later matches unlabeled:** existing 52-target limit remains. **Mitigation:** test deterministic cap; expansion requires separate proposal.
+
+## Migration Plan
+
+1. Add focused failing/characterization tests at modal, render, and live adapter seams.
+2. Keep existing correct render-only work; remove any remaining prompt restoration data, edit effects, adapter recovery, and unreachable `jump` state.
+3. Run automated validation: `bun test`, `bun run check-types`, `bun run lint`, `bun run format:check`, and `openspec validate --specs --strict`.
+4. Run required manual terminal sequence before release.
+
+No data or configuration migration is required. Rollback is a code revert; release must remain blocked rather than restoring buffer-mutating labels.
+
+## Open Questions
+
+None. Invalid labels retain current highlight state while leaving prompt text unchanged; changing cancellation UX requires separate evidence and scope.

--- a/openspec/changes/render-only-easymotion-labels/proposal.md
+++ b/openspec/changes/render-only-easymotion-labels/proposal.md
@@ -1,0 +1,38 @@
+## Why
+
+EasyMotion currently treats transient jump labels as prompt edits, so opening or cancelling it can clear redo history, pollute undo behavior, and risk exposing label text when an exit path misses restoration. This is a release blocker because presentation state must never own or rewrite prompt content.
+
+## What Changes
+
+- Render EasyMotion labels as transient visual substitutions over unchanged prompt cells.
+- Keep only label and coordinate metadata in modal state; remove prompt snapshots and restoration-only target data.
+- Make highlight entry, cancellation, invalid labels, and successful selection avoid text-edit effects.
+- Preserve cursor movement on valid selection while keeping undo and redo history intact.
+- Add focused modal, renderer, and live-editor regressions for visual-only labels, configured label color, cancellation, selection, invalid input, multiline targets, label limits, and undo/redo preservation.
+- Remove the unreachable EasyMotion `jump` state when no constructor remains.
+- Correct user-facing EasyMotion documentation to describe its opt-in command, prompt-wide targeting, and render-only labels.
+
+Non-goals:
+
+- Fixing repeated `,` character-search direction behavior.
+- Adding a default EasyMotion binding or changing its command/config surface.
+- Expanding beyond the existing 52 labels or pursuing full Vim/Neovim EasyMotion parity.
+- Reworking modal, render, or editor-adapter architecture.
+
+## Capabilities
+
+### New Capabilities
+
+- `vim-easymotion`: Defines prompt-local EasyMotion targeting, render-only labels, safe cancellation/invalid input, cursor movement, label limits, color rendering, and undo/redo preservation.
+
+### Modified Capabilities
+
+None.
+
+## Impact
+
+- Code seams: `src/modal/engine.ts`, `src/modal/types.ts`, `src/vim-editor.ts`, and `src/render.ts`.
+- Tests: focused modal-effect, render, and live `VimEditor` integration coverage; manual terminal verification remains required before release.
+- Documentation: correct `docs/features.md` and README wording; no command or setting contract changes.
+- APIs and compatibility: no breaking changes; existing opt-in EasyMotion bindings and `piVimMode.easymotion.labelColor` remain compatible.
+- Dependencies: no new runtime, peer, or development dependencies.

--- a/openspec/changes/render-only-easymotion-labels/specs/vim-easymotion/spec.md
+++ b/openspec/changes/render-only-easymotion-labels/specs/vim-easymotion/spec.md
@@ -1,0 +1,111 @@
+## ADDED Requirements
+
+### Requirement: EasyMotion character targeting is finite and opt-in
+
+The Vim editor SHALL start EasyMotion character targeting only through an explicitly configured EasyMotion command binding and SHALL assign deterministic single-character labels to case-insensitive matches across the current prompt.
+
+#### Scenario: Configured command finds prompt matches
+
+- **WHEN** the user invokes a configured EasyMotion command and enters a character present in the prompt with either letter case
+- **THEN** the editor displays labels for matching characters across prompt lines without moving the cursor
+
+#### Scenario: No command binding configured
+
+- **WHEN** no EasyMotion command binding resolves for an input sequence
+- **THEN** that input does not enter pending EasyMotion state
+
+#### Scenario: Character has no matches
+
+- **WHEN** EasyMotion is waiting for a target character and the user enters a character absent from the prompt
+- **THEN** the editor clears pending EasyMotion state without changing prompt text or cursor position
+
+#### Scenario: Match count exceeds available labels
+
+- **WHEN** the prompt contains more than 52 case-insensitive matches for the target character
+- **THEN** the editor labels only the first 52 matches in prompt order using the existing lowercase-then-uppercase label sequence
+
+### Requirement: EasyMotion labels are render-only
+
+The Vim editor SHALL render EasyMotion labels as transient visual substitutions over target cells and MUST NOT write label text into the prompt buffer.
+
+#### Scenario: Highlight state displays labels without editing
+
+- **WHEN** EasyMotion enters highlight state for one or more targets
+- **THEN** the rendered prompt displays each target label while the prompt text remains byte-identical
+
+#### Scenario: Configured label color is applied
+
+- **WHEN** EasyMotion labels are visible and `piVimMode.easymotion.labelColor` specifies an ANSI color
+- **THEN** each non-cursor, non-selected target label uses that color followed by an ANSI reset
+
+#### Scenario: Target occupies a wide cell
+
+- **WHEN** an EasyMotion target occupies a terminal cell wider than its label
+- **THEN** the renderer preserves the target cell's visible width and all rendered rows remain terminal-width safe
+
+#### Scenario: Label overlaps cursor or visual selection
+
+- **WHEN** an EasyMotion target coordinate also contains the cursor or active visual-selection styling
+- **THEN** the target label remains visible while existing cursor or selection styling retains precedence over EasyMotion label color
+
+#### Scenario: Label overlaps search highlight
+
+- **WHEN** an EasyMotion target coordinate also has search highlighting
+- **THEN** the EasyMotion label is rendered at that coordinate without changing stored search state or prompt text
+
+### Requirement: EasyMotion exits preserve prompt content
+
+The Vim editor SHALL keep prompt text unchanged when EasyMotion is cancelled, receives an invalid label, or completes a valid selection.
+
+#### Scenario: Escape cancels EasyMotion
+
+- **WHEN** the user presses `Escape` while EasyMotion is waiting for a target character or label
+- **THEN** pending EasyMotion state and visible labels clear while prompt text and cursor position remain unchanged
+
+#### Scenario: Valid label moves cursor
+
+- **WHEN** the user enters a visible EasyMotion label
+- **THEN** pending EasyMotion state clears, prompt text remains unchanged, and the cursor moves to that label's target coordinate
+
+#### Scenario: Invalid label is safe
+
+- **WHEN** the user enters a label that is not assigned in the current EasyMotion highlight state
+- **THEN** prompt text and cursor position remain unchanged and the current labels remain available for a valid selection or cancellation
+
+#### Scenario: Lowercase and uppercase labels remain distinct
+
+- **WHEN** targets have both lowercase and uppercase labels
+- **THEN** selecting either label moves to its exact assigned target without changing prompt text
+
+### Requirement: EasyMotion preserves editor side-effect state
+
+The Vim editor SHALL treat EasyMotion highlighting as transient presentation and SHALL preserve prompt edit history and unrelated modal side-effect state.
+
+#### Scenario: Undo skips EasyMotion presentation
+
+- **WHEN** the user makes a real prompt edit, opens or completes EasyMotion, and then invokes undo
+- **THEN** undo immediately reverses the prior real prompt edit rather than any EasyMotion label display
+
+#### Scenario: Redo survives EasyMotion cancellation
+
+- **WHEN** undo creates redo state and the user opens then cancels EasyMotion before invoking redo
+- **THEN** redo restores the undone real prompt edit
+
+#### Scenario: Unrelated modal state is preserved
+
+- **WHEN** EasyMotion is opened, cancelled, given an invalid label, or completed
+- **THEN** registers, marks, macro slots, dot-repeat state, search state, visual-selection history, and Ex message history remain unchanged
+
+#### Scenario: Automated validation covers EasyMotion ownership
+
+- **WHEN** repository validation runs
+- **THEN** focused tests verify render-only labels, cancellation, valid and invalid selection, multiline targets, label limits, configured color, and undo/redo preservation
+
+### Requirement: EasyMotion behavior is documented accurately
+
+User-facing documentation SHALL describe EasyMotion as an opt-in prompt-wide character-targeting command whose labels are rendered without changing prompt text.
+
+#### Scenario: User reads EasyMotion documentation
+
+- **WHEN** the user reads the feature guide or README summary
+- **THEN** the documentation identifies the configured EasyMotion command, prompt-wide matching, render-only labels, 52-target limit, and configurable label color without claiming that `f`, `t`, `F`, or `T` trigger EasyMotion

--- a/openspec/changes/render-only-easymotion-labels/tasks.md
+++ b/openspec/changes/render-only-easymotion-labels/tasks.md
@@ -1,0 +1,36 @@
+## 1. Modal State and Effects
+
+- [x] 1.1 Add focused `test/modal.test.ts` coverage proving case-insensitive prompt-wide matching builds only `{ label, line, character }` metadata, stops at 52 lowercase-then-uppercase labels, clears on no match, and emits no `edit` effect.
+- [x] 1.2 Add modal tests proving `Escape`, valid labels, and invalid labels never emit `edit`; valid labels clear pending state and emit only cursor restoration plus invalidation, while invalid labels retain highlight state.
+- [x] 1.3 Seed representative registers, marks, macro, dot-repeat, search, visual-history, and Ex-message state in one focused modal regression and verify EasyMotion entry/cancel/selection does not mutate it.
+- [x] 1.4 Remove the unreachable EasyMotion `jump` union variant and all handler/status branches after confirming no constructor exists; retain only `char` and `highlight` states with render metadata.
+
+## 2. Render and View
+
+- [x] 2.1 Expand `test/render.test.ts` coverage for visual label substitution, configured ANSI color plus reset, multiline targets, wide-cell width preservation, cursor/selection precedence, and EasyMotion precedence over search highlighting.
+- [x] 2.2 Verify and complete `src/render.ts` so target coordinates resolve to label glyphs over immutable snapshot cells, preserve cell width, and do not maintain restoration text or mutate copied prompt lines.
+
+## 3. Adapter and Live Editor
+
+- [x] 3.1 Add `test/vim-editor.test.ts` flows proving highlight, `Escape`, valid selection, invalid selection, no-match input, and lowercase/uppercase labels leave prompt text unchanged; valid labels alone move cursor.
+- [x] 3.2 Add live-editor history regressions proving undo after EasyMotion immediately reverses the prior real edit and redo survives EasyMotion open/cancel.
+- [x] 3.3 Verify and complete `src/vim-editor.ts` render input so every target label and coordinate reaches `src/render.ts`, with no EasyMotion text recovery, synthetic undo, or redo clearing.
+
+## 4. Configuration and Documentation
+
+- [x] 4.1 Confirm focused config/live-editor tests preserve no default EasyMotion binding, configured command resolution, configured `labelColor`, and existing protected Pi shortcut behavior without adding settings or clone paths.
+- [x] 4.2 Document opt-in prompt-wide EasyMotion behavior, render-only labels, 52-target limit, and label color in `docs/features.md`; replace stale README claims about `f`/`t`/`F`/`T`, current-line replacement, and restoration with a concise accurate summary/link.
+
+## 5. Manual Release Gate
+
+- [ ] 5.1 With prompt `banana apple alpha`, invoke configured EasyMotion for `a`, press `Escape`, then repeat with several valid labels; verify text stays byte-identical and cursor reaches each selected target.
+- [ ] 5.2 Create a real edit, undo it, open and cancel EasyMotion, then redo; verify the real edit returns immediately and no label text enters prompt history.
+- [ ] 5.3 Manually verify multiline targets, no match, invalid label, lowercase/uppercase labels, 52+ matches, and custom `piVimMode.easymotion.labelColor`; keep release blocked if any case fails.
+
+## 6. Validation
+
+- [x] 6.1 Run `bun test`.
+- [x] 6.2 Run `bun run check-types`.
+- [x] 6.3 Run `bun run lint`.
+- [x] 6.4 Run `bun run format:check`.
+- [x] 6.5 Run `openspec validate --specs --strict` and `openspec validate render-only-easymotion-labels --type change --strict`.

--- a/src/modal/engine.ts
+++ b/src/modal/engine.ts
@@ -1,6 +1,7 @@
 import { matchesKey, parseKey } from "@earendil-works/pi-tui";
 
 import type {
+  EasymotionTarget,
   ResolvedVimKeymap,
   VimActionBindingMode,
   VimDiagnostics,
@@ -8,7 +9,6 @@ import type {
 } from "../types.ts";
 import type {
   EditorSnapshot,
-  EasymotionTarget,
   FastInsertDelegateContext,
   ModalEffect,
   ModalOptions,

--- a/src/modal/engine.ts
+++ b/src/modal/engine.ts
@@ -8,6 +8,7 @@ import type {
 } from "../types.ts";
 import type {
   EditorSnapshot,
+  EasymotionTarget,
   FastInsertDelegateContext,
   ModalEffect,
   ModalOptions,
@@ -257,8 +258,8 @@ function handleEasymotionInput(
   }
 
   if (state.pendingEasymotion?.kind === "char") {
-    // Transition to highlight state with case-insensitive matching
-    const targets: { label: string; line: number; character: number }[] = [];
+    // Match each source character separately so folded expansions keep source offsets.
+    const targets: EasymotionTarget[] = [];
     const lines = snapshot.text.split("\n");
     const labels = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ".split("");
     let count = 0;
@@ -267,14 +268,16 @@ function handleEasymotionInput(
     for (let i = 0; i < lines.length && count < labels.length; i++) {
       const line = lines[i];
       if (line === undefined) continue;
-      // Case-insensitive matching
-      let pos = line.toLowerCase().indexOf(targetChar);
-      while (pos !== -1 && count < labels.length) {
-        const label = labels[count];
-        if (label === undefined) break;
-        targets.push({ label, line: i, character: pos });
-        count++;
-        pos = line.toLowerCase().indexOf(targetChar, pos + 1);
+      let sourceOffset = 0;
+      for (const sourceChar of line) {
+        if (sourceChar.toLowerCase().includes(targetChar)) {
+          const label = labels[count];
+          if (label === undefined) break;
+          targets.push({ label, line: i, character: sourceOffset });
+          count++;
+        }
+        sourceOffset += sourceChar.length;
+        if (count >= labels.length) break;
       }
     }
 

--- a/src/modal/engine.ts
+++ b/src/modal/engine.ts
@@ -248,7 +248,6 @@ export function canFastDelegateInsertInput(
 function handleEasymotionInput(
   state: ModalState,
   snapshot: EditorSnapshot,
-  _options: ModalOptions,
   data: string,
 ): ModalUpdate {
   const key = keySequence(data);
@@ -302,19 +301,6 @@ function handleEasymotionInput(
       ]);
     }
     return invalidate(state);
-  }
-
-  if (state.pendingEasymotion?.kind === "jump") {
-    const target = state.pendingEasymotion.targets.find((t: any) => t.label === key);
-    const { pendingEasymotion: _, ...rest } = state;
-
-    if (target) {
-      return withEffects(rest, [
-        { type: "restoreCursor", position: { line: target.line, col: target.character } },
-        { type: "invalidate" },
-      ]);
-    }
-    return invalidate(rest);
   }
 
   return invalidate(state);
@@ -1078,8 +1064,7 @@ function routeModalInput(
   if (routedState.helpPopup) return handleHelpPopupInput(routedState, options, data);
 
   // Easymotion routing
-  if (routedState.pendingEasymotion)
-    return handleEasymotionInput(routedState, snapshot, options, data);
+  if (routedState.pendingEasymotion) return handleEasymotionInput(routedState, snapshot, data);
 
   if (routedState.pendingEx)
     return handlePendingExInput(routedState, snapshot, options, data, diagnostics);
@@ -1101,10 +1086,6 @@ export function modalPendingDisplay(state: ModalState): string | undefined {
   if (state.pendingEasymotion?.kind === "highlight") {
     return `Jump [${state.pendingEasymotion.targets.map((t) => t.label).join("")}]: `;
   }
-  if (state.pendingEasymotion?.kind === "jump") {
-    return `Jump [${state.pendingEasymotion.targets.map((t: any) => t.label).join("")}]: `;
-  }
-
   return (
     exDisplay(state.pendingEx) ??
     pendingSearchDisplay(state.pendingSearch) ??

--- a/src/modal/types.ts
+++ b/src/modal/types.ts
@@ -197,8 +197,7 @@ export type ModalState = {
     | {
         kind: "highlight";
         targets: { label: string; line: number; character: number }[];
-      }
-    | { kind: "jump"; targets: { label: string; line: number; character: number }[]; char: string };
+      };
 };
 
 export type FastInsertDelegateContext = {

--- a/src/modal/types.ts
+++ b/src/modal/types.ts
@@ -1,6 +1,7 @@
 import type { ReadOnlyPopup } from "../read-only-popup.ts";
 import type {
   CursorStyle,
+  EasymotionTarget,
   EditResult,
   LineRange,
   PendingOperator,
@@ -59,12 +60,6 @@ export type BlockInsertState = {
   placement: "start" | "end";
   previewLine: number;
   text: string;
-};
-
-export type EasymotionTarget = {
-  label: string;
-  line: number;
-  character: number;
 };
 
 export type CharSearchState = {

--- a/src/modal/types.ts
+++ b/src/modal/types.ts
@@ -61,6 +61,12 @@ export type BlockInsertState = {
   text: string;
 };
 
+export type EasymotionTarget = {
+  label: string;
+  line: number;
+  character: number;
+};
+
 export type CharSearchState = {
   command: "findCharForward" | "findCharBackward" | "tillCharForward" | "tillCharBackward";
   target: string;
@@ -196,7 +202,7 @@ export type ModalState = {
     | { kind: "char" }
     | {
         kind: "highlight";
-        targets: { label: string; line: number; character: number }[];
+        targets: EasymotionTarget[];
       };
 };
 

--- a/src/render.ts
+++ b/src/render.ts
@@ -1,6 +1,6 @@
 import { CURSOR_MARKER, truncateToWidth, visibleWidth } from "@earendil-works/pi-tui";
 
-import type { CursorStyle, Position, TextRange, VimMode } from "./types.ts";
+import type { CursorStyle, EasymotionTarget, Position, TextRange, VimMode } from "./types.ts";
 
 import { findSearchHighlightRanges } from "./buffer.ts";
 import { isVisualCellSelected, isVisualLineSelected } from "./visual-selection.ts";
@@ -37,7 +37,7 @@ export type SearchHighlightRenderInput = {
 };
 
 export type EasymotionRenderInput = {
-  targets: { line: number; character: number; label: string }[];
+  targets: EasymotionTarget[];
   labelColor: string;
 };
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -428,6 +428,12 @@ export type Position = {
   col: number;
 };
 
+export type EasymotionTarget = {
+  label: string;
+  line: number;
+  character: number;
+};
+
 export type TextRange = {
   start: Position;
   end: Position;

--- a/test/modal.test.ts
+++ b/test/modal.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, test } from "bun:test";
 
-import type { ModalEffect, ModalOptions, ModalState } from "../src/modal/types.ts";
+import type {
+  EasymotionTarget,
+  ModalEffect,
+  ModalOptions,
+  ModalState,
+} from "../src/modal/types.ts";
 import type { ResolvedVimEditorOptions } from "../src/types.ts";
 
 import {
@@ -6090,9 +6095,7 @@ describe("gv visual reselection", () => {
 });
 
 describe("EasyMotion modal effects", () => {
-  const highlight = (
-    targets: { label: string; line: number; character: number }[],
-  ): ModalState => ({
+  const highlight = (targets: EasymotionTarget[]): ModalState => ({
     mode: "normal",
     pendingEasymotion: { kind: "highlight", targets },
   });
@@ -6116,6 +6119,23 @@ describe("EasyMotion modal effects", () => {
     });
     expect(update.effects).toEqual([{ type: "invalidate" }]);
     expect(update.effects.some((effect) => effect.type === "edit")).toBe(false);
+  });
+
+  test("preserves source offsets when case folding expands characters", () => {
+    const update = handleModalInput(
+      { mode: "normal", pendingEasymotion: { kind: "char" } },
+      { text: "İI", lines: ["İI"], cursor },
+      options,
+      "i",
+    );
+
+    expect(update.state.pendingEasymotion).toEqual({
+      kind: "highlight",
+      targets: [
+        { label: "a", line: 0, character: 0 },
+        { label: "b", line: 0, character: 1 },
+      ],
+    });
   });
 
   test("caps targets at 52 labels", () => {
@@ -6210,11 +6230,27 @@ describe("EasyMotion modal effects", () => {
       lastVisualSelection: { mode: "visual", anchor: p(0, 0), cursor: p(0, 1), text: "ab" },
       messageHistory: [{ kind: "info", text: "kept" }],
     };
-    const update = handleModalInput(initial, { text: "abc", lines: ["abc"], cursor }, options, "a");
+    const entered = handleModalInput(
+      initial,
+      { text: "abc", lines: ["abc"], cursor },
+      options,
+      "a",
+    );
+    const states = [
+      entered,
+      handleModalInput(entered.state, { text: "abc", lines: ["abc"], cursor }, options, "\x1b"),
+      handleModalInput(entered.state, { text: "abc", lines: ["abc"], cursor }, options, "Z"),
+      handleModalInput(entered.state, { text: "abc", lines: ["abc"], cursor }, options, "a"),
+    ];
 
     const { pendingEasymotion: _pending, ...durable } = initial;
-    expect(update.state).toMatchObject(durable);
-    expect(update.state.pendingEasymotion?.kind).toBe("highlight");
-    expect(update.effects.some((effect) => effect.type === "edit")).toBe(false);
+    for (const update of states) {
+      expect(update.state).toMatchObject(durable);
+      expect(update.effects.some((effect) => effect.type === "edit")).toBe(false);
+    }
+    expect(entered.state.pendingEasymotion?.kind).toBe("highlight");
+    expect(states[1]?.state.pendingEasymotion).toBeUndefined();
+    expect(states[2]?.state.pendingEasymotion?.kind).toBe("highlight");
+    expect(states[3]?.state.pendingEasymotion).toBeUndefined();
   });
 });

--- a/test/modal.test.ts
+++ b/test/modal.test.ts
@@ -6088,3 +6088,133 @@ describe("gv visual reselection", () => {
     expect(reselected.cursor).toEqual(p(0, 2));
   });
 });
+
+describe("EasyMotion modal effects", () => {
+  const highlight = (
+    targets: { label: string; line: number; character: number }[],
+  ): ModalState => ({
+    mode: "normal",
+    pendingEasymotion: { kind: "highlight", targets },
+  });
+
+  test("matches prompt-wide, case-insensitively, with lowercase then uppercase labels", () => {
+    const update = handleModalInput(
+      { mode: "normal", pendingEasymotion: { kind: "char" } },
+      { text: "Axa\ncatA", lines: ["Axa", "catA"], cursor },
+      options,
+      "a",
+    );
+
+    expect(update.state.pendingEasymotion).toEqual({
+      kind: "highlight",
+      targets: [
+        { label: "a", line: 0, character: 0 },
+        { label: "b", line: 0, character: 2 },
+        { label: "c", line: 1, character: 1 },
+        { label: "d", line: 1, character: 3 },
+      ],
+    });
+    expect(update.effects).toEqual([{ type: "invalidate" }]);
+    expect(update.effects.some((effect) => effect.type === "edit")).toBe(false);
+  });
+
+  test("caps targets at 52 labels", () => {
+    const text = "a".repeat(60);
+    const update = handleModalInput(
+      { mode: "normal", pendingEasymotion: { kind: "char" } },
+      { text, lines: [text], cursor },
+      options,
+      "a",
+    );
+    const targets = update.state.pendingEasymotion;
+
+    expect(targets?.kind).toBe("highlight");
+    if (targets?.kind !== "highlight") return;
+    expect(targets.targets).toHaveLength(52);
+    expect(targets.targets.at(-1)).toEqual({ label: "Z", line: 0, character: 51 });
+  });
+
+  test("no match clears pending state without editing", () => {
+    const update = handleModalInput(
+      { mode: "normal", pendingEasymotion: { kind: "char" } },
+      snapshot,
+      options,
+      "z",
+    );
+
+    expect(update.state).toEqual({ mode: "normal" });
+    expect(update.effects).toEqual([{ type: "invalidate" }]);
+  });
+
+  test("escape and invalid labels preserve highlight without editing", () => {
+    const initial = highlight([{ label: "a", line: 0, character: 2 }]);
+    const cancelled = handleModalInput(initial, { ...snapshot, text: "xxa" }, options, "\x1b");
+    const invalid = handleModalInput(initial, { ...snapshot, text: "xxa" }, options, "Z");
+
+    expect(cancelled.state).toEqual({ mode: "normal" });
+    expect(cancelled.effects).toEqual([{ type: "invalidate" }]);
+    expect(invalid.state).toEqual(initial);
+    expect(invalid.effects).toEqual([{ type: "invalidate" }]);
+    expect(
+      [...cancelled.effects, ...invalid.effects].some((effect) => effect.type === "edit"),
+    ).toBe(false);
+  });
+
+  test("valid lowercase and uppercase labels move cursor without editing", () => {
+    const lowercase = handleModalInput(
+      highlight([
+        { label: "a", line: 0, character: 2 },
+        { label: "A", line: 1, character: 4 },
+      ]),
+      { text: "xxa\nyyyyA", lines: ["xxa", "yyyyA"], cursor },
+      options,
+      "a",
+    );
+    const uppercase = handleModalInput(
+      highlight([
+        { label: "a", line: 0, character: 2 },
+        { label: "A", line: 1, character: 4 },
+      ]),
+      { text: "xxa\nyyyyA", lines: ["xxa", "yyyyA"], cursor },
+      options,
+      "A",
+    );
+
+    expect(lowercase.state.pendingEasymotion).toBeUndefined();
+    expect(uppercase.state.pendingEasymotion).toBeUndefined();
+    expect(lowercase.effects).toContainEqual({
+      type: "restoreCursor",
+      position: { line: 0, col: 2 },
+    });
+    expect(uppercase.effects).toContainEqual({
+      type: "restoreCursor",
+      position: { line: 1, col: 4 },
+    });
+    expect(
+      [...lowercase.effects, ...uppercase.effects].some((effect) => effect.type === "edit"),
+    ).toBe(false);
+  });
+
+  test("EasyMotion leaves durable modal state unchanged", () => {
+    const initial: ModalState = {
+      mode: "normal",
+      pendingEasymotion: { kind: "char" },
+      namedRegisters: { a: { type: "char", text: "register" } },
+      marks: { a: p(0, 1) },
+      macros: { q: ["x"] },
+      lastPlayedMacro: "q",
+      lastCharSearch: { command: "findCharForward", target: "," },
+      lastSearch: { query: "needle", direction: "forward" },
+      searchHistory: [{ query: "needle", matcherMode: "literal" }],
+      lastRepeatableChange: { type: "command", command: "deleteChar" },
+      lastVisualSelection: { mode: "visual", anchor: p(0, 0), cursor: p(0, 1), text: "ab" },
+      messageHistory: [{ kind: "info", text: "kept" }],
+    };
+    const update = handleModalInput(initial, { text: "abc", lines: ["abc"], cursor }, options, "a");
+
+    const { pendingEasymotion: _pending, ...durable } = initial;
+    expect(update.state).toMatchObject(durable);
+    expect(update.state.pendingEasymotion?.kind).toBe("highlight");
+    expect(update.effects.some((effect) => effect.type === "edit")).toBe(false);
+  });
+});

--- a/test/modal.test.ts
+++ b/test/modal.test.ts
@@ -1,12 +1,7 @@
 import { describe, expect, test } from "bun:test";
 
-import type {
-  EasymotionTarget,
-  ModalEffect,
-  ModalOptions,
-  ModalState,
-} from "../src/modal/types.ts";
-import type { ResolvedVimEditorOptions } from "../src/types.ts";
+import type { ModalEffect, ModalOptions, ModalState } from "../src/modal/types.ts";
+import type { EasymotionTarget, ResolvedVimEditorOptions } from "../src/types.ts";
 
 import {
   createVimConfigPlan,

--- a/test/render.test.ts
+++ b/test/render.test.ts
@@ -289,6 +289,55 @@ describe("EasyMotion rendering", () => {
     expect(visibleWidth(lines[1]!)).toBe(10);
     expect(lines.join("\n")).toContain("a ");
   });
+
+  test("substitutes labels across multiline prompt with configured color and reset", () => {
+    const labelColor = "\x1b[32m";
+    const lines = renderPromptEditor({
+      snapshot: { text: "one\ntwo", lines: ["one", "two"], cursor: p(0, 0) },
+      cursorStyle: "block",
+      viewport: { width: 10, focused: false },
+      easymotion: { targets: [{ line: 1, character: 1, label: "x" }], labelColor },
+    });
+
+    expect(lines.join("\n")).toContain(`${labelColor}x${ANSI_RESET}`);
+    expect(stripAnsi(lines.join("\n")).replaceAll(labelColor, "")).toContain("txo");
+  });
+
+  test("cursor and visual selection styling take precedence over EasyMotion color", () => {
+    const labelColor = "\x1b[32m";
+    const cursorLines = renderPromptEditor({
+      snapshot: { text: "one", lines: ["one"], cursor: p(0, 1) },
+      cursorStyle: "block",
+      viewport: { width: 10, focused: true },
+      easymotion: { targets: [{ line: 0, character: 1, label: "x" }], labelColor },
+    });
+    const selectedLines = renderVisualEditor({
+      snapshot: { text: "one", lines: ["one"], cursor: p(0, 2) },
+      visual: { mode: "visual", anchor: p(0, 0) },
+      cursorStyle: "block",
+      viewport: { width: 10, focused: false },
+      easymotion: { targets: [{ line: 0, character: 1, label: "x" }], labelColor },
+    });
+
+    expect(cursorLines.join("\n")).toContain(`${CURSOR_BLOCK_START}x${ANSI_RESET}`);
+    expect(cursorLines.join("\n")).not.toContain(`${labelColor}x${ANSI_RESET}`);
+    expect(selectedLines.join("\n")).toContain(`${SELECTION_START}x${ANSI_RESET}`);
+    expect(selectedLines.join("\n")).not.toContain(`${labelColor}x${ANSI_RESET}`);
+  });
+
+  test("EasyMotion label takes precedence over search highlight", () => {
+    const labelColor = "\x1b[32m";
+    const lines = renderPromptEditor({
+      snapshot: { text: "one one", lines: ["one one"], cursor: p(0, 6) },
+      cursorStyle: "block",
+      viewport: { width: 20, focused: false },
+      search: { query: "one", current: p(0, 0), highlightCurrent: true, maxHighlights: 20 },
+      easymotion: { targets: [{ line: 0, character: 0, label: "x" }], labelColor },
+    });
+
+    expect(lines.join("\n")).toContain(`${labelColor}x${ANSI_RESET}`);
+    expect(lines.join("\n")).not.toContain(`${SEARCH_CURRENT_START}x${ANSI_RESET}`);
+  });
 });
 
 describe("cursor rendering", () => {

--- a/test/vim-editor.test.ts
+++ b/test/vim-editor.test.ts
@@ -474,15 +474,49 @@ describe("vim editor integration", () => {
       piVimMode: { startMode: "normal", keymap: { commands: { easymotion: ["e"] } } },
     }).options;
     const { editor } = createEditor(options);
-    editor.setText("one");
+    editor.setText("xone");
     typeKeys(editor, ["e", "o"]);
 
-    expect(editor.getText()).toBe("one");
+    expect(editor.getText()).toBe("xone");
     expect(editor.render(20).join("\n")).toContain("\x1b[31ma\x1b[0m");
     editor.handleInput("a");
 
-    expect(editor.getText()).toBe("one");
-    expect(editor.getCursor()).toEqual({ line: 0, col: 0 });
+    expect(editor.getText()).toBe("xone");
+    expect(editor.getCursor()).toEqual({ line: 0, col: 1 });
+  });
+
+  test("EasyMotion cancel, invalid labels, and misses preserve prompt text", () => {
+    const options = resolveVimOptions({
+      piVimMode: { startMode: "normal", keymap: { commands: { easymotion: ["e"] } } },
+    }).options;
+    const { editor } = createEditor(options);
+    editor.setText("xone\ntwo");
+
+    typeKeys(editor, ["e", "o", "\x1b"]);
+    expect(editor.getText()).toBe("xone\ntwo");
+
+    typeKeys(editor, ["e", "z"]);
+    expect(editor.getText()).toBe("xone\ntwo");
+
+    typeKeys(editor, ["e", "o", "Z"]);
+    expect(editor.getText()).toBe("xone\ntwo");
+    expect(editor.render(20).join("\n")).toContain("\x1b[31ma\x1b[0m");
+  });
+
+  test("EasyMotion preserves undo and redo history", () => {
+    const options = resolveVimOptions({
+      piVimMode: { startMode: "normal", keymap: { commands: { easymotion: ["e"] } } },
+    }).options;
+    const { editor } = createEditor(options);
+    editor.setText("draft");
+    typeKeys(editor, ["g", "g", "i", "x", "\x1b", "u"]);
+    expect(editor.getText()).toBe("draft");
+
+    typeKeys(editor, ["e", "d", "\x1b"]);
+    expect(editor.getText()).toBe("draft");
+    editor.handleInput("\x12");
+
+    expect(editor.getText()).toBe("xdraft");
   });
 
   test("reconfigure preserves undo and redo behavior", () => {

--- a/test/vim-editor.test.ts
+++ b/test/vim-editor.test.ts
@@ -27,6 +27,12 @@ function ctrlVVisualBlockOptions(startMode: "insert" | "normal" = "insert") {
   }).options;
 }
 
+function easyMotionOptions() {
+  return resolveVimOptions({
+    piVimMode: { startMode: "normal", keymap: { commands: { easymotion: ["e"] } } },
+  }).options;
+}
+
 function runtimeConfiguration(
   planOrOptions: VimConfigPlan | ResolvedVimEditorOptions = DEFAULT_VIM_OPTIONS,
   diagnostics: VimDiagnostics = { warnings: [] },
@@ -470,9 +476,7 @@ describe("vim editor integration", () => {
   });
 
   test("EasyMotion labels render without editing prompt text", () => {
-    const options = resolveVimOptions({
-      piVimMode: { startMode: "normal", keymap: { commands: { easymotion: ["e"] } } },
-    }).options;
+    const options = easyMotionOptions();
     const { editor } = createEditor(options);
     editor.setText("xone");
     typeKeys(editor, ["e", "o"]);
@@ -486,9 +490,7 @@ describe("vim editor integration", () => {
   });
 
   test("EasyMotion cancel, invalid labels, and misses preserve prompt text", () => {
-    const options = resolveVimOptions({
-      piVimMode: { startMode: "normal", keymap: { commands: { easymotion: ["e"] } } },
-    }).options;
+    const options = easyMotionOptions();
     const { editor } = createEditor(options);
     editor.setText("xone\ntwo");
 
@@ -503,10 +505,21 @@ describe("vim editor integration", () => {
     expect(editor.render(20).join("\n")).toContain("\x1b[31ma\x1b[0m");
   });
 
+  test("undo after EasyMotion reverses prior real edit", () => {
+    const { editor } = createEditor(easyMotionOptions());
+    editor.setText("draft");
+    typeKeys(editor, ["g", "g", "i", "x", "\x1b"]);
+    expect(editor.getText()).toBe("xdraft");
+
+    typeKeys(editor, ["e", "d", "a"]);
+    expect(editor.getText()).toBe("xdraft");
+    editor.handleInput("u");
+
+    expect(editor.getText()).toBe("draft");
+  });
+
   test("EasyMotion preserves undo and redo history", () => {
-    const options = resolveVimOptions({
-      piVimMode: { startMode: "normal", keymap: { commands: { easymotion: ["e"] } } },
-    }).options;
+    const options = easyMotionOptions();
     const { editor } = createEditor(options);
     editor.setText("draft");
     typeKeys(editor, ["g", "g", "i", "x", "\x1b", "u"]);


### PR DESCRIPTION
## Summary

EasyMotion labels now behave as transient terminal presentation instead of prompt edits. Opening, cancelling, or completing EasyMotion no longer risks changing prompt content or undo/redo history.

## Changes

- Store only label and source-coordinate metadata in modal state.
- Render labels over immutable prompt cells with existing cursor, selection, search, width, and color behavior.
- Preserve Unicode source offsets during case-insensitive matching.
- Add modal, renderer, and live-editor coverage for cancellation, invalid labels, valid selection, label limits, color, Unicode offsets, and undo/redo.
- Document opt-in prompt-wide EasyMotion behavior.

## Testing

- [x] `bun run verify` passes
- [x] Manually tested in Pi

## Related Issues

- None.
