### PR TITLE
feat: add changelog popup

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -2,6 +2,8 @@
 
 ## What's new
 
+- Added manual `:changelog` display of packaged current-version release notes in the existing read-only popup, with semantic Markdown rendering, width-safe prose wrapping, preserved code indentation, rendered-row scrolling, and explicit unavailable fallback.
+
 - Added trusted JavaScript configuration via `~/.pi/agent/pi-vimmode.config.js`. Configure presets, leader, cursor mode, UI, macros, marks, search, Ex command, prompt structures/transforms, action presets, prompt/insert actions, replay mappings, and scoped unmaps with a small `vim` API. Configuration writes are validated and staged atomically; defaults, global JSON, JavaScript, and project JSON compile into one immutable scoped plan before activation. Project JSON remains final authority, and failed config files leave existing settings unchanged.
 
 ```js

--- a/docs/features.md
+++ b/docs/features.md
@@ -614,6 +614,7 @@ Important semantics:
 - `:help [topic]` opens a read-only popup with source-backed runtime help for finite pi-vimmode topics, e.g. `:help search` or `:help ex`.
 - `:features [query]` opens a read-only popup listing/searching supported feature areas, commands, actions, limits, and effective runtime state, e.g. `:features nohlsearch` or `:features redo`.
 - `:messages` opens a read-only popup with a bounded prompt-local summary of retained recent runtime messages without opening a pager.
+- `:changelog` opens packaged current-version release notes as width-safe Markdown in the same read-only popup; it never reads the working directory or network.
 - `:q` and `:quit` request graceful Pi shutdown through the Pi extension runtime without editing prompt text, registers, marks, search state, macros, cursor, or dot-repeat.
 - `:q!`, `:quit!`, `:wq`, `:x`, `:qa`, `:write`, `:edit`, `:shell`, and other file/window/shell Ex commands are intentionally unsupported.
 - `Esc` cancels command-line input. Normal Ex returns to normal mode; visual Ex restores the original visual mode, anchor, cursor, and highlight.
@@ -627,7 +628,7 @@ Important semantics:
 - Unsupported command, range, destination, delimiter, argument, flag, register operand, invalid regex, too-large regex input, or zero-length regex match produces transient Ex error text.
 - Unsupported range syntax includes repeated offsets such as `.+1-2`, repeated range separators, expression ranges, search addresses, mark addresses, `+cmd` suffixes, and broader Vimscript grammar.
 - Successful mutating/editing commands show transient count text such as `2 substitutions`, `1 line deleted`, `3 lines moved`, or `2 lines transformed`.
-- Valid read-only help/diagnostic commands open a bounded popup: `:help`, `:help <topic>`, `:features`, `:features <query>`, `:keybindings`, `:keybindings <query>`, `:actions`, `:actions <query>`, `:keymap`, `:keymap <action>`, `:mapcheck <key>`, `:messages`, `:vimmode inspect`, and `:vimdoctor`.
+- Valid read-only help/diagnostic commands open a bounded popup: `:help`, `:help <topic>`, `:features`, `:features <query>`, `:keybindings`, `:keybindings <query>`, `:actions`, `:actions <query>`, `:keymap`, `:keymap <action>`, `:mapcheck <key>`, `:messages`, `:changelog`, `:vimmode inspect`, and `:vimdoctor`.
 - Popup-backed commands do not edit prompt text, registers, marks, search state, visual state, macros, or dot-repeat.
 - Mutating command success/error feedback, parser errors, invalid command feedback, substitution preview/apply messages, `:noh`, prompt transforms, and optional no-op feedback stay in the compact Ex/workbench row.
 - Compact success/error/info messages stay in the Ex row until the next handled input.
@@ -670,7 +671,7 @@ Action keybinding presets are opt-in bundles selected with `piVimMode.keymap.act
 
 ### Read-only Ex popup and keybinding discovery
 
-Valid read-only Ex help and diagnostic commands open a dedicated bounded read-only overlay popup, similar to Pi picker-style overlay UIs. Popup-backed commands include `:help`, `:help <topic>`, `:features`, `:features <query>`, `:features keybindings`, `:keybindings`, `:keybindings <query>`, `:actions`, `:actions <query>`, `:keymap`, `:keymap <action>`, `:mapcheck <key>`, `:messages`, `:vimmode inspect`, and `:vimdoctor`.
+Valid read-only Ex help and diagnostic commands open a dedicated bounded read-only overlay popup, similar to Pi picker-style overlay UIs. Popup-backed commands include `:help`, `:help <topic>`, `:features`, `:features <query>`, `:features keybindings`, `:keybindings`, `:keybindings <query>`, `:actions`, `:actions <query>`, `:keymap`, `:keymap <action>`, `:mapcheck <key>`, `:messages`, `:changelog`, `:vimmode inspect`, and `:vimdoctor`.
 
 `:keybindings` is the direct keybinding discovery entry point. It lists effective pi-vimmode bindings from resolved settings by finite category: commands, motions, operators, text objects, macros, marks, searches, prompt transform actions, and protected Pi shortcuts. Each binding row shows key, supported mode scope, action ID, and description in a fixed grid. `:keybindings <query>` shows focused detail for action IDs (`redo`, `wordForward`, `prompt.transform.reflow`), descriptions, current keys, protected shortcuts such as `ctrl+p`, rejected metadata/action binding warnings, and bounded no-match output. Ex commands and diagnostic/help metadata IDs are excluded from the catalog because they are not keybindings. It is read-only discovery: it does not edit settings, create mappings, run a command palette, or dispatch metadata actions.
 

--- a/openspec/changes/ship-pi-vimmode-0-9-0/tasks.md
+++ b/openspec/changes/ship-pi-vimmode-0-9-0/tasks.md
@@ -24,7 +24,7 @@
 ## 5. Packaged Current-Version Changelog
 
 - [x] 5.1 Implement [#44](https://github.com/pekochan069/pi-vimmode/issues/44): validate first `RELEASE.md` release against package version, package current-release runtime asset, and prove defensive package-relative loading outside repository cwd. **Blocked by:** #34.
-- [ ] 5.2 Implement [#45](https://github.com/pekochan069/pi-vimmode/issues/45): add exact manual `:changelog` command and width-safe Markdown rendering through existing read-only popup while preserving all prompt-editing state. **Blocked by:** #44.
+- [x] 5.2 Implement [#45](https://github.com/pekochan069/pi-vimmode/issues/45): add exact manual `:changelog` command and width-safe Markdown rendering through existing read-only popup while preserving all prompt-editing state. **Blocked by:** #44.
 
 ## 6. Change Validation
 

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "README.md",
     "LICENSE",
     "RELEASE.md",
+    "release-notes.json",
     "docs/config.md",
     "docs/features.md",
     "docs/settings.md"

--- a/src/ex.ts
+++ b/src/ex.ts
@@ -87,6 +87,11 @@ export type ParsedExInspectCommand = {
   query: "inspect";
 };
 
+export type ParsedExChangelogCommand = {
+  type: "changelog";
+  command: "changelog";
+};
+
 export type ParsedExQuitCommand = {
   type: "quit";
   command: "q" | "quit";
@@ -104,6 +109,7 @@ export type ExParseResult =
   | ParsedExRuntimeHelpCommand
   | ParsedExKeybindingsCommand
   | ParsedExInspectCommand
+  | ParsedExChangelogCommand
   | { type: "nohlsearch"; command: "noh" | "nohlsearch" }
   | ParsedExQuitCommand
   | { type: "lineJump"; range: LineRange; line: number }
@@ -141,6 +147,7 @@ type ParsedCommandName =
   | "messages"
   | "keybindings"
   | "vimmode"
+  | "changelog"
   | "noh"
   | "nohlsearch"
   | "q"
@@ -159,6 +166,7 @@ type ParsedCommandType =
   | "runtimeHelp"
   | "keybindings"
   | "inspect"
+  | "changelog"
   | "nohlsearch"
   | "quit";
 
@@ -235,6 +243,8 @@ function commandType(command: ParsedCommandName): ParsedCommandType {
       return "keybindings";
     case "vimmode":
       return "inspect";
+    case "changelog":
+      return "changelog";
     case "noh":
     case "nohlsearch":
       return "nohlsearch";
@@ -285,6 +295,7 @@ function parseCommand(
     "messages",
     "keybindings",
     "vimmode",
+    "changelog",
     "noh",
     "nohlsearch",
     "q",
@@ -533,6 +544,11 @@ export function parseExCommand(commandLine: string, context: ExParseContext): Ex
     return { type, command: "vimmode", query: "inspect" };
   }
 
+  if (type === "changelog") {
+    const trailing = rejectTrailingArgs(command.rest);
+    return trailing ?? { type, command: "changelog" };
+  }
+
   if (type === "transform") {
     const transformAction = command.command.transformAction;
     if (!transformAction) return { type: "error", message: "Unsupported Ex command" };
@@ -616,6 +632,7 @@ const CANDIDATE_NAMES_BY_COMMAND_TYPE: Record<string, string[]> = {
   runtimeHelp: ["help", "features", "messages"],
   keybindings: ["keybindings"],
   inspect: ["vimmode"],
+  changelog: ["changelog"],
   transform: [] as string[],
 };
 

--- a/src/keybinding-discovery-overlay.ts
+++ b/src/keybinding-discovery-overlay.ts
@@ -8,6 +8,7 @@ import {
 
 import type { ReadOnlyPopup } from "./read-only-popup.ts";
 
+import { renderMarkdownRows } from "./markdown-popup.ts";
 import { HELP_POPUP_BODY_ROWS, scrollHelpPopup } from "./read-only-popup.ts";
 
 export const READ_ONLY_POPUP_MIN_WIDTH = 48;
@@ -91,6 +92,16 @@ export class ReadOnlyPopupOverlayComponent implements Component {
   render(width: number): string[] {
     const safeWidth = Math.max(36, width);
     const style = styleForTheme(this.theme);
+    if (this.popup.markdown !== undefined) {
+      this.popup = {
+        ...this.popup,
+        lines: renderMarkdownRows(
+          this.popup.markdown,
+          Math.max(1, safeWidth - BORDER_OVERHEAD),
+          style,
+        ),
+      };
+    }
     const bodyRows = Math.min(HELP_POPUP_BODY_ROWS, this.popup.lines.length);
     const maxOffset = Math.max(0, this.popup.lines.length - bodyRows);
     const offset = Math.max(0, Math.min(maxOffset, this.popup.scrollOffset));

--- a/src/keybinding-discovery-popup.ts
+++ b/src/keybinding-discovery-popup.ts
@@ -1,5 +1,6 @@
 import type { ExMessage, EditorSnapshot, ModalState } from "./modal/types.ts";
 import type { ReadOnlyPopup } from "./read-only-popup.ts";
+import type { CurrentRelease } from "./release-notes.ts";
 import type { ResolvedVimEditorOptions, VimDiagnostics } from "./types.ts";
 
 import { ACTION_KEYBINDING_RECIPES } from "./action-keybinding-recipes.ts";
@@ -19,6 +20,7 @@ import {
 } from "./customization.ts";
 import { runtimeMessagesMessage, vimmodeInspectMessage } from "./modal/inspect.ts";
 import { popupFromMessage } from "./read-only-popup.ts";
+import { loadCurrentRelease } from "./release-notes.ts";
 import { runtimeFeaturesMessage, runtimeHelpMessage } from "./runtime-help.ts";
 
 export {
@@ -151,6 +153,16 @@ export function inspectPopup(input: InspectPopupInput): ReadOnlyPopup {
     source: "inspect",
     message: vimmodeInspectMessage(input),
   });
+}
+
+export function changelogPopup(release: CurrentRelease = loadCurrentRelease()): ReadOnlyPopup {
+  return {
+    title: `pi-vimmode v${release.version} changes`,
+    source: "changelog",
+    scrollOffset: 0,
+    lines: [],
+    markdown: release.content,
+  };
 }
 
 function compactRecipeLines(): string[] {

--- a/src/markdown-popup.ts
+++ b/src/markdown-popup.ts
@@ -1,0 +1,79 @@
+import { truncateToWidth, visibleWidth, wrapTextWithAnsi } from "@earendil-works/pi-tui";
+
+type MarkdownStyle = {
+  accent: (text: string) => string;
+  bold: (text: string) => string;
+  dim: (text: string) => string;
+};
+
+function inlineMarkdown(source: string, style: MarkdownStyle): string {
+  return source
+    .replace(/\[([^\]]+)\]\(([^)]+)\)/g, (_match, label: string, url: string) =>
+      style.accent(`${label} (${url})`),
+    )
+    .replace(/\*\*([^*]+)\*\*/g, (_match, text: string) => style.bold(text))
+    .replace(/__([^_]+)__/g, (_match, text: string) => style.bold(text))
+    .replace(/\*([^*]+)\*/g, (_match, text: string) => style.dim(text))
+    .replace(/_([^_]+)_/g, (_match, text: string) => style.dim(text))
+    .replace(/`([^`]+)`/g, (_match, text: string) => style.accent(text));
+}
+
+function wrapped(source: string, width: number): string[] {
+  return wrapTextWithAnsi(source, width);
+}
+
+export function renderMarkdownRows(
+  markdown: string,
+  width: number,
+  style: MarkdownStyle,
+): string[] {
+  const safeWidth = Math.max(1, width);
+  const rows: string[] = [];
+  let fence: string | undefined;
+
+  for (const line of markdown.replace(/\r\n?/g, "\n").split("\n")) {
+    if (fence) {
+      if (new RegExp(`^\\s*${fence[0]}{${fence.length},}\\s*$`).test(line)) {
+        fence = undefined;
+      } else {
+        rows.push(style.dim(truncateToWidth(line, safeWidth, "")));
+      }
+      continue;
+    }
+
+    const marker = line.match(/^\s*(`{3,}|~{3,})/)?.[1];
+    if (marker) {
+      fence = marker;
+      continue;
+    }
+    if (!line.trim()) {
+      rows.push("");
+      continue;
+    }
+
+    const heading = /^(#{1,6})\s+(.+)$/.exec(line);
+    if (heading) {
+      rows.push(...wrapped(style.bold(heading[2]!), safeWidth));
+      continue;
+    }
+
+    const bullet = /^(\s*)([-*+]\s+|\d+[.)]\s+)(.+)$/.exec(line);
+    if (bullet) {
+      const marker = bullet[2]!.trim();
+      const rawPrefix = `${bullet[1] ?? ""}${/^\d/.test(marker) ? marker : "•"} `;
+      const prefix = truncateToWidth(rawPrefix, safeWidth, "");
+      const continuation = " ".repeat(visibleWidth(prefix));
+      const contentWidth = Math.max(1, safeWidth - visibleWidth(prefix));
+      rows.push(
+        ...wrapped(inlineMarkdown(bullet[3]!, style), contentWidth).map(
+          (row, index) => (index === 0 ? prefix : continuation) + row,
+        ),
+      );
+      continue;
+    }
+
+    rows.push(...wrapped(inlineMarkdown(line, style), safeWidth));
+  }
+
+  return rows.length ? rows : ["(no output)"];
+}

--- a/src/modal/ex-command-line.ts
+++ b/src/modal/ex-command-line.ts
@@ -31,6 +31,7 @@ import {
 import { keymapForOptions, promptTransformsForOptions } from "../config.ts";
 import { parseExCommand, suggestExCommands, type ParsedExSubstitution } from "../ex.ts";
 import {
+  changelogPopup,
   diagnosticPopup,
   inspectPopup,
   keybindingsPopup,
@@ -176,9 +177,16 @@ function cancelExCommand(state: ModalState): ModalUpdate {
 }
 
 function openReadOnlyPopup(state: ModalState, popup: ReadOnlyPopup): ModalUpdate {
+  const command = state.pendingEx?.command;
   const restored = restoreVisualExState(state);
   return {
-    state: { ...restored.state, helpPopup: popup },
+    state: {
+      ...restored.state,
+      helpPopup: popup,
+      exHistory: command
+        ? addExHistory(restored.state.exHistory, command)
+        : restored.state.exHistory,
+    },
     effects: [...restored.effects, { type: "openReadOnlyPopup", popup }],
   };
 }
@@ -333,6 +341,10 @@ function executeExCommand(
 
   if (parsed.type === "inspect") {
     return openReadOnlyPopup(state, inspectPopup({ state, snapshot, options, diagnostics }));
+  }
+
+  if (parsed.type === "changelog") {
+    return openReadOnlyPopup(state, changelogPopup());
   }
 
   if (parsed.type === "transform") {

--- a/src/read-only-popup.ts
+++ b/src/read-only-popup.ts
@@ -9,7 +9,8 @@ export type ReadOnlyPopupSource =
   | "mapcheck"
   | "vimdoctor"
   | "messages"
-  | "inspect";
+  | "inspect"
+  | "changelog";
 
 export type ReadOnlyPopup = {
   title: string;
@@ -17,6 +18,7 @@ export type ReadOnlyPopup = {
   source: ReadOnlyPopupSource;
   query?: string;
   scrollOffset: number;
+  markdown?: string;
 };
 
 export type HelpPopup = ReadOnlyPopup;

--- a/src/release-notes.ts
+++ b/src/release-notes.ts
@@ -138,9 +138,12 @@ function packageVersion(packageDirectory: string): string | undefined {
   }
 }
 
-export function loadCurrentRelease(
-  packageDirectory = dirname(fileURLToPath(import.meta.url)),
-): CurrentRelease {
+function defaultPackageDirectory(): string {
+  const moduleDirectory = dirname(fileURLToPath(import.meta.url));
+  return packageVersion(moduleDirectory) ? moduleDirectory : dirname(moduleDirectory);
+}
+
+export function loadCurrentRelease(packageDirectory = defaultPackageDirectory()): CurrentRelease {
   const version = packageVersion(packageDirectory);
   if (!version) return unavailable();
 

--- a/src/runtime-help.ts
+++ b/src/runtime-help.ts
@@ -83,8 +83,18 @@ const ENTRIES = [
     category: "ex",
     topics: ["ex", ":", "substitute", "s", "commands", "repeat", "register", "line", "quit", "q"],
     summary:
-      "finite Ex command-line supports :s substitution, :& repeat substitution, bare line jumps, line commands with register operands, transforms, diagnostics, runtime help, and :q/:quit Pi shutdown",
-    examples: [":3", ":$", ":s/old/new/", ":%s/old/new/gn", ":&", ":delete a", ":q", ":help ex"],
+      "finite Ex command-line supports :s substitution, :& repeat substitution, bare line jumps, line commands with register operands, transforms, diagnostics, runtime help, packaged :changelog, and :q/:quit Pi shutdown",
+    examples: [
+      ":3",
+      ":$",
+      ":s/old/new/",
+      ":%s/old/new/gn",
+      ":&",
+      ":delete a",
+      ":changelog",
+      ":q",
+      ":help ex",
+    ],
     limits: [
       "no Vimscript",
       "no confirmation flag",

--- a/test/ex.test.ts
+++ b/test/ex.test.ts
@@ -325,6 +325,18 @@ describe("Ex command parser", () => {
     });
   });
 
+  test("parses exact changelog popup command", () => {
+    expect(parseExCommand("changelog", context)).toEqual({
+      type: "changelog",
+      command: "changelog",
+    });
+    expect(parseExCommand("changelog old", context)).toEqual({
+      type: "error",
+      message: "Unexpected Ex command arguments",
+    });
+    expect(suggestExCommands("change", context)).toEqual(["changelog"]);
+  });
+
   test("parses dedicated keybindings popup command", () => {
     expect(parseExCommand("keybindings", context)).toEqual({
       type: "keybindings",

--- a/test/markdown-popup.test.ts
+++ b/test/markdown-popup.test.ts
@@ -1,0 +1,13 @@
+import { expect, test } from "bun:test";
+
+import { renderMarkdownRows } from "../src/markdown-popup.ts";
+
+const style = {
+  accent: (text: string) => text,
+  bold: (text: string) => text,
+  dim: (text: string) => text,
+};
+
+test("keeps every wrapped bullet continuation indented", () => {
+  expect(renderMarkdownRows("- word word word", 10, style)).toEqual(["• word", "  word", "  word"]);
+});

--- a/test/modal.test.ts
+++ b/test/modal.test.ts
@@ -1139,6 +1139,32 @@ describe("Ex command-line modal behavior", () => {
     expect(result.state.helpPopup?.lines.join("\n")).toContain("vimmode.doctor");
   });
 
+  test("changelog Ex command preserves prompt state and records successful history", () => {
+    const initial: ModalState = {
+      mode: "normal",
+      register: { type: "char", text: "saved" },
+      marks: { a: p(0, 1) },
+      macros: { a: ["x"] },
+      lastSearch: { query: "abc", direction: "forward" },
+      lastRepeatableChange: { type: "command", command: "deleteChar" },
+    };
+    const result = applyModalKeys(initial, "abc", p(0, 1), [":", ..."changelog", "\r"]);
+
+    expect(result.text).toBe("abc");
+    expect(result.cursor).toEqual(p(0, 1));
+    expect(result.state.register).toEqual(initial.register);
+    expect(result.state.marks).toEqual(initial.marks);
+    expect(result.state.macros).toEqual(initial.macros);
+    expect(result.state.lastSearch).toEqual(initial.lastSearch);
+    expect(result.state.lastRepeatableChange).toEqual(initial.lastRepeatableChange);
+    expect(result.state.exHistory).toEqual(["changelog"]);
+    expect(result.state.helpPopup).toMatchObject({
+      title: "pi-vimmode v0.9.0 changes",
+      source: "changelog",
+    });
+    expect(result.state.helpPopup?.markdown).toContain("Changelog unavailable for v0.9.0");
+  });
+
   test("visual features keybindings popup restores visual state after marker deletion", () => {
     const opened = handleModalInput(
       { mode: "visual", visualAnchor: p(0, 1) },

--- a/test/read-only-popup-overlay.test.ts
+++ b/test/read-only-popup-overlay.test.ts
@@ -71,6 +71,46 @@ describe("read-only popup overlay", () => {
     expect(renders.length).toBeGreaterThanOrEqual(4);
   });
 
+  test("renders Markdown semantically, wraps prose, and preserves code indentation", () => {
+    const input = popup([]);
+    input.source = "changelog";
+    input.markdown = [
+      "## Added",
+      "",
+      "- Long **bold** prose with [`link`](https://example.com) that wraps across rows.",
+      "",
+      "```js",
+      "  const value = 1;",
+      "```",
+    ].join("\n");
+    const { component } = createComponent(input);
+    const rows = component.render(48);
+    const text = rows.join("\n");
+
+    expect(text).toContain("Added");
+    expect(text).toContain("• Long bold prose");
+    expect(text).toContain("link");
+    expect(text).toContain("(https://example.com)");
+    expect(text).toContain("  const value = 1;");
+    expect(text).not.toContain("```js");
+    expect(text).toContain("1-7/7");
+    for (const row of rows) expect(visibleWidth(row)).toBeLessThanOrEqual(48);
+  });
+
+  test("counts wrapped Markdown rows for scrolling", () => {
+    const input = popup([]);
+    input.source = "changelog";
+    input.markdown = Array.from(
+      { length: 6 },
+      () => "Long prose that wraps onto another rendered row.",
+    ).join("\n");
+    const { component } = createComponent(input);
+
+    expect(component.render(40).join("\n")).toContain("1-10/12 ↓2");
+    component.handleInput("j");
+    expect(component.render(40).join("\n")).toContain("2-11/12 ↑1 ↓1");
+  });
+
   test("close controls are local to overlay", () => {
     for (const key of ["\x1b", "\x03", "\x07"]) {
       const { component, closed } = createComponent(popup(["output"]));

--- a/test/release-notes.test.ts
+++ b/test/release-notes.test.ts
@@ -3,6 +3,7 @@ import { mkdtemp, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
+import { changelogPopup } from "../src/keybinding-discovery-popup.ts";
 import { loadCurrentRelease, parseCurrentRelease } from "../src/release-notes.ts";
 
 const repositoryReleaseUrl = "https://github.com/pekochan069/pi-vimmode/releases/tag/v0.9.0";
@@ -42,6 +43,22 @@ describe("current release parsing", () => {
       parseCurrentRelease("# v0.9.0\n\n## Added\n\n```text\n```not-a-close\n```", "0.9.0"),
     ).toBe("## Added\n\n```text\n```not-a-close\n```");
   });
+});
+
+test("builds titled changelog popup without outer release heading", () => {
+  const popup = changelogPopup({
+    available: true,
+    version: "0.9.0",
+    content: "## Added\n\nText",
+    releaseUrl: repositoryReleaseUrl,
+  });
+
+  expect(popup).toMatchObject({
+    title: "pi-vimmode v0.9.0 changes",
+    source: "changelog",
+    markdown: "## Added\n\nText",
+  });
+  expect(popup.markdown).not.toContain("# v0.9.0");
 });
 
 describe("packaged current release", () => {


### PR DESCRIPTION
## Summary

Add manual `:changelog` Ex command showing packaged current-version release notes in existing read-only popup.

## Changes

- Add package-relative release asset loading and unavailable fallback.
- Render Markdown with wrapping, indentation, scrolling, and width safety.
- Preserve prompt/editor state and add tests/docs.

## Testing

- [x] `bun run verify` passes
- [x] Manually tested in Pi

## Related Issues

Closes #45