### PR TITLE
feat: add release-gate benchmark core

### DIFF
--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -2,15 +2,16 @@
 
 Dependency-free production-path benchmark for pi-vimmode. Harness generates corpora in memory; no generated prompt files are committed.
 
-Reproduce committed pre-change evidence:
+Release-gate runs default to 30 measured samples after 10 warmups:
 
 ```sh
-PI_VIMMODE_VERSION=0.9.0
+bun benchmark/run.ts --output benchmark/version/0.10.0.json
+```
 
-bun benchmark/run.ts \
-  --runs=10 \
-  --warmup=10 \
-  --output "benchmark/version/${PI_VIMMODE_VERSION}.json"
+Use explicit lower counts only for local smoke runs:
+
+```sh
+bun benchmark/run.ts --runs=1 --warmup=0
 ```
 
 Harness measures `VimEditor.handleInput` through modal dispatch and installed Pi `CustomEditor`, plus warmed `VimEditor.render`, at an 80×40 viewport. Setup, corpus generation, warmup, editor construction, reset, and assertions stay outside timed regions. Each measured operation asserts text, cursor, mode, or rendered row width.
@@ -22,7 +23,7 @@ Corpus matrix:
 - 100k and 1m ASCII multi-line prompts; 1m uses 20k lines
 - 1k, 5k, 10k, 25k, 50k, and 100k cursor-restoration scaling cases
 
-Output records revision, Bun, OS, CPU, viewport, corpus code units, line count, run count, min, p50, p95, and max milliseconds. Percentiles use nearest rank. Absolute values are reference evidence for matching environments, not CI latency gates. `--case` selects exact cases; committed version JSON records its selection. Full pre-change word restoration is intentionally slow under current implementation, so focused runs are available.
+Output records revision; runtime, OS, CPU, and viewport environment; sample and warmup counts; corpus code units and line count; correctness status; min, p50, p95, and max milliseconds. Percentiles use nearest rank. Assertions run outside timed regions, and failure prevents result emission. `cursor-restoration/prompt-search-repeat/ascii-single-100k` measures repeated prompt search across distant 100k matches. `long-line-render/warmed/mixed-single-1m` covers mixed-width 1m rendering. Absolute values are reference evidence for matching environments, not CI latency gates. `--case` selects exact cases; committed version JSON records its selection. Full pre-change word restoration is intentionally slow under current implementation, so focused runs are available.
 
 Focused CPU profiles use Bun's 100 µs sampling interval. Keep cursor restoration and rendering separate:
 

--- a/benchmark/run.ts
+++ b/benchmark/run.ts
@@ -30,10 +30,12 @@ type BenchmarkResult = {
   name: string;
   corpus: CorpusMetadata;
   runs: number;
+  warmup: number;
+  correctness: "passed";
   milliseconds: Timings;
 };
 
-type BenchmarkCase = {
+export type BenchmarkCase = {
   name: string;
   corpus: Corpus;
   setup: (editor: VimEditor) => void;
@@ -41,7 +43,7 @@ type BenchmarkCase = {
   assert: (editor: VimEditor, result: unknown) => void;
 };
 
-type Arguments = {
+export type Arguments = {
   output?: string;
   profile?: "cursor-restoration" | "long-line-render";
   cases: string[];
@@ -171,6 +173,35 @@ function stripRenderFormatting(text: string): string {
     .replaceAll(`${escape}[0m`, "");
 }
 
+function promptSearchRepeatCase(): BenchmarkCase {
+  const needle = "needle";
+  const firstMatch = 100;
+  const secondMatch = 100_000 - needle.length;
+  const text = `${"x".repeat(firstMatch)}${needle}${"x".repeat(secondMatch - firstMatch - needle.length)}${needle}`;
+  const corpus: Corpus = {
+    name: "ascii-single-100k",
+    kind: "ascii-single",
+    text,
+    codeUnits: text.length,
+    lines: 1,
+  };
+  return {
+    name: "cursor-restoration/prompt-search-repeat/ascii-single-100k",
+    corpus,
+    setup: (editor) => {
+      editor.setText(text);
+      for (const key of ["g", "g", "/", ...needle, "\r"]) editor.handleInput(key);
+    },
+    measure: (editor) => editor.handleInput("n"),
+    assert: (editor) => {
+      if (editor.getText() !== text) throw new Error("prompt-search-repeat changed text");
+      if (editor.getCursor().col !== secondMatch)
+        throw new Error("prompt-search-repeat cursor mismatch");
+      if (editor.getVimMode() !== "normal") throw new Error("prompt-search-repeat mode mismatch");
+    },
+  };
+}
+
 function renderCase(corpus: Corpus): BenchmarkCase {
   let expectedCursor: { line: number; col: number } | undefined;
   return {
@@ -194,6 +225,7 @@ function renderCase(corpus: Corpus): BenchmarkCase {
         if (visibleWidth(row) > WIDTH) throw new Error("render exceeded viewport width");
       }
       if (editor.getText() !== corpus.text) throw new Error("render changed text");
+      if (editor.getVimMode() !== "normal") throw new Error("render changed mode");
       if (!expectedCursor) throw new Error("render setup missing cursor");
       if (
         editor.getCursor().line !== expectedCursor.line ||
@@ -229,6 +261,7 @@ function buildCases(corpora: Corpus[]): BenchmarkCase[] {
   cases.push(leftCase(byName.get("ascii-single-100k")!));
   cases.push(leftCase(byName.get("mixed-single-100k")!));
   cases.push(bufferStartCase(byName.get("ascii-multiline-100k")!));
+  cases.push(promptSearchRepeatCase());
   cases.push(...corpora.map(renderCase));
   return cases;
 }
@@ -248,7 +281,7 @@ function summarize(samples: number[]): Timings {
   };
 }
 
-function measureCase(item: BenchmarkCase, runs: number, warmup: number): BenchmarkResult {
+export function measureCase(item: BenchmarkCase, runs: number, warmup: number): BenchmarkResult {
   for (let index = 0; index < warmup; index++) {
     const editor = createEditor();
     item.setup(editor);
@@ -271,6 +304,8 @@ function measureCase(item: BenchmarkCase, runs: number, warmup: number): Benchma
     name: item.name,
     corpus: corpusMetadata(item.corpus),
     runs,
+    warmup,
+    correctness: "passed",
     milliseconds: summarize(samples),
   };
 }
@@ -307,7 +342,7 @@ function validateArguments(args: Arguments): void {
 }
 
 function parseArguments(argv: string[]): Arguments {
-  const args: Arguments = { cases: [], runs: 3, warmup: 1 };
+  const args: Arguments = { cases: [], runs: 30, warmup: 10 };
   for (let index = 0; index < argv.length; index++) {
     const argument = argv[index];
     if (argument === "--help") {
@@ -326,7 +361,7 @@ function parseArguments(argv: string[]): Arguments {
   return args;
 }
 
-function selectCases(
+export function selectCases(
   cases: BenchmarkCase[],
   profile: Arguments["profile"],
   filters: string[],
@@ -343,15 +378,37 @@ function selectCases(
   );
 }
 
+export function createOutput(
+  args: Arguments,
+  corpora: Corpus[],
+  results: BenchmarkResult[],
+  environment: {
+    revision: string;
+    runtime: { bun: string; os: string; cpu: string };
+    viewport: { columns: number; rows: number };
+  },
+) {
+  return {
+    schemaVersion: 2,
+    baseline: "pi-vimmode-0.10.0-release-gate",
+    revision: environment.revision,
+    environment: { runtime: environment.runtime, viewport: environment.viewport },
+    samples: args.runs,
+    warmups: args.warmup,
+    profile: args.profile ?? "full",
+    selection: args.cases.length > 0 ? args.cases : "all",
+    corpora: corpora.map(corpusMetadata),
+    results,
+  };
+}
+
 async function run(): Promise<void> {
   const args = parseArguments(process.argv.slice(2));
   const corpora = buildCorpora();
   const cases = selectCases(buildCases(corpora), args.profile, args.cases);
   if (cases.length === 0) throw new Error("No benchmark cases selected");
   const results = cases.map((item) => measureCase(item, args.runs, args.warmup));
-  const output = {
-    schemaVersion: 1,
-    baseline: "pi-vimmode-0.9.0-pre-change",
+  const output = createOutput(args, corpora, results, {
     revision: commandOutput(["git", "rev-parse", "HEAD"]),
     runtime: {
       bun: Bun.version,
@@ -359,11 +416,7 @@ async function run(): Promise<void> {
       cpu: cpus()[0]?.model ?? "unknown",
     },
     viewport: { columns: WIDTH, rows: ROWS },
-    profile: args.profile ?? "full",
-    selection: args.cases.length > 0 ? args.cases : "all",
-    corpora: corpora.map(corpusMetadata),
-    results,
-  };
+  });
   const json = `${JSON.stringify(output, null, 2)}\n`;
   if (args.output) {
     await mkdir(dirname(args.output), { recursive: true });
@@ -375,4 +428,4 @@ async function run(): Promise<void> {
 
 if (import.meta.main) await run();
 
-export { buildCorpora, summarize };
+export { buildCases, buildCorpora, summarize };

--- a/test/benchmark.test.ts
+++ b/test/benchmark.test.ts
@@ -1,6 +1,14 @@
 import { describe, expect, test } from "bun:test";
 
-import { buildCorpora, summarize } from "../benchmark/run.ts";
+import {
+  buildCases,
+  buildCorpora,
+  createOutput,
+  measureCase,
+  selectCases,
+  summarize,
+  type BenchmarkCase,
+} from "../benchmark/run.ts";
 
 describe("benchmark corpus", () => {
   test("covers exact production corpus sizes", () => {
@@ -16,5 +24,57 @@ describe("benchmark corpus", () => {
 
   test("summarizes nearest-rank percentiles", () => {
     expect(summarize([4, 1, 3, 2])).toEqual({ min: 1, p50: 2, p95: 4, max: 4 });
+    expect(summarize([1, 2, 3, 4, 5, 6])).toEqual({ min: 1, p50: 3, p95: 6, max: 6 });
+  });
+
+  test("selects exact cases within profile", () => {
+    const cases = buildCases(buildCorpora());
+    const name = "cursor-restoration/prompt-search-repeat/ascii-single-100k";
+    expect(selectCases(cases, "cursor-restoration", [name]).map((item) => item.name)).toEqual([
+      name,
+    ]);
+    expect(selectCases(cases, "long-line-render", [name])).toEqual([]);
+  });
+
+  test("emits release-gate metadata", () => {
+    const output = createOutput(
+      { cases: [], runs: 30, warmup: 10 },
+      buildCorpora(),
+      [
+        {
+          name: "case",
+          corpus: { name: "corpus", kind: "ascii-single", codeUnits: 100_000, lines: 1 },
+          runs: 30,
+          warmup: 10,
+          correctness: "passed",
+          milliseconds: { min: 1, p50: 2, p95: 3, max: 4 },
+        },
+      ],
+      {
+        revision: "revision",
+        runtime: { bun: "1.0", os: "test", cpu: "test" },
+        viewport: { columns: 80, rows: 40 },
+      },
+    );
+    expect(output).toMatchObject({
+      revision: "revision",
+      environment: { runtime: { bun: "1.0", os: "test", cpu: "test" } },
+      samples: 30,
+      warmups: 10,
+      results: [{ runs: 30, warmup: 10, correctness: "passed", milliseconds: { p50: 2, p95: 3 } }],
+    });
+  });
+
+  test("stops on correctness assertion failure", () => {
+    const item: BenchmarkCase = {
+      name: "broken",
+      corpus: { name: "corpus", kind: "ascii-single", text: "text", codeUnits: 4, lines: 1 },
+      setup: () => {},
+      measure: () => undefined,
+      assert: () => {
+        throw new Error("incorrect result");
+      },
+    };
+    expect(() => measureCase(item, 1, 0)).toThrow("incorrect result");
   });
 });


### PR DESCRIPTION
## Summary

Release-gate benchmark runs now produce reproducible 0.10.0 evidence for prompt-search restoration and mixed-width rendering.

## Changes

- Default release runs to 30 measured samples after 10 warmups.
- Emit schema v2 metadata: revision, runtime environment, sample counts, percentiles, and correctness.
- Add distant-match 100k prompt-search-repeat case; harden mixed-width 1m render mode assertion.
- Cover selection, nearest-rank percentiles, metadata, and assertion failure behavior.

## Testing

- [x] `bun run verify` passes
- [x] Focused benchmark smoke run

## Related Issues

Closes #82
