### PR TITLE
perf: capture reproducible 0.9.0 baseline

### DIFF
--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -1,0 +1,26 @@
+# 0.9.0 performance baseline
+
+Run from repository root:
+
+```sh
+bun run benchmark:baseline
+```
+
+This writes `benchmark/results/0.9.0-pre-change.json`. Harness uses production `VimEditor` entry points at an 80×40 viewport:
+
+- normal-mode renders exercise pi-vimmode renderer;
+- exact-mark jumps exercise modal engine and cursor restoration through Pi's installed editor base class;
+- insert-mode input exercises `VimEditor` fast delegation into Pi's installed editor behavior.
+
+Corpora include 100k and 1m UTF-16 code-unit ASCII single-line, equal-size ASCII multi-line, and mixed-width Unicode prompts. Cursor-restoration cases use 100, 1k, and 10k code units. Corpus/editor setup and correctness assertions stay outside timed regions. Default run records 20 samples after one warmup. Revision metadata also reports whether production source differed from that commit.
+
+## CPU profiles
+
+Use separate profiles with 100 µs sampling:
+
+```sh
+bun --cpu-prof --cpu-prof-interval=100 --cpu-prof-name=cursor-restoration.cpuprofile benchmark/perf-baseline.ts --only cursor-restoration/ascii-single/10000 --runs 1 --warmup 0 --output /tmp/pi-vimmode-cursor-profile.json
+bun --cpu-prof --cpu-prof-interval=100 --cpu-prof-name=long-line-render.cpuprofile benchmark/perf-baseline.ts --only vim-render/ascii-single/1000000 --runs 1 --warmup 0 --output /tmp/pi-vimmode-render-profile.json
+```
+
+Profiles and benchmark assets remain repository-only. `package.json` uses an explicit publish allowlist, and package verification rejects benchmark/profile/result paths.

--- a/benchmark/perf-baseline.ts
+++ b/benchmark/perf-baseline.ts
@@ -1,0 +1,220 @@
+import { visibleWidth } from "@earendil-works/pi-tui";
+import { mkdir, writeFile } from "node:fs/promises";
+import { cpus, platform, release } from "node:os";
+import { dirname, resolve } from "node:path";
+
+import { createVimConfigPlan, DEFAULT_VIM_OPTIONS } from "../src/config.ts";
+import { VimEditor } from "../src/vim-editor.ts";
+
+const VIEWPORT = { columns: 80, rows: 40 } as const;
+const DEFAULT_OUTPUT = "benchmark/results/0.9.0-pre-change.json";
+
+type BenchmarkCase = {
+  name: string;
+  corpus: string;
+  codeUnits: number;
+  setup: () => void;
+  operation: () => unknown;
+  assert: (result: unknown) => void;
+};
+
+type Options = { runs: number; warmup: number; only?: string; output: string };
+
+function assert(condition: unknown, message: string): asserts condition {
+  if (!condition) throw new Error(message);
+}
+
+function createDependencies() {
+  const tui = {
+    terminal: { rows: VIEWPORT.rows, columns: VIEWPORT.columns, write() {} },
+    requestRender() {},
+    getShowHardwareCursor: () => false,
+    setShowHardwareCursor() {},
+  } as any;
+  const theme = {
+    borderColor: (text: string) => text,
+    selectList: {
+      selectedText: (text: string) => text,
+      description: (text: string) => text,
+      noMatch: (text: string) => text,
+      scrollInfo: (text: string) => text,
+    },
+  } as any;
+  const keybindings = {
+    matches: () => false,
+    getKeys: () => [],
+    getDefinition: () => ({ defaultKeys: [] }),
+    getConflicts: () => [],
+  } as any;
+  return { tui, theme, keybindings };
+}
+
+function createVimEditor(startMode: "insert" | "normal"): VimEditor {
+  const { tui, theme, keybindings } = createDependencies();
+  const options = { ...DEFAULT_VIM_OPTIONS, startMode };
+  const plan = createVimConfigPlan(options, []);
+  return new VimEditor(tui, theme, keybindings, { plan, diagnostics: plan.diagnostics });
+}
+
+function corpus(kind: "ascii-single" | "ascii-multiline" | "mixed-width", size: number) {
+  if (kind === "ascii-single") return "a".repeat(size);
+  if (kind === "mixed-width") return "a界🙂".repeat(Math.ceil(size / 4)).slice(0, size);
+  const line = `${"m".repeat(78)}\n`;
+  return line.repeat(Math.ceil(size / line.length)).slice(0, size);
+}
+
+function assertRender(result: unknown, expectedTail: string): void {
+  assert(Array.isArray(result) && result.length >= 3, "render returned too few rows");
+  assert(
+    result.every((row) => typeof row === "string" && visibleWidth(row) <= VIEWPORT.columns),
+    "render exceeded viewport width",
+  );
+  assert(result.join("\n").includes(expectedTail), "render omitted corpus tail");
+}
+
+function renderCases(): BenchmarkCase[] {
+  const cases: BenchmarkCase[] = [];
+  for (const kind of ["ascii-single", "ascii-multiline", "mixed-width"] as const) {
+    for (const size of [100_000, 1_000_000]) {
+      const text = corpus(kind, size);
+      const editor = createVimEditor("normal");
+      editor.setText(text);
+      cases.push({
+        name: `vim-render/${kind}/${size}`,
+        corpus: kind,
+        codeUnits: text.length,
+        setup() {},
+        operation: () => editor.render(VIEWPORT.columns),
+        assert: (result) => assertRender(result, text.slice(-8)),
+      });
+    }
+  }
+  return cases;
+}
+
+function cursorCases(): BenchmarkCase[] {
+  return [100, 1_000, 10_000].map((size) => {
+    const text = corpus("ascii-single", size);
+    const editor = createVimEditor("normal");
+    return {
+      name: `cursor-restoration/ascii-single/${size}`,
+      corpus: "ascii-single",
+      codeUnits: text.length,
+      setup() {
+        editor.setText(text);
+        editor.handleInput("m");
+        editor.handleInput("a");
+        editor.handleInput("0");
+        assert(editor.getCursor().col === 0, "cursor setup missed line start");
+      },
+      operation() {
+        editor.handleInput("`");
+        editor.handleInput("a");
+      },
+      assert() {
+        assert(editor.getCursor().col === text.length, "cursor restoration missed line end");
+      },
+    };
+  });
+}
+
+function piEditorCases(): BenchmarkCase[] {
+  return [100_000, 1_000_000].map((size) => {
+    const text = corpus("ascii-single", size);
+    const editor = createVimEditor("insert");
+    return {
+      name: `pi-editor-insert/ascii-single/${size}`,
+      corpus: "ascii-single",
+      codeUnits: text.length,
+      setup: () => editor.setText(text),
+      operation: () => editor.handleInput("x"),
+      assert() {
+        assert(editor.getText() === `${text}x`, "Pi editor inserted wrong text");
+        assert(editor.getCursor().col === text.length + 1, "Pi editor cursor missed insert end");
+      },
+    };
+  });
+}
+
+function parseOptions(args: string[]): Options {
+  const value = (flag: string) => {
+    const index = args.indexOf(flag);
+    return index === -1 ? undefined : args[index + 1];
+  };
+  const runs = Number(value("--runs") ?? 20);
+  const warmup = Number(value("--warmup") ?? 1);
+  assert(Number.isInteger(runs) && runs > 0, "--runs must be a positive integer");
+  assert(Number.isInteger(warmup) && warmup >= 0, "--warmup must be a non-negative integer");
+  return { runs, warmup, only: value("--only"), output: value("--output") ?? DEFAULT_OUTPUT };
+}
+
+function percentile(sorted: number[], fraction: number): number {
+  return sorted[Math.max(0, Math.ceil(sorted.length * fraction) - 1)]!;
+}
+
+function measure(item: BenchmarkCase, options: Options) {
+  for (let i = 0; i < options.warmup; i++) {
+    item.setup();
+    item.assert(item.operation());
+  }
+  const samples: number[] = [];
+  for (let i = 0; i < options.runs; i++) {
+    item.setup();
+    const start = performance.now();
+    const result = item.operation();
+    samples.push(performance.now() - start);
+    item.assert(result);
+  }
+  samples.sort((a, b) => a - b);
+  return {
+    name: item.name,
+    corpus: item.corpus,
+    codeUnits: item.codeUnits,
+    runs: options.runs,
+    milliseconds: {
+      min: samples[0],
+      p50: percentile(samples, 0.5),
+      p95: percentile(samples, 0.95),
+      max: samples.at(-1),
+    },
+  };
+}
+
+async function git(args: string[]): Promise<{ code: number; stdout: string }> {
+  const child = Bun.spawn(["git", ...args], { stdout: "pipe", stderr: "ignore" });
+  const [code, stdout] = await Promise.all([child.exited, new Response(child.stdout).text()]);
+  return { code, stdout: stdout.trim() };
+}
+
+async function revision(): Promise<{ commit: string; sourceDirty: boolean }> {
+  const head = await git(["rev-parse", "HEAD"]);
+  assert(head.code === 0, "git rev-parse HEAD failed");
+  const source = await git(["diff", "--quiet", "HEAD", "--", "src", "index.ts"]);
+  assert(source.code === 0 || source.code === 1, "git diff failed");
+  return { commit: head.stdout, sourceDirty: source.code === 1 };
+}
+
+async function main(): Promise<void> {
+  const options = parseOptions(Bun.argv.slice(2));
+  const allCases = [...renderCases(), ...cursorCases(), ...piEditorCases()];
+  const selected = options.only ? allCases.filter((item) => item.name === options.only) : allCases;
+  assert(selected.length > 0, `no benchmark matched --only ${options.only}`);
+  const results = selected.map((item) => measure(item, options));
+  const sourceRevision = await revision();
+  const output = {
+    schemaVersion: 1,
+    generatedAt: new Date().toISOString(),
+    revision: sourceRevision.commit,
+    sourceDirty: sourceRevision.sourceDirty,
+    runtime: { bun: Bun.version },
+    system: { platform: platform(), release: release(), arch: process.arch, cpu: cpus()[0]?.model },
+    viewport: VIEWPORT,
+    results,
+  };
+  const path = resolve(options.output);
+  await mkdir(dirname(path), { recursive: true });
+  await writeFile(path, `${JSON.stringify(output, null, 2)}\n`);
+  console.log(`Wrote ${results.length} results to ${options.output}`);
+}
+
+await main();

--- a/benchmark/results/0.9.0-pre-change.json
+++ b/benchmark/results/0.9.0-pre-change.json
@@ -1,0 +1,153 @@
+{
+  "schemaVersion": 1,
+  "generatedAt": "2026-07-22T15:37:02.856Z",
+  "revision": "592328efa50771c729d39e78ab9673b21103b6b8",
+  "sourceDirty": false,
+  "runtime": {
+    "bun": "1.3.14"
+  },
+  "system": {
+    "platform": "linux",
+    "release": "6.6.87.2-microsoft-standard-WSL2",
+    "arch": "x64",
+    "cpu": "13th Gen Intel(R) Core(TM) i7-13700F"
+  },
+  "viewport": {
+    "columns": 80,
+    "rows": 40
+  },
+  "results": [
+    {
+      "name": "vim-render/ascii-single/100000",
+      "corpus": "ascii-single",
+      "codeUnits": 100000,
+      "runs": 20,
+      "milliseconds": {
+        "min": 1.5553910000000428,
+        "p50": 2.5137640000000374,
+        "p95": 4.588728000000003,
+        "max": 4.808930000000032
+      }
+    },
+    {
+      "name": "vim-render/ascii-single/1000000",
+      "corpus": "ascii-single",
+      "codeUnits": 1000000,
+      "runs": 20,
+      "milliseconds": {
+        "min": 13.12462400000004,
+        "p50": 18.566880999999967,
+        "p95": 29.736221,
+        "max": 33.57392600000003
+      }
+    },
+    {
+      "name": "vim-render/ascii-multiline/100000",
+      "corpus": "ascii-multiline",
+      "codeUnits": 100000,
+      "runs": 20,
+      "milliseconds": {
+        "min": 0.4344789999998966,
+        "p50": 0.5409949999999526,
+        "p95": 2.0020210000000134,
+        "max": 8.025609000000031
+      }
+    },
+    {
+      "name": "vim-render/ascii-multiline/1000000",
+      "corpus": "ascii-multiline",
+      "codeUnits": 1000000,
+      "runs": 20,
+      "milliseconds": {
+        "min": 1.3475120000000516,
+        "p50": 2.4569099999999935,
+        "p95": 2.9546739999999545,
+        "max": 3.8009510000000546
+      }
+    },
+    {
+      "name": "vim-render/mixed-width/100000",
+      "corpus": "mixed-width",
+      "codeUnits": 100000,
+      "runs": 20,
+      "milliseconds": {
+        "min": 3.5991270000001805,
+        "p50": 4.7162150000001475,
+        "p95": 7.287511999999879,
+        "max": 12.640329999999949
+      }
+    },
+    {
+      "name": "vim-render/mixed-width/1000000",
+      "corpus": "mixed-width",
+      "codeUnits": 1000000,
+      "runs": 20,
+      "milliseconds": {
+        "min": 29.859954000000016,
+        "p50": 36.094286999999895,
+        "p95": 60.18051400000013,
+        "max": 64.19596200000024
+      }
+    },
+    {
+      "name": "cursor-restoration/ascii-single/100",
+      "corpus": "ascii-single",
+      "codeUnits": 100,
+      "runs": 20,
+      "milliseconds": {
+        "min": 1.798276999999871,
+        "p50": 2.2577930000002198,
+        "p95": 2.767293999999765,
+        "max": 2.9077139999999417
+      }
+    },
+    {
+      "name": "cursor-restoration/ascii-single/1000",
+      "corpus": "ascii-single",
+      "codeUnits": 1000,
+      "runs": 20,
+      "milliseconds": {
+        "min": 74.09304699999984,
+        "p50": 76.14605600000004,
+        "p95": 79.72471099999984,
+        "max": 80.53271099999984
+      }
+    },
+    {
+      "name": "cursor-restoration/ascii-single/10000",
+      "corpus": "ascii-single",
+      "codeUnits": 10000,
+      "runs": 20,
+      "milliseconds": {
+        "min": 7094.220520000001,
+        "p50": 7233.153118000002,
+        "p95": 7295.670736999993,
+        "max": 7308.260172000009
+      }
+    },
+    {
+      "name": "pi-editor-insert/ascii-single/100000",
+      "corpus": "ascii-single",
+      "codeUnits": 100000,
+      "runs": 20,
+      "milliseconds": {
+        "min": 0.03330199999618344,
+        "p50": 0.07398499999544583,
+        "p95": 0.11035400000400841,
+        "max": 0.1122099999920465
+      }
+    },
+    {
+      "name": "pi-editor-insert/ascii-single/1000000",
+      "corpus": "ascii-single",
+      "codeUnits": 1000000,
+      "runs": 20,
+      "milliseconds": {
+        "min": 0.6944080000102986,
+        "p50": 1.003498000005493,
+        "p95": 1.3304099999950267,
+        "max": 3.5030210000113584
+      }
+    }
+  ]
+}

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "verify-package": "bun scripts/verify-package.ts",
     "generate:config-reference": "bun scripts/generate-config-reference.ts",
     "check:config-reference": "bun scripts/generate-config-reference.ts --check",
+    "benchmark:baseline": "bun benchmark/perf-baseline.ts",
     "prepublish": "bun run build && bun run verify-package",
     "format": "oxfmt",
     "format:check": "oxfmt --check",


### PR DESCRIPTION
## Summary

Establishes reproducible production-path evidence for pi-vimmode 0.9.0 performance, so later optimizations can compare against a named pre-change baseline instead of ad hoc timings.

## Changes

- Benchmarks long single-line, multi-line, mixed-width, cursor-restoration, and Pi-editor delegation paths at 80×40
- Records 20-run min/p50/p95/max results with revision, source-dirty state, Bun, OS, CPU, viewport, and corpus metadata
- Documents separate 100 µs CPU-profile commands while keeping benchmark assets outside published packages

## Testing

- [x] `bun run verify` passes
- [ ] Manually tested in Pi
- [x] `bun run benchmark:baseline`
- [x] `bun run build && bun run verify-package`

## Related Issues

Closes #33
